### PR TITLE
Update SpamTestHeloHost.cpp

### DIFF
--- a/hmailserver/source/Server/Common/AntiSpam/SpamTestHeloHost.cpp
+++ b/hmailserver/source/Server/Common/AntiSpam/SpamTestHeloHost.cpp
@@ -12,6 +12,7 @@
 
 #include "../TCPIP/DNSResolver.h"
 #include "../TCPIP/IPAddress.h"
+#include "../TCPIP/LocalIPAddresses.h"
 #include "../Util/TLD.h"
 
 #ifdef _DEBUG
@@ -47,6 +48,12 @@ namespace HM
       if (sHeloHost.IsEmpty())
       {
          // Not possible to run this test without a host.
+         return setSpamTestResults;
+      }
+
+      if (LocalIPAddresses::Instance()->IsLocalIPAddress(iIPAdress))
+      {
+         // Ignore this test if send thru localhost.
          return setSpamTestResults;
       }
 


### PR DESCRIPTION
SpamTestHeloHost, on localhost the reported host is the computer name, eg, it will always fail this test when send thru 127.0.0.1 and therefor should be ignored