### PR TITLE
5.7.0 InstallLocation RegKey 64-bit

### DIFF
--- a/hmailserver/installation/hMailServerInnoExtension.iss
+++ b/hmailserver/installation/hMailServerInnoExtension.iss
@@ -848,7 +848,7 @@ begin
 	begin
    // Create a registry key that tell
 	  // other apps where we're installed.
-	  RegWriteStringValue(HKLM32, 'Software\hMailServer', 'InstallLocation', ExpandConstant('{app}'));
+	  RegWriteStringValue(HKLM64, 'Software\hMailServer', 'InstallLocation', ExpandConstant('{app}'));
    	
 	  // Write db location to hMailServer.ini.
 	  szIniFile := ExpandConstant('{app}\Bin\hMailServer.ini');


### PR DESCRIPTION
On 64-bit, this registry key is created in HKLM\SOFTWARE\WOW6432Node\hMailServer\InstallLocation which is the 32-bit location
I believe on 64-bit this has to be HKLM\SOFTWARE\hMailServer\InstallLocation