### PR TITLE
Add TLS server cipher preference support to hMailServer 5.6.x

### DIFF
--- a/hmailserver/source/DBScripts/CreateTablesMSSQL.sql
+++ b/hmailserver/source/DBScripts/CreateTablesMSSQL.sql
@@ -935,7 +935,7 @@ insert into hm_settings (settingname, settingstring, settinginteger) values ('Ss
 
 insert into hm_settings (settingname, settingstring, settinginteger) values ('SslVersions', '', 14)
 
-insert into hm_settings (settingname, settingstring, settinginteger) values ('TlsOptions', '', 2)
+insert into hm_settings (settingname, settingstring, settinginteger) values ('TlsOptions', '', 0)
 
 insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2, portconnectionsecurity, portsslcertificateid) values (1, 25, 0, NULL, 0, 0) 
 

--- a/hmailserver/source/DBScripts/CreateTablesMSSQL.sql
+++ b/hmailserver/source/DBScripts/CreateTablesMSSQL.sql
@@ -935,6 +935,8 @@ insert into hm_settings (settingname, settingstring, settinginteger) values ('Ss
 
 insert into hm_settings (settingname, settingstring, settinginteger) values ('SslVersions', '', 14)
 
+insert into hm_settings (settingname, settingstring, settinginteger) values ('TlsOptions', '', 2)
+
 insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2, portconnectionsecurity, portsslcertificateid) values (1, 25, 0, NULL, 0, 0) 
 
 insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2, portconnectionsecurity, portsslcertificateid) values (1, 587, 0, NULL, 0, 0) 

--- a/hmailserver/source/DBScripts/CreateTablesMYSQL.sql
+++ b/hmailserver/source/DBScripts/CreateTablesMYSQL.sql
@@ -760,6 +760,8 @@ insert into hm_settings (settingname, settingstring, settinginteger) values ('Ss
 
 insert into hm_settings (settingname, settingstring, settinginteger) values ('SslVersions', '', 14);
 
+insert into hm_settings (settingname, settingstring, settinginteger) values ('TlsOptions', '', 2);
+
 insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2, portconnectionsecurity, portsslcertificateid) values (1, 25, 0, NULL, 0, 0);
 
 insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2, portconnectionsecurity, portsslcertificateid) values (1, 587, 0, NULL, 0, 0);

--- a/hmailserver/source/DBScripts/CreateTablesMYSQL.sql
+++ b/hmailserver/source/DBScripts/CreateTablesMYSQL.sql
@@ -760,7 +760,7 @@ insert into hm_settings (settingname, settingstring, settinginteger) values ('Ss
 
 insert into hm_settings (settingname, settingstring, settinginteger) values ('SslVersions', '', 14);
 
-insert into hm_settings (settingname, settingstring, settinginteger) values ('TlsOptions', '', 2);
+insert into hm_settings (settingname, settingstring, settinginteger) values ('TlsOptions', '', 0);
 
 insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2, portconnectionsecurity, portsslcertificateid) values (1, 25, 0, NULL, 0, 0);
 

--- a/hmailserver/source/DBScripts/CreateTablesPGSQL.sql
+++ b/hmailserver/source/DBScripts/CreateTablesPGSQL.sql
@@ -776,6 +776,8 @@ insert into hm_settings (settingname, settingstring, settinginteger) values ('Ss
 
 insert into hm_settings (settingname, settingstring, settinginteger) values ('SslVersions', '', 14);
 
+insert into hm_settings (settingname, settingstring, settinginteger) values ('TlsOptions', '', 2);
+
 insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2, portconnectionsecurity, portsslcertificateid) values (1, 25, 0, NULL, 0, 0);
 
 insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2, portconnectionsecurity, portsslcertificateid) values (1, 587, 0, NULL, 0, 0);

--- a/hmailserver/source/DBScripts/CreateTablesPGSQL.sql
+++ b/hmailserver/source/DBScripts/CreateTablesPGSQL.sql
@@ -776,7 +776,7 @@ insert into hm_settings (settingname, settingstring, settinginteger) values ('Ss
 
 insert into hm_settings (settingname, settingstring, settinginteger) values ('SslVersions', '', 14);
 
-insert into hm_settings (settingname, settingstring, settinginteger) values ('TlsOptions', '', 2);
+insert into hm_settings (settingname, settingstring, settinginteger) values ('TlsOptions', '', 0);
 
 insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2, portconnectionsecurity, portsslcertificateid) values (1, 25, 0, NULL, 0, 0);
 

--- a/hmailserver/source/DBScripts/Upgrade5601to5609MSSQLCE.sql
+++ b/hmailserver/source/DBScripts/Upgrade5601to5609MSSQLCE.sql
@@ -1,0 +1,3 @@
+insert into hm_settings (settingname, settingstring, settinginteger) values ('TlsOptions', '', 2)
+
+update hm_dbversion set value = 5609

