### PR TITLE
Add OnClientValidatePassword event

### DIFF
--- a/hmailserver/source/Server/Common/Scripting/ScriptObjectContainer.cpp
+++ b/hmailserver/source/Server/Common/Scripting/ScriptObjectContainer.cpp
@@ -10,6 +10,7 @@
 #include "../../COM/InterfaceClient.h"
 #include "../../COM/InterfaceEventLog.h"
 #include "../../COM/InterfaceFetchAccount.h"
+#include "../../COM/InterfaceAccount.h"
 
 //#include "IScriptObject.h"
 #include "ScriptObjectContainer.h"
@@ -100,6 +101,15 @@ namespace HM
          {
             CComObject<InterfaceFetchAccount> *pInterface = new CComObject<InterfaceFetchAccount>();
             std::shared_ptr<FetchAccount> pObject = std::static_pointer_cast<FetchAccount>(pObj->pObject);
+            pInterface->AttachItem(pObject);
+            pInterface->QueryInterface(ppunkItem);
+
+            return true;
+         }
+      case ScriptObject::OTAccount:
+         {
+            CComObject<InterfaceAccount> *pInterface = new CComObject<InterfaceAccount>();
+            std::shared_ptr<Account> pObject = std::static_pointer_cast<Account>(pObj->pObject);
             pInterface->AttachItem(pObject);
             pInterface->QueryInterface(ppunkItem);
 

--- a/hmailserver/source/Server/Common/Scripting/ScriptObjectContainer.h
+++ b/hmailserver/source/Server/Common/Scripting/ScriptObjectContainer.h
@@ -17,7 +17,8 @@ namespace HM
          OTMessage = 1001,
          OTClient = 1002,
          OTEventLog = 1003,
-         OTFetchAccount = 1004
+         OTFetchAccount = 1004,
+         OTAccount = 1005
       };
 
       String sName;

--- a/hmailserver/source/Server/Common/Scripting/ScriptServer.cpp
+++ b/hmailserver/source/Server/Common/Scripting/ScriptServer.cpp
@@ -101,6 +101,7 @@ namespace HM
          has_on_smtpdata_ = DoesFunctionExist_("OnSMTPData");
          has_on_helo_ = DoesFunctionExist_("OnHELO");
          has_on_client_logon_ = DoesFunctionExist_("OnClientLogon");
+         has_on_client_validate_password_ = DoesFunctionExist_("OnClientValidatePassword");
       }
       catch (...)
       {
@@ -262,6 +263,11 @@ namespace HM
          if (!has_on_client_logon_)
             return;
          event_name = _T("OnClientLogon");
+         break;
+      case EventOnClientValidatePassword:
+         if (!has_on_client_validate_password_)
+            return;
+         event_name = _T("OnClientValidatePassword");
          break;
       case EventCustom:
          break;

--- a/hmailserver/source/Server/Common/Scripting/ScriptServer.cpp
+++ b/hmailserver/source/Server/Common/Scripting/ScriptServer.cpp
@@ -31,7 +31,8 @@ namespace HM
       has_on_external_account_download_(false),
       has_on_smtpdata_(false),
       has_on_helo_(false),
-      has_on_client_logon_(false)
+      has_on_client_logon_(false),
+      has_on_client_validate_password_(false)
    {
       
    }

--- a/hmailserver/source/Server/Common/Scripting/ScriptServer.h
+++ b/hmailserver/source/Server/Common/Scripting/ScriptServer.h
@@ -29,7 +29,8 @@ namespace HM
          EventOnExternalAccountDownload = 1011,
          EventOnSMTPData = 1012,
          EventOnHELO = 1013,
-         EventOnClientLogon = 1014
+         EventOnClientLogon = 1014,
+         EventOnClientValidatePassword = 1015
       };
 
       ScriptServer(void);
@@ -68,6 +69,7 @@ namespace HM
       bool has_on_smtpdata_;
       bool has_on_helo_;
       bool has_on_client_logon_;
+      bool has_on_client_validate_password_;
 
       String script_contents_;
       String script_extension_;

