### PR TITLE
Update RMSPF.cpp

### DIFF
--- a/hmailserver/source/Server/SMTP/SPF/RMSPF.cpp
+++ b/hmailserver/source/Server/SMTP/SPF/RMSPF.cpp
@@ -4062,6 +4062,8 @@ const char** explain)
       *(const uchar**)&ipaddr += 12;
       // fall thru
    case AF_INET:
+      if (addrequal(ipaddr, localhost4, 8))
+         return SPF_Pass;
       spfdata.spf_ipv6 = false;
       break;
    default:


### PR DESCRIPTION
SpamTestSPF should be ignored if mail is coming thru 127.0.0.1, it now returns: Fail, but according RFC it should return: Pass for localhost.... this two lines are in the original RMSPF.C lib, not sure why you deleted it?