--- a/hmailserver/source/DBScripts/Upgrade5601to5609MSSQLCE.sql
+++ b/hmailserver/source/DBScripts/Upgrade5601to5609MSSQLCE.sql
@@ -1,3 +1,3 @@
-insert into hm_settings (settingname, settingstring, settinginteger) values ('TlsOptions', '', 2)
+insert into hm_settings (settingname, settingstring, settinginteger) values ('TlsOptions', '', 0)
 
 update hm_dbversion set value = 5609

--- a/hmailserver/source/DBScripts/Upgrade5601to5609MySQL.sql
+++ b/hmailserver/source/DBScripts/Upgrade5601to5609MySQL.sql
@@ -1,0 +1,3 @@
+insert into hm_settings (settingname, settingstring, settinginteger) values ('TlsOptions', '', 2);
+
+update hm_dbversion set value = 5609;

--- a/hmailserver/source/DBScripts/Upgrade5601to5609MySQL.sql
+++ b/hmailserver/source/DBScripts/Upgrade5601to5609MySQL.sql
@@ -1,3 +1,3 @@
-insert into hm_settings (settingname, settingstring, settinginteger) values ('TlsOptions', '', 2);
+insert into hm_settings (settingname, settingstring, settinginteger) values ('TlsOptions', '', 0);
 
 update hm_dbversion set value = 5609;

--- a/hmailserver/source/DBScripts/Upgrade5601to5609PGSQL.sql
+++ b/hmailserver/source/DBScripts/Upgrade5601to5609PGSQL.sql
@@ -1,0 +1,3 @@
+insert into hm_settings (settingname, settingstring, settinginteger) values ('TlsOptions', '', 2);
+
+update hm_dbversion set value = 5609;

--- a/hmailserver/source/DBScripts/Upgrade5601to5609PGSQL.sql
+++ b/hmailserver/source/DBScripts/Upgrade5601to5609PGSQL.sql
@@ -1,3 +1,3 @@
-insert into hm_settings (settingname, settingstring, settinginteger) values ('TlsOptions', '', 2);
+insert into hm_settings (settingname, settingstring, settinginteger) values ('TlsOptions', '', 0);
 
 update hm_dbversion set value = 5609;

--- a/hmailserver/source/Server/COM/InterfaceSettings.cpp
+++ b/hmailserver/source/Server/COM/InterfaceSettings.cpp
@@ -2453,3 +2453,37 @@ STDMETHODIMP InterfaceSettings::get_TlsVersion13Enabled(VARIANT_BOOL *pVal)
       return COMError::GenerateGenericMessage();
    }
 }
+
+
+STDMETHODIMP InterfaceSettings::put_TlsOptionPreferServerCiphersEnabled(VARIANT_BOOL newVal)
+{
+   try
+   {
+      if (!config_)
+         return GetAccessDenied();
+
+      config_->SetTlsOptionEnabled(HM::TlsOptionPreferServerCiphers, newVal == VARIANT_TRUE);
+      return S_OK;
+   }
+   catch (...)
+   {
+      return COMError::GenerateGenericMessage();
+   }
+}
+
+
+STDMETHODIMP InterfaceSettings::get_TlsOptionPreferServerCiphersEnabled(VARIANT_BOOL *pVal)
+{
+   try
+   {
+      if (!config_)
+         return GetAccessDenied();
+
+      *pVal = config_->GetTlsOptionEnabled(HM::TlsOptionPreferServerCiphers) ? VARIANT_TRUE : VARIANT_FALSE;
+      return S_OK;
+   }
+   catch (...)
+   {
+      return COMError::GenerateGenericMessage();
+   }
+}

--- a/hmailserver/source/Server/COM/InterfaceSettings.cpp
+++ b/hmailserver/source/Server/COM/InterfaceSettings.cpp
@@ -2487,3 +2487,37 @@ STDMETHODIMP InterfaceSettings::get_TlsOptionPreferServerCiphersEnabled(VARIANT_
       return COMError::GenerateGenericMessage();
    }
 }
+
+
+STDMETHODIMP InterfaceSettings::put_TlsOptionPrioritizeChaChaEnabled(VARIANT_BOOL newVal)
+{
+   try
+   {
+      if (!config_)
+         return GetAccessDenied();
+
+      config_->SetTlsOptionEnabled(HM::TlsOptionPrioritizeChaCha, newVal == VARIANT_TRUE);
+      return S_OK;
+   }
+   catch (...)
+   {
+      return COMError::GenerateGenericMessage();
+   }
+}
+
+
+STDMETHODIMP InterfaceSettings::get_TlsOptionPrioritizeChaChaEnabled(VARIANT_BOOL *pVal)
+{
+   try
+   {
+      if (!config_)
+         return GetAccessDenied();
+
+      *pVal = config_->GetTlsOptionEnabled(HM::TlsOptionPrioritizeChaCha) ? VARIANT_TRUE : VARIANT_FALSE;
+      return S_OK;
+   }
+   catch (...)
+   {
+      return COMError::GenerateGenericMessage();
+   }
+}

