### PR TITLE
Set JScript engine version

### DIFF
--- a/hmailserver/source/Server/Common/Scripting/Events.cpp
+++ b/hmailserver/source/Server/Common/Scripting/Events.cpp
@@ -186,7 +186,7 @@ namespace HM
       }
       else if (sScriptLanguage == _T("JScript"))
       {
-         sRemoteUIDCopy.Replace(_T("'"), _T("\'"));
+         sRemoteUIDCopy.Replace(_T("'"), _T("\\'"));
 
          if (pMessage)
             sEventCaller.Format(_T("OnExternalAccountDownload(HMAILSERVER_FETCHACCOUNT, HMAILSERVER_MESSAGE, '%s')"), sRemoteUIDCopy.c_str());

--- a/hmailserver/source/Server/Common/Scripting/ScriptSite.h
+++ b/hmailserver/source/Server/Common/Scripting/ScriptSite.h
@@ -229,6 +229,17 @@ public:
       USES_CONVERSION;
       HR(engine_.CoCreateInstance(T2COLE(pszLanguage)));
 
+      if (lstrcmp(pszLanguage, _T("JScript")) == 0)
+      {
+         // Set the JScript version to use - see https://docs.microsoft.com/en-us/scripting/winscript/reference/iactivescriptproperty-setproperty
+         CComPtr<IActiveScriptProperty> pScriptProperty;
+         HR(engine_->QueryInterface(IID_IActiveScriptProperty, reinterpret_cast<void**>(&pScriptProperty)));
+         VARIANT engineVersion;
+         engineVersion.vt = VT_I4;
+         engineVersion.llVal = SCRIPTLANGUAGEVERSION_5_8;
+         HR(pScriptProperty->SetProperty(SCRIPTPROP_INVOKEVERSIONING, 0, &engineVersion));
+      }
+
       // Attach to site
       HR(engine_->SetScriptSite(static_cast<IActiveScriptSite*>(this)));
 


### PR DESCRIPTION
This pull request adds some code to request version 5.8 of the JScript engine from Windows for scripts. The main reason I did this is to get access to built-in JSON object parsing, but there are several other useful features (like being able to index through strings!) that you can see here: https://docs.microsoft.com/en-us/archive/blogs/jscript/versioning-language-features-in-jscript (scroll down to "List of features versioned")

I don't think any of the new features in version 5.8 are incompatible with existing scripts, so I have it enabling the new version for everything.

I also fixed a minor bug with the OnExternalAccountDownload event and how it called JScript code when the remote UID had a single quote in it.