### PR TITLE
5.7.0 SpamAssassin X-hMailServer-Envelope-From

### DIFF
--- a/hmailserver/source/Server/Common/AntiSpam/SpamTestSpamAssassin.cpp
+++ b/hmailserver/source/Server/Common/AntiSpam/SpamTestSpamAssassin.cpp
@@ -57,18 +57,12 @@ namespace HM
       std::shared_ptr<Message> pMessage = pTestData->GetMessageData()->GetMessage();
       const String sFilename = PersistentMessage::GetFileName(pMessage);
 
-      // Add Return-Path header if none exist (ExternalAccount download?)
-      if (pTestData->GetMessageData()->GetReturnPath().IsEmpty())
-      {
-         String sEnvelopeFrom = pTestData->GetEnvelopeFrom();
+      // Add envelope-from header "Envelope-Sender"
+      std::vector<std::pair<AnsiString, AnsiString> > fieldsToWrite;
+      fieldsToWrite.push_back(std::make_pair("Envelope-Sender", pTestData->GetEnvelopeFrom()));
+      TraceHeaderWriter writer;
+      writer.Write(sFilename, pMessage, fieldsToWrite);
 
-         std::vector<std::pair<AnsiString, AnsiString>> fieldsToWrite;
-         fieldsToWrite.push_back(std::make_pair("Return-Path", sEnvelopeFrom));
-         
-         TraceHeaderWriter writer;
-         writer.Write(sFilename, pMessage, fieldsToWrite);
-      }
-      
       std::shared_ptr<IOService> pIOService = Application::Instance()->GetIOService();
 
       bool testCompleted;
@@ -117,12 +111,7 @@ namespace HM
 
       // Check if the message is tagged as spam.
       std::shared_ptr<MessageData> pMessageData = pTestData->GetMessageData();
-
       pMessageData->RefreshFromMessage();
-      // The Return-Path header was added above to help SpamAssassin with its SPF checks.
-      // We should remove it again to restore the headers to original state (except for any added by SA).
-      pMessageData->DeleteField("Return-Path");
-      pMessageData->Write(sFilename);
 
       bool bIsSpam = false;
       AnsiString sSpamStatus = pMessageData->GetFieldValue("X-Spam-Status");


### PR DESCRIPTION
Use X-hMailServer-Envelope-From header in favour of first adding and later removing the Return-Path Header for use with SpamAssassin

This basically undo's this pull
https://github.com/hmailserver/hmailserver/issues/116