### PR TITLE
Update DNSResolver.cpp

### DIFF
--- a/hmailserver/source/Server/Common/Application/Errors.txt
+++ b/hmailserver/source/Server/Common/Application/Errors.txt
@@ -1,4 +1,5 @@
-4401, Too many recursions during IP adress lookup. Query: {0}
+4401, Too many recursions during IP address lookup. Query: {0}
+4402, Too many recursions during TXT record lookup. Query: {0}
 5121, PersistentACLPermission::SaveObject, ACL item of type PTAnyone not initialized correctly.
 5122, SQLCEConnection::_UpgradeDatabase(), Failed to create instance of SQL CE Engine.
 5123, SQLCEConnection::_UpgradeDatabase(), Failed to upgrade SQL CE database. HRESULT:

--- a/hmailserver/source/Server/Common/TCPIP/DNSResolver.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/DNSResolver.cpp
@@ -74,7 +74,7 @@ namespace HM
 
       if (recursionLevel > 10)
       {
-         String sMessage = Formatter::Format("Too many recursions during IP adress lookup. Query: {0}", hostName);
+         String sMessage = Formatter::Format("Too many recursions during IP address lookup. Query: {0}", hostName);
          ErrorManager::Instance()->ReportError(ErrorManager::Low, 4401, "DNSResolver::GetIpAddressesRecursive_", sMessage);
 
          return false;
@@ -110,6 +110,26 @@ namespace HM
    bool 
    DNSResolver::GetTXTRecords(const String &sDomain, std::vector<String> &foundResult)
    {
+      return GetTXTRecordsRecursive_(sDomain, foundResult, 0);
+   }
+
+   bool
+   DNSResolver::GetTXTRecordsRecursive_(const String &sDomain, std::vector<String> &foundResult, int recursionLevel)
+   {
+      if (sDomain.IsEmpty())
+      {
+         ErrorManager::Instance()->ReportError(ErrorManager::Medium, 5516, "DNSResolver::GetTXTRecordsRecursive", "Attempted DNS lookup for empty host name.");
+         return false;
+      }
+
+      if (recursionLevel > 10)
+      {
+         String sMessage = Formatter::Format("Too many recursions during TXT record lookup. Query: {0}", sDomain);
+         ErrorManager::Instance()->ReportError(ErrorManager::Low, 4402, "DNSResolver::GetTXTRecordsRecursive", sMessage);
+
+         return false;
+      }
+      
       DNSResolverWinApi resolver;
 
       std::vector<DNSRecord> foundRecords;
@@ -126,7 +146,7 @@ namespace HM
          if (cnameQueryResult && foundCNames.size() == 1)
          {
             auto cnameHostName = foundCNames[0].GetValue();
-            return GetTXTRecords(cnameHostName, foundResult);
+            return GetTXTRecordsRecursive_(cnameHostName, foundResult, recursionLevel + 1);
          }
       }
 

--- a/hmailserver/source/Server/Common/TCPIP/DNSResolver.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/DNSResolver.cpp
@@ -116,6 +116,20 @@ namespace HM
 
       bool result = resolver.Query(sDomain, DNS_TYPE_TEXT, foundRecords);
 
+      if (foundRecords.size() == 0)
+      {
+         // The queries for TXT didn't return any records. Attempt to look up via CNAME
+         std::vector<DNSRecord> foundCNames;
+         bool cnameQueryResult = resolver.Query(sDomain, DNS_TYPE_CNAME, foundCNames);
+
+         // A CNAME should only point at a single host name.
+         if (cnameQueryResult && foundCNames.size() == 1)
+         {
+            auto cnameHostName = foundCNames[0].GetValue();
+            return GetTXTRecords(cnameHostName, foundResult);
+         }
+      }
+
       foundResult = GetDnsRecordsValues_(foundRecords);
 
       return result;

--- a/hmailserver/source/Server/Common/TCPIP/DNSResolver.h
+++ b/hmailserver/source/Server/Common/TCPIP/DNSResolver.h
@@ -24,6 +24,7 @@ namespace HM
    private:
 
       bool GetIpAddressesRecursive_(const String &hostName, std::vector<String> &addresses, int recursionLevel, bool followCnameRecords);
+      bool GetTXTRecordsRecursive_(const String &sDomain, std::vector<String> &foundResult, int recursionLevel);
 
       std::vector<String> GetDnsRecordsValues_(std::vector<DNSRecord> records);
    };


### PR DESCRIPTION
DKIM signature verification when published DNS record is CNAME

Only seems to be a issue on 5.7.x

For details see:
https://www.hmailserver.com/forum/viewtopic.php?f=7&t=34834&p=218884#p218884