### PR TITLE
 5.7.x resolve MX records that contains CNAME record

### DIFF
--- a/hmailserver/source/Server/Common/Application/Errors.txt
+++ b/hmailserver/source/Server/Common/Application/Errors.txt
@@ -1,5 +1,6 @@
 4401, Too many recursions during IP address lookup. Query: {0}
 4402, Too many recursions during TXT record lookup. Query: {0}
+4403, Too many recursions during MX record lookup. Query: {0}
 5121, PersistentACLPermission::SaveObject, ACL item of type PTAnyone not initialized correctly.
 5122, SQLCEConnection::_UpgradeDatabase(), Failed to create instance of SQL CE Engine.
 5123, SQLCEConnection::_UpgradeDatabase(), Failed to upgrade SQL CE database. HRESULT:

--- a/hmailserver/source/Server/Common/TCPIP/DNSResolver.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/DNSResolver.cpp
@@ -208,8 +208,9 @@ namespace HM
          bool dnsQueryFailure = false;
          for (DNSRecord dnsRecord : foundMxRecords)
          {
-            // Null MX
-            if (dnsRecord.GetValue() == ".")
+            // Null MX, see: rfc7505 
+            // https://tools.ietf.org/html/rfc7505
+            if (dnsRecord.GetValue() == "." && dnsRecord.GetPreference() == 0)
             {
                dnsQueryFailure = true;
                continue;

--- a/hmailserver/source/Server/Common/TCPIP/DNSResolver.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/DNSResolver.cpp
@@ -212,7 +212,6 @@ namespace HM
             // https://tools.ietf.org/html/rfc7505
             if (dnsRecord.GetValue() == "." && dnsRecord.GetPreference() == 0)
             {
-               dnsQueryFailure = true;
                continue;
             }
 

--- a/hmailserver/source/Server/Common/TCPIP/DNSResolver.h
+++ b/hmailserver/source/Server/Common/TCPIP/DNSResolver.h
@@ -25,6 +25,7 @@ namespace HM
 
       bool GetIpAddressesRecursive_(const String &hostName, std::vector<String> &addresses, int recursionLevel, bool followCnameRecords);
       bool GetTXTRecordsRecursive_(const String &sDomain, std::vector<String> &foundResult, int recursionLevel);
+      bool GetMXRecordsRecursive_(const String &sDomain, std::vector<String> &vecFoundNames, int recursionLevel);
 
       std::vector<String> GetDnsRecordsValues_(std::vector<DNSRecord> records);
    };


### PR DESCRIPTION
hMailServer 5.7.x doesn't resolve MX records that contain CNAME record(s)
Prevent A, AAAA and CNAME Lookup for Null MX

Details: https://github.com/hmailserver/hmailserver/issues/371