--- a/hmailserver/source/Server/COM/InterfaceSettings.h
+++ b/hmailserver/source/Server/COM/InterfaceSettings.h
@@ -240,6 +240,8 @@ END_COM_MAP()
 
    STDMETHOD(get_TlsOptionPreferServerCiphersEnabled)(/*[out, retval]*/ VARIANT_BOOL *pVal);
    STDMETHOD(put_TlsOptionPreferServerCiphersEnabled)(/*[in]*/ VARIANT_BOOL newVal);
+   STDMETHOD(get_TlsOptionPrioritizeChaChaEnabled)(/*[out, retval]*/ VARIANT_BOOL *pVal);
+   STDMETHOD(put_TlsOptionPrioritizeChaChaEnabled)(/*[in]*/ VARIANT_BOOL newVal);
 
    STDMETHOD(get_CrashSimulationMode)(/*[out, retval]*/ long *pVal);
    STDMETHOD(put_CrashSimulationMode)(/*[in]*/ long newVal);

--- a/hmailserver/source/Server/COM/InterfaceSettings.h
+++ b/hmailserver/source/Server/COM/InterfaceSettings.h
@@ -238,6 +238,9 @@ END_COM_MAP()
    STDMETHOD(get_TlsVersion13Enabled)(/*[out, retval]*/ VARIANT_BOOL *pVal);
    STDMETHOD(put_TlsVersion13Enabled)(/*[in]*/ VARIANT_BOOL newVal);
 
+   STDMETHOD(get_TlsOptionPreferServerCiphersEnabled)(/*[out, retval]*/ VARIANT_BOOL *pVal);
+   STDMETHOD(put_TlsOptionPreferServerCiphersEnabled)(/*[in]*/ VARIANT_BOOL newVal);
+
    STDMETHOD(get_CrashSimulationMode)(/*[out, retval]*/ long *pVal);
    STDMETHOD(put_CrashSimulationMode)(/*[in]*/ long newVal);
 

--- a/hmailserver/source/Server/Common/Application/Configuration.cpp
+++ b/hmailserver/source/Server/Common/Application/Configuration.cpp
@@ -648,6 +648,25 @@ namespace HM
       GetSettings()->SetLong(PROPERTY_SSLVERSIONS, versions);
    }
 
+   bool
+	   Configuration::GetTlsOptionEnabled(TlsOption option) const
+   {
+	   return (GetSettings()->GetLong(PROPERTY_TLSOPTIONS) & option) ? true : false;
+   }
+
+   void
+	   Configuration::SetTlsOptionEnabled(TlsOption option, bool enabled)
+   {
+	   int options = GetSettings()->GetLong(PROPERTY_TLSOPTIONS);
+
+	   if (enabled)
+		   options = options | option;
+	   else
+		   options = options &~option;
+
+	   GetSettings()->SetLong(PROPERTY_TLSOPTIONS, options);
+   }
+
    int
    Configuration::GetCrashSimulationMode() const
    {

--- a/hmailserver/source/Server/Common/Application/Configuration.h
+++ b/hmailserver/source/Server/Common/Application/Configuration.h
@@ -159,6 +159,9 @@ namespace HM
       bool GetSslVersionEnabled(SslTlsVersion version) const;
       void SetSslVersionEnabled(SslTlsVersion version, bool enabled);
 
+	  bool GetTlsOptionEnabled(TlsOption option) const;
+	  void SetTlsOptionEnabled(TlsOption option, bool enabled);
+
       int GetCrashSimulationMode() const;
       void SetCrashSimulationMode(int mode);
 

--- a/hmailserver/source/Server/Common/Application/Constants.h
+++ b/hmailserver/source/Server/Common/Application/Constants.h
@@ -124,6 +124,8 @@
 
 #define PROPERTY_SSLVERSIONS _T("SslVersions")
 
+#define PROPERTY_TLSOPTIONS _T("TlsOptions")
+
 #define PROPERTY_CLAMAV_ENABLED              _T("ClamAVEnabled")
 #define PROPERTY_CLAMAV_HOST                 _T("ClamAVHost")
 #define PROPERTY_CLAMAV_PORT                 _T("ClamAVPort")

--- a/hmailserver/source/Server/Common/TCPIP/SocketConstants.h
+++ b/hmailserver/source/Server/Common/TCPIP/SocketConstants.h
@@ -44,6 +44,7 @@ namespace HM
 
    enum TlsOption
    {
-	   TlsOptionPreferServerCiphers = 2
+      TlsOptionPreferServerCiphers = 2,
+      TlsOptionPrioritizeChaCha = 4
    };
 }

