### PR TITLE
Insert X-hMailServer-ExternalAccount-header in same position as other x-hMailServer fields

### DIFF
--- a/hmailserver/source/Server/ExternalFetcher/POP3ClientConnection.cpp
+++ b/hmailserver/source/Server/ExternalFetcher/POP3ClientConnection.cpp
@@ -646,22 +646,22 @@ namespace HM
       return true;
    }
 
-   void 
-   POP3ClientConnection::PrependHeaders_()
+   void
+   POP3ClientConnection::AppendHeaders_()
    //---------------------------------------------------------------------------()
    // DESCRIPTION:
-   // Adds headers to the beginning of the message.
+   // Adds headers after the last existing header
    //---------------------------------------------------------------------------()
    {
       // Add a header with the name of the external account, so that
       // we can check where we downloaded it from later on.
 
-      String sHeader;
-      sHeader.Format(_T("X-hMailServer-ExternalAccount: %s\r\n"), account_->GetName().c_str());
+      String fileName = PersistentMessage::GetFileName(current_message_);
 
-      AnsiString sAnsiHeader = sHeader;
-
-      transmission_buffer_->Append((BYTE*) sAnsiHeader.GetBuffer(), sAnsiHeader.GetLength());
+      std::shared_ptr<MessageData> messageData = std::shared_ptr<MessageData>(new MessageData());
+      messageData->LoadFromMessage(fileName, current_message_);
+      messageData->SetFieldValue("X-hMailServer-ExternalAccount", account_->GetName().c_str());
+      messageData->Write(fileName);
    }
 
    void
@@ -722,8 +722,6 @@ namespace HM
             QuitNow_();
             return;
          }
-
-         PrependHeaders_();
       }
 
       transmission_buffer_->Append(pBuf->GetBuffer(), pBuf->GetSize());
@@ -762,6 +760,8 @@ namespace HM
          QuitNow_();
          return;
       }
+
+      AppendHeaders_();
 
       ParseMessageHeaders_();
 

--- a/hmailserver/source/Server/ExternalFetcher/POP3ClientConnection.cpp
+++ b/hmailserver/source/Server/ExternalFetcher/POP3ClientConnection.cpp
@@ -761,8 +761,6 @@ namespace HM
          return;
       }
 
-      AppendHeaders_();
-
       ParseMessageHeaders_();
 
       if (DoSpamProtection_())
@@ -778,6 +776,8 @@ namespace HM
          // Notify the SMTP deliverer that there is a new message.
          Application::Instance()->SubmitPendingEmail();
       }
+
+      AppendHeaders_();
 
       MarkCurrentMessageAsRead_();
 

--- a/hmailserver/source/Server/ExternalFetcher/POP3ClientConnection.h
+++ b/hmailserver/source/Server/ExternalFetcher/POP3ClientConnection.h
@@ -87,8 +87,8 @@ namespace HM
 
       void RetrieveReceivedDate_(std::shared_ptr<MimeHeader> pHeader);
 
-      void PrependHeaders_();
-      // Adds headers to the beginning of the message.
+      void AppendHeaders_();
+      // Adds headers after the last existing header
 
       void QuitNow_();
       // Sends a QUIT message and switch over to


### PR DESCRIPTION
**use AppendHeader(s) in favor of PrependHeader(s)**

With PrependHeader(s) the X-hMailServer-ExternalAccount header was placed directly above the 1st Received: header, and thus placed completely different relative to other possible added X-hMailServer-* headers

Using AppendHeader(s) the X-hMailServer-ExternalAccount header is placed directly under the last existing header grouping it nicely together with other X-hMailServer-* headers, like:

```
X-hMailServer-ExternalAccount: user@account.name
X-hMailServer-Reason-1: The host name specified in HELO does not match IP address. - (Score: 1)
X-hMailServer-Reason-Score: 1
```