### PR TITLE
Fix 'Unencrypted Cleartext Login' vulnerability detection

### DIFF
--- a/hmailserver/source/Server/IMAP/IMAPCommandCapability.cpp
+++ b/hmailserver/source/Server/IMAP/IMAPCommandCapability.cpp
@@ -36,7 +36,7 @@ namespace HM
           pConnection->GetConnectionSecurity() == CSSTARTTLSRequired)
          sResponse += " STARTTLS";
 
-      if (pConfig->GetUseIMAPSASLPlain())
+      if (pConfig->GetUseIMAPSASLPlain() && (pConnection->IsSSLConnection() || pConnection->GetConnectionSecurity() != CSSTARTTLSRequired))
 	      sResponse += " AUTH=PLAIN";
 
       if (pConfig->GetUseIMAPSASLInitialResponse())

--- a/hmailserver/source/Server/POP3/POP3Connection.cpp
+++ b/hmailserver/source/Server/POP3/POP3Connection.cpp
@@ -375,7 +375,10 @@ namespace HM
    void
    POP3Connection::ProtocolCAPA_()
    {
-      String capabilities = "USER\r\nUIDL\r\nTOP\r\n";
+      String capabilities = "UIDL\r\nTOP\r\n";
+
+      if (IsSSLConnection() || GetConnectionSecurity() != CSSTARTTLSRequired)
+         capabilities+="USER\r\n";
 
       if (GetConnectionSecurity() == CSSTARTTLSOptional ||
           GetConnectionSecurity() == CSSTARTTLSRequired)

--- a/hmailserver/source/Server/SMTP/SMTPConnection.cpp
+++ b/hmailserver/source/Server/SMTP/SMTPConnection.cpp
@@ -1467,7 +1467,7 @@ namespace HM
          }
       }
 
-      if (GetAuthIsEnabled_())
+      if (GetAuthIsEnabled_() && (IsSSLConnection() || GetConnectionSecurity() != CSSTARTTLSRequired))
       {
          String sAuth = "\r\n250-AUTH LOGIN";
 


### PR DESCRIPTION
**hMailServer: 5.6.8 B2501 (SMTP+POP3), 5.7 (SMTP+POP3+IMAP)**

**Problem:**

Problem was already discussed in #63 marked as solved but still present. If you enable "STARTTLS (Required)" for SMTP/POP3/IMAP connections it'll be detected as 'Unencrypted Cleartext Login' vulnerability because hmailserver will return AUTH/USER/LOGIN as possible capability even if it is not possible to use login before TLS connection is established.

**Solution:**

Don't send AUTH/USER/LOGIN in capabilities list before TLS connection is established if TLS is required.

**Note:**
IMAP is affected if "SASL Plain" is enabled. SMTP and POP3 are affected in default configuration.