--- a/hmailserver/source/Server/Common/TCPIP/SocketConstants.h
+++ b/hmailserver/source/Server/Common/TCPIP/SocketConstants.h
@@ -41,4 +41,9 @@ namespace HM
       TlsVersion12 = 8,
       TlsVersion13 = 16
    };
+
+   enum TlsOption
+   {
+	   TlsOptionPreferServerCiphers = 2
+   };
 }

--- a/hmailserver/source/Server/Common/TCPIP/SslContextInitializer.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/SslContextInitializer.cpp
@@ -180,6 +180,7 @@ namespace HM
       bool tlsv11 = Configuration::Instance()->GetSslVersionEnabled(TlsVersion11);
       bool tlsv12 = Configuration::Instance()->GetSslVersionEnabled(TlsVersion12);
       bool tlsv13 = Configuration::Instance()->GetSslVersionEnabled(TlsVersion13);
+	  bool tlsPreferServerCiphers = Configuration::Instance()->GetTlsOptionEnabled(TlsOptionPreferServerCiphers);
 
       int options = SSL_OP_ALL | SSL_OP_SINGLE_DH_USE | SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_SINGLE_ECDH_USE;
 
@@ -191,6 +192,9 @@ namespace HM
          options = options | SSL_OP_NO_TLSv1_2;
       if (!tlsv13)
          options = options | SSL_OP_NO_TLSv1_3;
+
+	  if (tlsPreferServerCiphers)
+		  options = options | SSL_OP_CIPHER_SERVER_PREFERENCE;
 
       SSL_CTX* ssl = context.native_handle();
       SSL_CTX_set_options(ssl, options);

--- a/hmailserver/source/Server/Common/TCPIP/SslContextInitializer.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/SslContextInitializer.cpp
@@ -180,7 +180,8 @@ namespace HM
       bool tlsv11 = Configuration::Instance()->GetSslVersionEnabled(TlsVersion11);
       bool tlsv12 = Configuration::Instance()->GetSslVersionEnabled(TlsVersion12);
       bool tlsv13 = Configuration::Instance()->GetSslVersionEnabled(TlsVersion13);
-	  bool tlsPreferServerCiphers = Configuration::Instance()->GetTlsOptionEnabled(TlsOptionPreferServerCiphers);
+      bool tlsPreferServerCiphers = Configuration::Instance()->GetTlsOptionEnabled(TlsOptionPreferServerCiphers);
+      bool tlsPrioritizeChaCha = Configuration::Instance()->GetTlsOptionEnabled(TlsOptionPrioritizeChaCha);
 
       int options = SSL_OP_ALL | SSL_OP_SINGLE_DH_USE | SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_SINGLE_ECDH_USE;
 
@@ -193,8 +194,11 @@ namespace HM
       if (!tlsv13)
          options = options | SSL_OP_NO_TLSv1_3;
 
-	  if (tlsPreferServerCiphers)
-		  options = options | SSL_OP_CIPHER_SERVER_PREFERENCE;
+      if (tlsPreferServerCiphers)
+         options = options | SSL_OP_CIPHER_SERVER_PREFERENCE;
+
+      if (tlsPrioritizeChaCha && tlsPreferServerCiphers && (tlsv12 || tlsv13))
+         options = options | SSL_OP_PRIORITIZE_CHACHA;
 
       SSL_CTX* ssl = context.native_handle();
       SSL_CTX_set_options(ssl, options);

--- a/hmailserver/source/Server/hMailServer/hMailServer.idl
+++ b/hmailserver/source/Server/hMailServer/hMailServer.idl
@@ -670,6 +670,9 @@ interface IInterfaceSettings : IDispatch{
 
    [propget, id(100), helpstring("Enable TLS version 1.3")] HRESULT TlsVersion13Enabled([out, retval] VARIANT_BOOL *pVal);
    [propput, id(100), helpstring("Enable TLS version 1.3")] HRESULT TlsVersion13Enabled([in] VARIANT_BOOL newVal);
+
+   [propget, id(101), helpstring("Prefer SSL/TLS server ciphers over client ciphers")] HRESULT TlsOptionPreferServerCiphersEnabled([out, retval] VARIANT_BOOL *pVal);
+   [propput, id(101), helpstring("Prefer SSL/TLS server ciphers over client ciphers")] HRESULT TlsOptionPreferServerCiphersEnabled([in] VARIANT_BOOL newVal);
 };
 
 