--- a/hmailserver/source/Server/Common/Util/PasswordValidator.cpp
+++ b/hmailserver/source/Server/Common/Util/PasswordValidator.cpp
@@ -14,6 +14,10 @@
 #include "../Util/Crypt.h"
 #include "../Persistence/PersistentDomain.h"
 #include "../Persistence/PersistentAccount.h"
+#include "../Scripting/ClientInfo.h"
+#include "../Scripting/ScriptServer.h"
+#include "../Scripting/ScriptObjectContainer.h"
+#include "../Scripting/Result.h"
 
 #ifdef _DEBUG
 #define DEBUG_NEW new(_NORMAL_BLOCK, __FILE__, __LINE__)
@@ -108,6 +112,57 @@ namespace HM
    bool 
    PasswordValidator::ValidatePassword(std::shared_ptr<const Account> pAccount, const String &sPassword)
    {
+      if (Configuration::Instance()->GetUseScriptServer())
+      {
+         std::shared_ptr<ScriptObjectContainer> pContainer = std::shared_ptr<ScriptObjectContainer>(new ScriptObjectContainer);
+         std::shared_ptr<Result> pResult = std::shared_ptr<Result>(new Result);
+
+         // We cannot use the provided pAccount directly, since it might come from cache.
+         // (that's why it's a const Account)
+         // So, we use it to load from the PersistentAccount.
+         std::shared_ptr<Account> pPersistentAccount = std::shared_ptr<Account>(new Account);
+         PersistentAccount::ReadObject(pPersistentAccount, pAccount->GetAddress());
+
+         pContainer->AddObject("HMAILSERVER_ACCOUNT", pPersistentAccount, ScriptObject::OTAccount);
+         pContainer->AddObject("Result", pResult, ScriptObject::OTResult);
+
+         // By default, pass through.
+         pResult->SetValue(2);
+
+         String sEventCaller;
+
+         String sScriptLanguage = Configuration::Instance()->GetScriptLanguage();
+         if (sScriptLanguage == _T("VBScript"))
+         {
+            String sEscapedPassword = sPassword;
+            sEscapedPassword.Replace(_T("\""), _T("\"\""));
+
+            sEventCaller.Format(_T("OnClientValidatePassword(HMAILSERVER_ACCOUNT, \"%s\")"), sEscapedPassword.c_str());
+         }
+         else if (sScriptLanguage == _T("JScript"))
+         {
+            String sEscapedPassword = sPassword;
+            sEscapedPassword.Replace(_T("'"), _T("\\'"));
+
+            sEventCaller.Format(_T("OnClientValidatePassword(HMAILSERVER_ACCOUNT, '%s')"), sEscapedPassword.c_str());
+         }
+
+         ScriptServer::Instance()->FireEvent(ScriptServer::EventOnClientValidatePassword, sEventCaller, pContainer);
+
+         if (pResult->GetValue() == 0)
+         {
+            // The script said to let the user through.
+            return true;
+         }
+         else if (pResult->GetValue() == 1)
+         {
+            // The script said the password wasn't correct.
+            return false;
+         }
+
+         // The script gave us a different value, which means we should continue normally.
+      }
+
       if (sPassword.GetLength() == 0)
       {
          // Empty passwords are not permitted.


### PR DESCRIPTION
This pull request adds a new `OnClientValidatePassword` event for scripts. The idea is to allow scripts to authenticate users. For example, if you want to validate user passwords against a database or external login provider, you could write a script to handle that event.

The event is called with two parameters (`OnClientValidatePassword(oAccount, sPassword)`): the account that is trying to sign in and the password that's being used. The script can then set Result.Value to:
* 0 - The user was authenticated, let them in.
* 1 - The user was not authenticated, return an "invalid username or password" error.
* 2 - _(default)_ Bypass the script and continue with the normal hMailServer password validation.

Hopefully this makes some sense, let me know if you have any feedback!

(also, is there any way to add to the documentation [on this page](https://www.hmailserver.com/documentation/latest/?page=reference_scripts)? I wanted to add a page about this event as part of the pull request but couldn't find where that comes from)