### PR TITLE
SPF test to include "HELO/EHLO host" used by DNS macros

### DIFF
--- a/hmailserver/source/Server/Common/AntiSpam/SpamTestSPF.cpp
+++ b/hmailserver/source/Server/Common/AntiSpam/SpamTestSPF.cpp
@@ -54,7 +54,7 @@ namespace HM
          return setSpamTestResults;
 
       String sExplanation;
-      SPF::Result result = SPF::Instance()->Test(originatingAddress.ToString(), pTestData->GetEnvelopeFrom(), sExplanation);
+      SPF::Result result = SPF::Instance()->Test(originatingAddress.ToString(), pTestData->GetEnvelopeFrom(), pTestData->GetHeloHost(), sExplanation);
       
       if (result == SPF::Fail)
       {

--- a/hmailserver/source/Server/SMTP/SPF/SPF.cpp
+++ b/hmailserver/source/Server/SMTP/SPF/SPF.cpp
@@ -25,7 +25,7 @@ namespace HM
    }
 
    SPF::Result
-   SPF::Test(const String &sSenderIP, const String &sSenderEmail, String &sExplanation)
+   SPF::Test(const String &sSenderIP, const String &sSenderEmail, const String &sHeloHost, String &sExplanation)
    {
       USES_CONVERSION;
       String sDomain = StringParser::ExtractDomain(sSenderEmail);
@@ -45,7 +45,7 @@ namespace HM
          return Neutral;
 
       const char* explain;
-      int result=SPFQuery(family,BinaryIP,T2A(sSenderEmail),NULL,NULL,NULL,&explain);
+      int result = SPFQuery(family, BinaryIP, T2A(sSenderEmail), NULL, T2A(sHeloHost), NULL, &explain);
 
       if (explain != NULL)
       {
@@ -70,13 +70,13 @@ namespace HM
    {
       String sExplanation;
 
-      if (SPF::Instance()->Test("5.189.183.138", "example@hmailserver.com", sExplanation) != SPF::Pass)
+      if (SPF::Instance()->Test("5.189.183.138", "example@hmailserver.com", "mail.hmailserver.com", sExplanation) != SPF::Pass)
       {
          // Should be allowed. The sub domain instantpayroll.advantagepayroll.com does not have a SPF record.
          throw;
       }
 
-      if (SPF::Instance()->Test("1.2.3.4", "example@hmailserver.com", sExplanation) != SPF::Fail)
+      if (SPF::Instance()->Test("1.2.3.4", "example@hmailserver.com", "mail.hmailserver.com", sExplanation) != SPF::Fail)
       {
          // Should not be allowed. advantagepayroll.com has SPF records.
          throw;

--- a/hmailserver/source/Server/SMTP/SPF/SPF.cpp
+++ b/hmailserver/source/Server/SMTP/SPF/SPF.cpp
@@ -45,7 +45,7 @@ namespace HM
          return Neutral;
 
       const char* explain;
-      int result = SPFQuery(family, BinaryIP, T2A(sSenderEmail), NULL, T2A(sHeloHost), NULL, &explain);
+      int result=SPFQuery(family,BinaryIP,T2A(sSenderEmail),NULL,T2A(sHeloHost),NULL,&explain);
 
       if (explain != NULL)
       {

--- a/hmailserver/source/Server/SMTP/SPF/SPF.h
+++ b/hmailserver/source/Server/SMTP/SPF/SPF.h
@@ -18,7 +18,7 @@ namespace HM
          Pass = 2
       };
 
-      Result Test(const String &sSenderIP, const String &sSenderEmail, String &sExplanation);
+      Result Test(const String &sSenderIP, const String &sSenderEmail, const String &sHeloHost, String &sExplanation);  
 
    private:
       


### PR DESCRIPTION
Include HELO/EHLO hostname for the SPF test for macro expansion (%{h})

"v=spf1 exists:_i.%{i}._h.%{h}._o.%{o}._spf.domain.com -all"

All credits for this go to Søren Raagaard Rathje