--- a/hmailserver/source/Server/hMailServer/hMailServer.idl
+++ b/hmailserver/source/Server/hMailServer/hMailServer.idl
@@ -671,8 +671,10 @@ interface IInterfaceSettings : IDispatch{
    [propget, id(100), helpstring("Enable TLS version 1.3")] HRESULT TlsVersion13Enabled([out, retval] VARIANT_BOOL *pVal);
    [propput, id(100), helpstring("Enable TLS version 1.3")] HRESULT TlsVersion13Enabled([in] VARIANT_BOOL newVal);
 
-   [propget, id(101), helpstring("Prefer SSL/TLS server ciphers over client ciphers")] HRESULT TlsOptionPreferServerCiphersEnabled([out, retval] VARIANT_BOOL *pVal);
-   [propput, id(101), helpstring("Prefer SSL/TLS server ciphers over client ciphers")] HRESULT TlsOptionPreferServerCiphersEnabled([in] VARIANT_BOOL newVal);
+   [propget, id(101), helpstring("Prefer SSL/TLS server ciphers over client ciphers.")] HRESULT TlsOptionPreferServerCiphersEnabled([out, retval] VARIANT_BOOL *pVal);
+   [propput, id(101), helpstring("Prefer SSL/TLS server ciphers over client ciphers.")] HRESULT TlsOptionPreferServerCiphersEnabled([in] VARIANT_BOOL newVal);
+   [propget, id(102), helpstring("Prioritize ChaCha20Poly1305 when client does.")] HRESULT TlsOptionPrioritizeChaChaEnabled([out, retval] VARIANT_BOOL *pVal);
+   [propput, id(102), helpstring("Prioritize ChaCha20Poly1305 when client does.")] HRESULT TlsOptionPrioritizeChaChaEnabled([in] VARIANT_BOOL newVal);
 };
 
 

--- a/hmailserver/source/Tools/Administrator/Main panes/ucSSLTLS.Designer.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucSSLTLS.Designer.cs
@@ -36,6 +36,8 @@ namespace hMailServer.Administrator
             this.checkTlsVersion11 = new hMailServer.Administrator.Controls.ucCheckbox();
             this.checkTlsVersion12 = new hMailServer.Administrator.Controls.ucCheckbox();
             this.checkTlsVersion13 = new hMailServer.Administrator.Controls.ucCheckbox();
+            this.labelOptions = new System.Windows.Forms.Label();
+            this.checkTlsOptionPreferServerCiphers = new hMailServer.Administrator.Controls.ucCheckbox();
             this.SuspendLayout();
             // 
             // labelsslTlsCiphers
@@ -128,10 +130,33 @@ namespace hMailServer.Administrator
             this.checkTlsVersion13.Text = "TLS v1.3";
             this.checkTlsVersion13.UseVisualStyleBackColor = true;
             // 
+            // labelOptions
+            // 
+            this.labelOptions.AutoSize = true;
+            this.labelOptions.Location = new System.Drawing.Point(7, 348);
+            this.labelOptions.Name = "labelOptions";
+            this.labelOptions.Size = new System.Drawing.Size(43, 13);
+            this.labelOptions.TabIndex = 25;
+            this.labelOptions.Text = "Options";
+            // 
+            // checkTlsOptionPreferServerCiphers
+            // 
+            this.checkTlsOptionPreferServerCiphers.AutoSize = true;
+            this.checkTlsOptionPreferServerCiphers.Checked = true;
+            this.checkTlsOptionPreferServerCiphers.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkTlsOptionPreferServerCiphers.Location = new System.Drawing.Point(33, 376);
+            this.checkTlsOptionPreferServerCiphers.Name = "checkTlsOptionPreferServerCiphers";
+            this.checkTlsOptionPreferServerCiphers.Size = new System.Drawing.Size(123, 17);
+            this.checkTlsOptionPreferServerCiphers.TabIndex = 26;
+            this.checkTlsOptionPreferServerCiphers.Text = "Prefer server ciphers";
+            this.checkTlsOptionPreferServerCiphers.UseVisualStyleBackColor = true;
+            // 
             // ucSSLTLS
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.labelOptions);
+            this.Controls.Add(this.checkTlsOptionPreferServerCiphers);
             this.Controls.Add(this.checkTlsVersion13);
             this.Controls.Add(this.checkTlsVersion12);
             this.Controls.Add(this.checkTlsVersion11);
@@ -157,6 +182,8 @@ namespace hMailServer.Administrator
         private Controls.ucCheckbox checkTlsVersion11;
         private Controls.ucCheckbox checkTlsVersion12;
         private Controls.ucCheckbox checkTlsVersion13;
+        private System.Windows.Forms.Label labelOptions;
+        private Controls.ucCheckbox checkTlsOptionPreferServerCiphers;
 
     }
 }

