### PR TITLE
DKIM sign NDR messages (forwarded to external)

### DIFF
--- a/hmailserver/source/Server/Common/Application/IniFileSettings.cpp
+++ b/hmailserver/source/Server/Common/Application/IniFileSettings.cpp
@@ -139,6 +139,8 @@ namespace HM
 
       max_no_of_external_fetch_threads_ = ReadIniSettingInteger_("Settings", "MaxNumberOfExternalFetchThreads", 15);
       add_xauth_user_header_ = ReadIniSettingInteger_("Settings", "AddXAuthUserHeader", 0) == 1;
+
+      daemonaddress_domain_ = ReadIniSettingString_("Settings", "DaemonAddressDomain", "");
       
       greylisting_enabled_during_record_expiration_ = ReadIniSettingInteger_("Settings", "GreylistingEnabledDuringRecordExpiration", 1) == 1;
       greylisting_expiration_interval_ = ReadIniSettingInteger_("Settings", "GreylistingRecordExpirationInterval", 240);

--- a/hmailserver/source/Server/Common/Application/IniFileSettings.h
+++ b/hmailserver/source/Server/Common/Application/IniFileSettings.h
@@ -71,6 +71,7 @@ namespace HM
       int GetDBConnectionAttemptsDelay() const;
       
       bool GetAddXAuthUserHeader() {return add_xauth_user_header_; }
+      String GetDaemonAddressDomain() const { return daemonaddress_domain_; }
       int GetMaxNumberOfExternalFetchThreads() {return max_no_of_external_fetch_threads_ ;}
       bool GetGreylistingEnabledDuringRecordExpiration() {return greylisting_enabled_during_record_expiration_;}
       int GetGreylistingExpirationInterval() {return greylisting_expiration_interval_; }
@@ -141,6 +142,7 @@ namespace HM
       int no_of_dbconnection_attempts_;
       int no_of_dbconnection_attempts_Delay;
       bool add_xauth_user_header_;
+      String daemonaddress_domain_;
       int max_no_of_external_fetch_threads_;
 
       bool greylisting_enabled_during_record_expiration_;

--- a/hmailserver/source/Server/Common/Util/MailerDaemonAddressDeterminer.cpp
+++ b/hmailserver/source/Server/Common/Util/MailerDaemonAddressDeterminer.cpp
@@ -69,6 +69,11 @@ namespace HM
          sHostName = Utilities::ComputerName();
       }
 
+      if (!IniFileSettings::Instance()->GetDaemonAddressDomain().IsEmpty())
+      {
+         sHostName = IniFileSettings::Instance()->GetDaemonAddressDomain();
+      }
+
       String sRetVal;
       sRetVal.Format(_T("mailer-daemon@%s"), sHostName.c_str());
 

--- a/hmailserver/source/Server/SMTP/RuleApplier.cpp
+++ b/hmailserver/source/Server/SMTP/RuleApplier.cpp
@@ -20,6 +20,7 @@
 #include "../Common/Util/Time.h"
 #include "../Common/Util/Utilities.h"
 #include "../Common/Util/RegularExpression.h"
+#include "../common/Util/MailerDaemonAddressDeterminer.h"
 
 #include "../Common/Persistence/PersistentMessage.h"
 
@@ -248,7 +249,10 @@ namespace HM
       // We need to update the SMTP envelope from address, if this
       // message is forwarded by a user-level account.
       std::shared_ptr<CONST Account> pAccount = CacheContainer::Instance()->GetAccount(rule_account_id_);
-      if (pAccount && IniFileSettings::Instance()->GetRewriteEnvelopeFromWhenForwarding())
+      String sMailerDaemonAddress = MailerDaemonAddressDeterminer::GetMailerDaemonAddress(pMsg);
+      if (pMsg->GetFromAddress().IsEmpty())
+         pMsg->SetFromAddress(sMailerDaemonAddress);
+      else if (pAccount && IniFileSettings::Instance()->GetRewriteEnvelopeFromWhenForwarding())
          pMsg->SetFromAddress(pAccount->GetAddress());
       
       // Add new recipients

--- a/hmailserver/source/Server/SMTP/SMTPForwarding.cpp
+++ b/hmailserver/source/Server/SMTP/SMTPForwarding.cpp
@@ -14,6 +14,8 @@
 
 #include "../Common/Persistence/PersistentMessage.h"
 
+#include "../common/Util/MailerDaemonAddressDeterminer.h"
+
 #include "RecipientParser.h"
 
 #ifdef _DEBUG
@@ -83,7 +85,10 @@ namespace HM
       // Create a copy of the message
       std::shared_ptr<Message> pNewMessage = PersistentMessage::CopyToQueue(pRecipientAccount, pOriginalMessage);
      
-      if (IniFileSettings::Instance()->GetRewriteEnvelopeFromWhenForwarding())
+      String sMailerDaemonAddress = MailerDaemonAddressDeterminer::GetMailerDaemonAddress(pNewMessage);
+      if (pNewMessage->GetFromAddress().IsEmpty())
+         pNewMessage->SetFromAddress(sMailerDaemonAddress);
+      else if (IniFileSettings::Instance()->GetRewriteEnvelopeFromWhenForwarding())
          pNewMessage->SetFromAddress(pRecipientAccount->GetAddress());
 
       pNewMessage->SetState(Message::Delivering);


### PR DESCRIPTION
This change adds the possiblity/ability to DKIM (and DMARC) sign NDR messages forwarded to external-accounts.
Even if RewriteEnvelopeFromWhenForwardingsetting is set NDR messages EnvelopeFrom will not be rewritten to localaccount address but uses mailer-daemon@ instead as EnvelopeFrom address.

**Requirements to DKIM sign NDR messages**
If the mailer-daemon@ domain exists on the server and DKIM is enabled for that domain the NDR message forwarded to external domains will be DKIM (and optionaly DMARC) signed