### PR TITLE
5.6.x & 5.7.x - AWStats::LogDeliveryFailure called 2x for OnDeliveryFailed

### DIFF
--- a/hmailserver/source/Server/Common/Scripting/Events.cpp
+++ b/hmailserver/source/Server/Common/Scripting/Events.cpp
@@ -111,8 +111,6 @@ namespace HM
    // several times for a single message.
    //---------------------------------------------------------------------------()
    {
-      AWStats::LogDeliveryFailure(sSendersIP, pMessage->GetFromAddress(), sRecipient,  550);
-
       // Send an event
       if (Configuration::Instance()->GetUseScriptServer())
       {


### PR DESCRIPTION
AWStats::LogDeliveryFailure was called twice for each failed message, once in either SMTPDeliverer.cpp and/or ExternalDelivery.cpp and then again in Events.cpp