--- a/hmailserver/source/Tools/Administrator/Main panes/ucSSLTLS.Designer.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucSSLTLS.Designer.cs
@@ -36,7 +36,7 @@ namespace hMailServer.Administrator
             this.checkTlsVersion11 = new hMailServer.Administrator.Controls.ucCheckbox();
             this.checkTlsVersion12 = new hMailServer.Administrator.Controls.ucCheckbox();
             this.checkTlsVersion13 = new hMailServer.Administrator.Controls.ucCheckbox();
-            this.labelOptions = new System.Windows.Forms.Label();
+            this.labelCipherPriority = new System.Windows.Forms.Label();
             this.checkTlsOptionPreferServerCiphers = new hMailServer.Administrator.Controls.ucCheckbox();
             this.checkTlsOptionPrioritizeChaCha = new hMailServer.Administrator.Controls.ucCheckbox();
             this.SuspendLayout();
@@ -131,14 +131,14 @@ namespace hMailServer.Administrator
             this.checkTlsVersion13.Text = "TLS v1.3";
             this.checkTlsVersion13.UseVisualStyleBackColor = true;
             // 
-            // labelOptions
+            // labelCipherPriority
             // 
-            this.labelOptions.AutoSize = true;
-            this.labelOptions.Location = new System.Drawing.Point(7, 348);
-            this.labelOptions.Name = "labelOptions";
-            this.labelOptions.Size = new System.Drawing.Size(43, 13);
-            this.labelOptions.TabIndex = 25;
-            this.labelOptions.Text = "Options";
+            this.labelCipherPriority.AutoSize = true;
+            this.labelCipherPriority.Location = new System.Drawing.Point(7, 348);
+            this.labelCipherPriority.Name = "labelCipherPriority";
+            this.labelCipherPriority.Size = new System.Drawing.Size(70, 13);
+            this.labelCipherPriority.TabIndex = 25;
+            this.labelCipherPriority.Text = "Cipher priority";
             // 
             // checkTlsOptionPreferServerCiphers
             // 
@@ -161,7 +161,7 @@ namespace hMailServer.Administrator
             this.checkTlsOptionPrioritizeChaCha.Name = "checkTlsOptionPrioritizeChaCha";
             this.checkTlsOptionPrioritizeChaCha.Size = new System.Drawing.Size(397, 17);
             this.checkTlsOptionPrioritizeChaCha.TabIndex = 27;
-            this.checkTlsOptionPrioritizeChaCha.Text = "Prioritize ChaCha20Poly1305 when client does (requires TLS v1.2 or TLS v1.3)";
+            this.checkTlsOptionPrioritizeChaCha.Text = "Prioritize ChaCha20-Poly1305 when client does (requires TLS v1.2 or TLS v1.3)";
             this.checkTlsOptionPrioritizeChaCha.UseVisualStyleBackColor = true;
             // 
             // ucSSLTLS
@@ -169,7 +169,7 @@ namespace hMailServer.Administrator
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.checkTlsOptionPrioritizeChaCha);
-            this.Controls.Add(this.labelOptions);
+            this.Controls.Add(this.labelCipherPriority);
             this.Controls.Add(this.checkTlsOptionPreferServerCiphers);
             this.Controls.Add(this.checkTlsVersion13);
             this.Controls.Add(this.checkTlsVersion12);
@@ -196,7 +196,7 @@ namespace hMailServer.Administrator
         private Controls.ucCheckbox checkTlsVersion11;
         private Controls.ucCheckbox checkTlsVersion12;
         private Controls.ucCheckbox checkTlsVersion13;
-        private System.Windows.Forms.Label labelOptions;
+        private System.Windows.Forms.Label labelCipherPriority;
         private Controls.ucCheckbox checkTlsOptionPreferServerCiphers;
         private Controls.ucCheckbox checkTlsOptionPrioritizeChaCha;
 

--- a/hmailserver/source/Tools/Administrator/Main panes/ucSSLTLS.Designer.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucSSLTLS.Designer.cs
@@ -38,6 +38,7 @@ namespace hMailServer.Administrator
             this.checkTlsVersion13 = new hMailServer.Administrator.Controls.ucCheckbox();
             this.labelOptions = new System.Windows.Forms.Label();
             this.checkTlsOptionPreferServerCiphers = new hMailServer.Administrator.Controls.ucCheckbox();
+            this.checkTlsOptionPrioritizeChaCha = new hMailServer.Administrator.Controls.ucCheckbox();
             this.SuspendLayout();
             // 
             // labelsslTlsCiphers
@@ -151,10 +152,23 @@ namespace hMailServer.Administrator
             this.checkTlsOptionPreferServerCiphers.Text = "Prefer server ciphers";
             this.checkTlsOptionPreferServerCiphers.UseVisualStyleBackColor = true;
             // 
