### PR TITLE
Update DNSResolver.cpp to prefer IPv6

### DIFF
--- a/hmailserver/source/Server/Common/TCPIP/DNSResolver.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/DNSResolver.cpp
@@ -243,11 +243,11 @@ namespace HM
          return false;
       }
 
-      bool ipv4AddressResult = Resolve_(sDomain, vecFoundNames, DNS_TYPE_A, 0);
-
       bool ipv6AddressResult = Configuration::Instance()->IsIPv6Available() ?
                                  Resolve_(sDomain, vecFoundNames, DNS_TYPE_AAAA, 0) :
                                  false;
+	   
+      bool ipv4AddressResult = Resolve_(sDomain, vecFoundNames, DNS_TYPE_A, 0);
 
       return ipv4AddressResult || ipv6AddressResult;
    }


### PR DESCRIPTION
If IPv6 is available, this should be put in the result as the primary record. IPv4 is fallback.

Today IPv4 is prefered from a subdomainname containing both A & AAAA records. This should be changed to fully support IPv6.