### PR TITLE
5.6.x & 5.7.x Update SMTPDeliverer.cpp

### DIFF
--- a/hmailserver/source/Server/Common/Scripting/Events.cpp
+++ b/hmailserver/source/Server/Common/Scripting/Events.cpp
@@ -84,7 +84,7 @@ namespace HM
 
          switch (pResult->GetValue())
          {
-         case 1:
+            case 1:
             {
                String sMessage;
                sMessage.Format(_T("SMTPDeliverer - Message %I64d: ")
@@ -93,7 +93,8 @@ namespace HM
 
                LOG_APPLICATION(sMessage);
 
-               PersistentMessage::DeleteObject(pMessage);             
+               //Moved to PreprocessMessage_() in SMTPDeliverer.cpp
+               //PersistentMessage::DeleteObject(pMessage);                   
 
                return false;
             }

--- a/hmailserver/source/Server/SMTP/SMTPDeliverer.cpp
+++ b/hmailserver/source/Server/SMTP/SMTPDeliverer.cpp
@@ -164,10 +164,7 @@ namespace HM
          return false;
       }
 
-      if (AWStats::GetEnabled())
-      {
-         sendersIP = MessageUtilities::GetSendersIP(pMessage);
-      }
+      sendersIP = MessageUtilities::GetSendersIP(pMessage);
 
       // Create recipient list.
       String sRecipientList = pMessage->GetRecipients()->GetCommaSeperatedRecipientList();
@@ -197,14 +194,16 @@ namespace HM
       // Run virus protection.
       if (!RunVirusProtection_(pMessage))
       {
-         LogAwstatsMessageRejected_(sendersIP, pMessage, "Message delivery cancelled during virus scanning");
+         //LogAwstatsMessageRejected_ moved to HandleInfectedMessage_()
+         //LogAwstatsMessageRejected_(sendersIP, pMessage, "Message delivery cancelled during virus scanning");
          return false;
       }
 
       // Apply rules on this message.
       if (!RunGlobalRules_(pMessage, globalRuleResult))
       {
-         LogAwstatsMessageRejected_(sendersIP, pMessage, "Message delivery cancelled during global rules");
+         //LogAwstatsMessageRejected_ moved to RunGlobalRules_()
+         //LogAwstatsMessageRejected_(sendersIP, pMessage, "Message delivery cancelled during global rules");
          return false;
       }
 
@@ -337,6 +336,8 @@ namespace HM
       if (antiVirusConfig.AVAction() == AntiVirusConfiguration::ActionDelete)
       {
          // The message should be deleted.
+         String sendersIP = MessageUtilities::GetSendersIP(pMessage);
+         LogAwstatsMessageRejected_(sendersIP, pMessage, "Message delivery cancelled during virus scanning");
 
          // Should we notify the recipient?
          if (antiVirusConfig.AVNotifyReceiver())
@@ -436,6 +437,9 @@ namespace HM
 
       if (ruleResult.GetDeleteEmail())
       {
+         String sendersIP = MessageUtilities::GetSendersIP(pMessage);
+         LogAwstatsMessageRejected_(sendersIP, pMessage, "Message delivery cancelled during global rules");
+
          String sDeleteRuleName = ruleResult.GetDeleteRuleName();
 
          String sMessage;
@@ -463,8 +467,8 @@ namespace HM
    // client to the server.
    //---------------------------------------------------------------------------()
    {
-      // Check that message exists, and that the awstats log is enabled.
-      if (!pMessage || !AWStats::GetEnabled())
+      // Check that message exists
+      if (!pMessage)
          return;
 
       // Go through the recipients and log one row for each of them.

--- a/hmailserver/source/Server/SMTP/SMTPDeliverer.cpp
+++ b/hmailserver/source/Server/SMTP/SMTPDeliverer.cpp
@@ -194,23 +194,27 @@ namespace HM
       // Run virus protection.
       if (!RunVirusProtection_(pMessage))
       {
-         //LogAwstatsMessageRejected_ moved to HandleInfectedMessage_()
-         //LogAwstatsMessageRejected_(sendersIP, pMessage, "Message delivery cancelled during virus scanning");
+         //PersistentMessage::DeleteObject(pMessage) moved from HandleInfectedMessage_() to here
+         LogAwstatsMessageRejected_(sendersIP, pMessage, "Message delivery cancelled during virus scanning");
+         PersistentMessage::DeleteObject(pMessage);
          return false;
       }
 
       // Apply rules on this message.
       if (!RunGlobalRules_(pMessage, globalRuleResult))
       {
-         //LogAwstatsMessageRejected_ moved to RunGlobalRules_()
-         //LogAwstatsMessageRejected_(sendersIP, pMessage, "Message delivery cancelled during global rules");
+         //PersistentMessage::DeleteObject(pMessage) moved from RunGlobalRules_() to here
+         LogAwstatsMessageRejected_(sendersIP, pMessage, "Message delivery cancelled during global rules");
+         PersistentMessage::DeleteObject(pMessage);
          return false;
       }
 
       // Run the OnDeliverMessage-event
       if (!Events::FireOnDeliverMessage(pMessage))
       {
+         //PersistentMessage::DeleteObject(pMessage) moved from FireOnDeliverMessage() event to here
          LogAwstatsMessageRejected_(sendersIP, pMessage, "Message delivery cancelled during OnDeliverMessage-event");
+         PersistentMessage::DeleteObject(pMessage);
          return false;
       }
 
@@ -336,8 +340,6 @@ namespace HM
       if (antiVirusConfig.AVAction() == AntiVirusConfiguration::ActionDelete)
       {
          // The message should be deleted.
-         String sendersIP = MessageUtilities::GetSendersIP(pMessage);
-         LogAwstatsMessageRejected_(sendersIP, pMessage, "Message delivery cancelled during virus scanning");
 
          // Should we notify the recipient?
          if (antiVirusConfig.AVNotifyReceiver())
@@ -362,7 +364,8 @@ namespace HM
 
          LOG_APPLICATION(logMessage);
 
-         PersistentMessage::DeleteObject(pMessage);
+         //Moved to PreprocessMessage_() in SMTPDeliverer.cpp
+         //PersistentMessage::DeleteObject(pMessage);
          
          return false; // do not continue delivery
 
@@ -450,7 +453,8 @@ namespace HM
 
          LOG_APPLICATION(sMessage);
 
-         PersistentMessage::DeleteObject(pMessage);
+         //Moved to PreprocessMessage_() in SMTPDeliverer.cpp
+         //PersistentMessage::DeleteObject(pMessage);
          return false;
       }
 


### PR DESCRIPTION
oMessage object was emtpy when called from OnDeliveryFailed in SMTPDeliverer.cpp but the documentation says the oMessage object is available in OnDeliveryFailed Event

https://github.com/hmailserver/hmailserver/issues/239