+            // checkTlsOptionPrioritizeChaCha
+            // 
+            this.checkTlsOptionPrioritizeChaCha.AutoSize = true;
+            this.checkTlsOptionPrioritizeChaCha.Checked = true;
+            this.checkTlsOptionPrioritizeChaCha.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkTlsOptionPrioritizeChaCha.Location = new System.Drawing.Point(42, 399);
+            this.checkTlsOptionPrioritizeChaCha.Name = "checkTlsOptionPrioritizeChaCha";
+            this.checkTlsOptionPrioritizeChaCha.Size = new System.Drawing.Size(397, 17);
+            this.checkTlsOptionPrioritizeChaCha.TabIndex = 27;
+            this.checkTlsOptionPrioritizeChaCha.Text = "Prioritize ChaCha20Poly1305 when client does (requires TLS v1.2 or TLS v1.3)";
+            this.checkTlsOptionPrioritizeChaCha.UseVisualStyleBackColor = true;
+            // 
             // ucSSLTLS
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.checkTlsOptionPrioritizeChaCha);
             this.Controls.Add(this.labelOptions);
             this.Controls.Add(this.checkTlsOptionPreferServerCiphers);
             this.Controls.Add(this.checkTlsVersion13);
@@ -184,6 +198,7 @@ namespace hMailServer.Administrator
         private Controls.ucCheckbox checkTlsVersion13;
         private System.Windows.Forms.Label labelOptions;
         private Controls.ucCheckbox checkTlsOptionPreferServerCiphers;
+        private Controls.ucCheckbox checkTlsOptionPrioritizeChaCha;
 
     }
 }

--- a/hmailserver/source/Tools/Administrator/Main panes/ucSSLTLS.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucSSLTLS.cs
@@ -51,6 +51,8 @@ namespace hMailServer.Administrator
            checkTlsVersion12.Checked = settings.TlsVersion12Enabled;
            checkTlsVersion13.Checked = settings.TlsVersion13Enabled;
            checkTlsOptionPreferServerCiphers.Checked = settings.TlsOptionPreferServerCiphersEnabled;
+           checkTlsOptionPrioritizeChaCha.Enabled = (settings.TlsVersion12Enabled || settings.TlsVersion13Enabled) && settings.TlsOptionPreferServerCiphersEnabled;
+           checkTlsOptionPrioritizeChaCha.Checked = settings.TlsOptionPrioritizeChaChaEnabled;
 
            Marshal.ReleaseComObject(settings);
         }
@@ -61,7 +63,14 @@ namespace hMailServer.Administrator
 
            hMailServer.Settings settings = app.Settings;
 
-           bool restartRequired = textSslCipherList.Dirty || checkTlsVersion10.Dirty || checkTlsVersion11.Dirty || checkTlsVersion12.Dirty || checkTlsVersion13.Dirty || checkTlsOptionPreferServerCiphers.Dirty;
+           bool restartRequired =
+             textSslCipherList.Dirty || 
+             checkTlsVersion10.Dirty ||
+             checkTlsVersion11.Dirty ||
+             checkTlsVersion12.Dirty ||
+             checkTlsVersion13.Dirty || 
+             checkTlsOptionPreferServerCiphers.Dirty ||
+             checkTlsOptionPrioritizeChaCha.Dirty;
 
            settings.VerifyRemoteSslCertificate = checkVerifyRemoteServerSslCertificate.Checked;
            settings.SslCipherList = textSslCipherList.Text;
@@ -72,6 +81,7 @@ namespace hMailServer.Administrator
            settings.TlsVersion13Enabled = checkTlsVersion13.Checked;
 
            settings.TlsOptionPreferServerCiphersEnabled = checkTlsOptionPreferServerCiphers.Checked;
+           settings.TlsOptionPrioritizeChaChaEnabled = checkTlsOptionPrioritizeChaCha.Enabled && checkTlsOptionPrioritizeChaCha.Checked;
 
            Marshal.ReleaseComObject(settings);
 
@@ -92,6 +102,8 @@ namespace hMailServer.Administrator
         private void OnContentChanged()
         {
            Instances.MainForm.OnContentChanged();
+
+           checkTlsOptionPrioritizeChaCha.Enabled = (checkTlsVersion12.Checked || checkTlsVersion13.Checked) && checkTlsOptionPreferServerCiphers.Checked;
         }
 
         private void OnContentChanged(object sender, EventArgs e)

--- a/hmailserver/source/Tools/Administrator/Main panes/ucSSLTLS.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucSSLTLS.cs
@@ -104,6 +104,7 @@ namespace hMailServer.Administrator
            Instances.MainForm.OnContentChanged();
 
            checkTlsOptionPrioritizeChaCha.Enabled = (checkTlsVersion12.Checked || checkTlsVersion13.Checked) && checkTlsOptionPreferServerCiphers.Checked;
+           checkTlsOptionPrioritizeChaCha.Checked = checkTlsOptionPrioritizeChaCha.Enabled && checkTlsOptionPrioritizeChaCha.Checked;
         }
 
         private void OnContentChanged(object sender, EventArgs e)

--- a/hmailserver/source/Tools/Administrator/Main panes/ucSSLTLS.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucSSLTLS.cs
@@ -104,7 +104,10 @@ namespace hMailServer.Administrator
            Instances.MainForm.OnContentChanged();
 
            checkTlsOptionPrioritizeChaCha.Enabled = (checkTlsVersion12.Checked || checkTlsVersion13.Checked) && checkTlsOptionPreferServerCiphers.Checked;
-           checkTlsOptionPrioritizeChaCha.Checked = checkTlsOptionPrioritizeChaCha.Enabled && checkTlsOptionPrioritizeChaCha.Checked;
+           if (!checkTlsOptionPrioritizeChaCha.Enabled && checkTlsOptionPrioritizeChaCha.Checked)
+           {
+               checkTlsOptionPrioritizeChaCha.Checked = false;
+           }
         }
 
         private void OnContentChanged(object sender, EventArgs e)

--- a/hmailserver/source/Tools/Administrator/Main panes/ucSSLTLS.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucSSLTLS.cs
@@ -50,6 +50,7 @@ namespace hMailServer.Administrator
            checkTlsVersion11.Checked = settings.TlsVersion11Enabled;
            checkTlsVersion12.Checked = settings.TlsVersion12Enabled;
            checkTlsVersion13.Checked = settings.TlsVersion13Enabled;
+           checkTlsOptionPreferServerCiphers.Checked = settings.TlsOptionPreferServerCiphersEnabled;
 
            Marshal.ReleaseComObject(settings);
         }
@@ -60,7 +61,7 @@ namespace hMailServer.Administrator
 
            hMailServer.Settings settings = app.Settings;
 
-           bool restartRequired = textSslCipherList.Dirty || checkTlsVersion10.Dirty || checkTlsVersion11.Dirty || checkTlsVersion12.Dirty || checkTlsVersion13.Dirty;
+           bool restartRequired = textSslCipherList.Dirty || checkTlsVersion10.Dirty || checkTlsVersion11.Dirty || checkTlsVersion12.Dirty || checkTlsVersion13.Dirty || checkTlsOptionPreferServerCiphers.Dirty;
 
            settings.VerifyRemoteSslCertificate = checkVerifyRemoteServerSslCertificate.Checked;
            settings.SslCipherList = textSslCipherList.Text;
@@ -69,6 +70,8 @@ namespace hMailServer.Administrator
            settings.TlsVersion11Enabled = checkTlsVersion11.Checked;
            settings.TlsVersion12Enabled = checkTlsVersion12.Checked;
            settings.TlsVersion13Enabled = checkTlsVersion13.Checked;
+
+           settings.TlsOptionPreferServerCiphersEnabled = checkTlsOptionPreferServerCiphers.Checked;
 
            Marshal.ReleaseComObject(settings);
 


### PR DESCRIPTION
This pull request is for hMailServer 5.6.x. For lack of a better branch, I picked 5.6.8. It should be added to a new branch for a new 5.6.x version.

The added function concerns the OpenSSL option SSL_OP_CIPHER_SERVER_PREFERENCE. One existing example of the use of this option is  by NGINX using the `ssl_prefer_server_ciphers` option. With server cipher preference (once enabled), the server will prioritize its own cipher load order instead of that of the client.

* The [NCSC IT Security Guidelines for Transport Layer Security (TLS)](https://english.ncsc.nl/publications/publications/2021/january/19/it-security-guidelines-for-transport-layer-security-2.1) recommends the use of server cipher preference with specific ciphers. See B2-5 for more information.
* Enabling server cipher preference is recommended [by Mozilla for very old clients](https://ssl-config.mozilla.org/).
* Server cipher preference is required to fully pass some online SMTP server tests. [One example is provided by internet.nl](https://internet.nl/test-mail/).

~~I enabled the function by default through the hMailServer database SQL initialization files, based on that TLS 1.0 support (which is also required by older clients) is enabled by default as well. Users can toggle this function on the SSL/TLS page of hMailServer Administrator.~~

All new functionality in this PR is disabled by default for backwards compatibility.

Furthermore, another OpenSSL option, SSL_OP_PRIORITIZE_CHACHA, has been added to prioritize ChaCha20-Poly1305 on the server whenever it is prioritized by the client. [This is especially useful for devices that do not support AES-NI](https://crypto.stackexchange.com/questions/34455/whats-the-appeal-of-using-chacha20-instead-of-aes/34458#34458), such as mobile devices running mail clients. This does not influence clients that do not prioritize ChaCha20-Poly1305.