### PR TITLE
DKIM signature for domain aliases

### DIFF
--- a/hmailserver/source/Server/COM/InterfaceDomain.cpp
+++ b/hmailserver/source/Server/COM/InterfaceDomain.cpp
@@ -1198,6 +1198,47 @@ STDMETHODIMP InterfaceDomain::put_DKIMSignEnabled(VARIANT_BOOL newVal)
    }
 }
 
+STDMETHODIMP InterfaceDomain::get_DKIMSignAliasesEnabled(VARIANT_BOOL* pVal)
+{
+   try
+   {
+      if (!object_)
+         return GetAccessDenied();
+
+      if (!authentication_->GetIsDomainAdmin())
+         return authentication_->GetAccessDenied();
+
+      *pVal = object_->GetDKIMAliasesEnabled() ? VARIANT_TRUE : VARIANT_FALSE;
+
+      return S_OK;
+   }
+   catch (...)
+   {
+      return COMError::GenerateGenericMessage();
+   }
+}
+
+STDMETHODIMP InterfaceDomain::put_DKIMSignAliasesEnabled(VARIANT_BOOL newVal)
+{
+   try
+   {
+      if (!object_)
+         return GetAccessDenied();
+
+      if (!authentication_->GetIsDomainAdmin())
+         return authentication_->GetAccessDenied();
+
+      object_->SetDKIMAliasesEnabled(newVal == VARIANT_TRUE);
+
+      return S_OK;
+   }
+   catch (...)
+   {
+      return COMError::GenerateGenericMessage();
+   }
+}
+
+
 STDMETHODIMP InterfaceDomain::get_DKIMSelector(BSTR *pVal)
 {
    try

--- a/hmailserver/source/Server/COM/InterfaceDomain.h
+++ b/hmailserver/source/Server/COM/InterfaceDomain.h
@@ -151,6 +151,8 @@ END_COM_MAP()
    STDMETHOD(put_DKIMBodyCanonicalizationMethod)(/*[in]*/ eDKIMCanonicalizationMethod newVal);
    STDMETHOD(get_DKIMSigningAlgorithm)(/*[out, retval]*/ eDKIMAlgorithm *pVal);
    STDMETHOD(put_DKIMSigningAlgorithm)(/*[in]*/ eDKIMAlgorithm newVal);
+   STDMETHOD(get_DKIMSignAliasesEnabled)(/*[out, retval]*/ VARIANT_BOOL* pVal);
+   STDMETHOD(put_DKIMSignAliasesEnabled)(/*[in]*/ VARIANT_BOOL newVal);
 
    // dkim end.
 private:

--- a/hmailserver/source/Server/Common/AntiSpam/DKIM/DKIMSigner.cpp
+++ b/hmailserver/source/Server/Common/AntiSpam/DKIM/DKIMSigner.cpp
@@ -10,8 +10,11 @@
 
 #include "../../BO/Message.h"
 #include "../../BO/Domain.h"
+#include "../../BO/Alias.h"
+#include "../../Application/ObjectCache.h"
 #include "../../Cache/CacheContainer.h"
 #include "../../Util/Hashing/HashCreator.h"
+#include "../../BO/DomainAliases.h"
 
 #ifdef _DEBUG
 #define DEBUG_NEW new(_NORMAL_BLOCK, __FILE__, __LINE__)
@@ -30,18 +33,30 @@ namespace HM
    {
      
       AnsiString senderAddress = message->GetFromAddress();
+      std::shared_ptr<DomainAliases> pDA = ObjectCache::Instance()->GetDomainAliases();
+      // try to get mailbox from the alias (if it is an alias actually)
+      String sSender = pDA->ApplyAliasesOnAddress(sSender);
       AnsiString senderDomain = StringParser::ExtractDomain(senderAddress);
+      AnsiString mbDomain = StringParser::ExtractDomain(sSender);
+
+      // was the sender address from the main domain already?
+      boolean sameDomain = senderDomain.CompareNoCase(mbDomain) == 0;
 
       // Check if signing is enabled for this domain.
-      std::shared_ptr<const Domain> pDomain = CacheContainer::Instance()->GetDomain(senderDomain);
+      std::shared_ptr<const Domain> pDomain = CacheContainer::Instance()->GetDomain(mbDomain);
 
       if (!pDomain || !pDomain->GetDKIMEnabled())
          return;
+      // main domain signing enabled, do we have the sender address from the main domain or do we allow signing of the aliases?
+      if (!(pDomain->GetDKIMAliasesEnabled() || sameDomain))
+         return;
+
 
       LOG_DEBUG("Signing message using DKIM...");
 
       AnsiString selector = pDomain->GetDKIMSelector();
-      AnsiString domain = pDomain->GetName();
+      // the senderDomain is either the main domain or it is allowed to sign using the key from the main domain
+      AnsiString domain = senderDomain;
       AnsiString privateKeyFile = pDomain->GetDKIMPrivateKeyFile();
 
       if (selector.IsEmpty() || privateKeyFile.IsEmpty())

--- a/hmailserver/source/Server/Common/AntiSpam/DKIM/DKIMSigner.cpp
+++ b/hmailserver/source/Server/Common/AntiSpam/DKIM/DKIMSigner.cpp
@@ -35,7 +35,7 @@ namespace HM
       AnsiString senderAddress = message->GetFromAddress();
       std::shared_ptr<DomainAliases> pDA = ObjectCache::Instance()->GetDomainAliases();
       // try to get mailbox from the alias (if it is an alias actually)
-      String sSender = pDA->ApplyAliasesOnAddress(sSender);
+      String sSender = pDA->ApplyAliasesOnAddress(senderAddress);
       AnsiString senderDomain = StringParser::ExtractDomain(senderAddress);
       AnsiString mbDomain = StringParser::ExtractDomain(sSender);
 

--- a/hmailserver/source/Server/Common/BO/Domain.cpp
+++ b/hmailserver/source/Server/Common/BO/Domain.cpp
@@ -420,7 +420,19 @@ namespace HM
       anti_spam_options_ = newValue ? anti_spam_options_ | ASDKIMSign : anti_spam_options_ & ~ASDKIMSign;
    }
 
-   AnsiString 
+   bool
+      Domain::GetDKIMAliasesEnabled() const
+   {
+      return (anti_spam_options_ & ASDKIMSignAliases) ? true : false;
+   }
+
+   void
+      Domain::SetDKIMAliasesEnabled(bool newValue)
+   {
+      anti_spam_options_ = newValue ? anti_spam_options_ | ASDKIMSignAliases : anti_spam_options_ & ~ASDKIMSignAliases;
+   }
+
+   AnsiString
    Domain::GetDKIMSelector() const
    {
       return dkim_selector_;

--- a/hmailserver/source/Server/Common/BO/Domain.h
+++ b/hmailserver/source/Server/Common/BO/Domain.h
@@ -26,6 +26,7 @@ namespace HM
          ASDKIMSimpleHeader = 4,
          ASDKIMSimpleBody = 8,
          ASDKIMSHA1 = 16,
+         ASDKIMSignAliases = 32,
       };
 
       enum DomainSignatureMethod
@@ -117,6 +118,10 @@ namespace HM
       */
       bool GetDKIMEnabled() const;
       void SetDKIMEnabled(bool newVal);
+
+      bool GetDKIMAliasesEnabled() const;
+      void SetDKIMAliasesEnabled(bool newVal);
+
 
       AnsiString GetDKIMSelector() const;
       void SetDKIMSelector(const String &newValue);

--- a/hmailserver/source/Server/hMailServer/hMailServer.idl
+++ b/hmailserver/source/Server/hMailServer/hMailServer.idl
@@ -770,6 +770,9 @@ interface IInterfaceDomain : IDispatch
 	   [propput, id(38), helpstring("Gets or sets the body canonicalization method.")] HRESULT DKIMBodyCanonicalizationMethod([in] eDKIMCanonicalizationMethod newVal);
 	   [propget, id(39), helpstring("Gets or sets the signing algorithm.")] HRESULT DKIMSigningAlgorithm([out, retval] eDKIMAlgorithm *pVal);
 	   [propput, id(39), helpstring("Gets or sets the signing algorithm.")] HRESULT DKIMSigningAlgorithm([in] eDKIMAlgorithm newVal);
+	   [propget, id(40), helpstring("Enable DKIM signing for aliases.")] HRESULT DKIMSignAliasesEnabled([out, retval] VARIANT_BOOL* pVal);
+	   [propput, id(40), helpstring("Enable DKIM signing for aliases.")] HRESULT DKIMSignAliasesEnabled([in] VARIANT_BOOL pVal);
+
 
 };
 [

--- a/hmailserver/source/Tools/Administrator/Main panes/ucDomain.Designer.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucDomain.Designer.cs
@@ -87,6 +87,7 @@ namespace hMailServer.Administrator
            this.labelDKIMPrivateKeyFile = new System.Windows.Forms.Label();
            this.textDKIMPrivateKeyFile = new hMailServer.Shared.ucText();
            this.checkDKIMSignEnabled = new hMailServer.Administrator.Controls.ucCheckbox();
+           this.checkDKIMSignAliasesEnabled = new hMailServer.Administrator.Controls.ucCheckbox();
            this.tabPageAdvanced = new System.Windows.Forms.TabPage();
            this.textCatchAllAddress = new hMailServer.Administrator.Controls.ucEmailEdit();
            this.labelCatchAll = new System.Windows.Forms.Label();
@@ -557,6 +558,7 @@ namespace hMailServer.Administrator
            this.tabPageDKIM.Controls.Add(this.labelDKIMPrivateKeyFile);
            this.tabPageDKIM.Controls.Add(this.textDKIMPrivateKeyFile);
            this.tabPageDKIM.Controls.Add(this.checkDKIMSignEnabled);
+           this.tabPageDKIM.Controls.Add(this.checkDKIMSignAliasesEnabled);
            this.tabPageDKIM.Location = new System.Drawing.Point(4, 22);
            this.tabPageDKIM.Name = "tabPageDKIM";
            this.tabPageDKIM.Size = new System.Drawing.Size(554, 354);
@@ -701,7 +703,7 @@ namespace hMailServer.Administrator
            this.labelDKIMSelector.Location = new System.Drawing.Point(11, 89);
            this.labelDKIMSelector.Name = "labelDKIMSelector";
            this.labelDKIMSelector.Size = new System.Drawing.Size(46, 13);
-           this.labelDKIMSelector.TabIndex = 19;
+           this.labelDKIMSelector.TabIndex = 20;
            this.labelDKIMSelector.Text = "Selector";
            // 
            // textDKIMSelector
@@ -711,7 +713,7 @@ namespace hMailServer.Administrator
            this.textDKIMSelector.Number = 0;
            this.textDKIMSelector.Numeric = false;
            this.textDKIMSelector.Size = new System.Drawing.Size(161, 20);
-           this.textDKIMSelector.TabIndex = 18;
+           this.textDKIMSelector.TabIndex = 19;
            // 
            // labelDKIMPrivateKeyFile
            // 
@@ -719,7 +721,7 @@ namespace hMailServer.Administrator
            this.labelDKIMPrivateKeyFile.Location = new System.Drawing.Point(11, 43);
            this.labelDKIMPrivateKeyFile.Name = "labelDKIMPrivateKeyFile";
            this.labelDKIMPrivateKeyFile.Size = new System.Drawing.Size(76, 13);
-           this.labelDKIMPrivateKeyFile.TabIndex = 17;
+           this.labelDKIMPrivateKeyFile.TabIndex = 18;
            this.labelDKIMPrivateKeyFile.Text = "Private key file";
            // 
            // textDKIMPrivateKeyFile
@@ -729,7 +731,7 @@ namespace hMailServer.Administrator
            this.textDKIMPrivateKeyFile.Number = 0;
            this.textDKIMPrivateKeyFile.Numeric = false;
            this.textDKIMPrivateKeyFile.Size = new System.Drawing.Size(205, 20);
-           this.textDKIMPrivateKeyFile.TabIndex = 16;
+           this.textDKIMPrivateKeyFile.TabIndex = 17;
            // 
            // checkDKIMSignEnabled
            // 
@@ -740,10 +742,20 @@ namespace hMailServer.Administrator
            this.checkDKIMSignEnabled.TabIndex = 15;
            this.checkDKIMSignEnabled.Text = "Enabled";
            this.checkDKIMSignEnabled.UseVisualStyleBackColor = true;
-           // 
-           // tabPageAdvanced
-           // 
-           this.tabPageAdvanced.Controls.Add(this.textCatchAllAddress);
+            // 
+            // checkDKIMSignAliasesEnabled
+            // 
+            this.checkDKIMSignAliasesEnabled.AutoSize = true;
+            this.checkDKIMSignAliasesEnabled.Location = new System.Drawing.Point(90, 14);
+            this.checkDKIMSignAliasesEnabled.Name = "checkDKIMSignAliasesEnabled";
+            this.checkDKIMSignAliasesEnabled.Size = new System.Drawing.Size(90, 17);
+            this.checkDKIMSignAliasesEnabled.TabIndex = 16;
+            this.checkDKIMSignAliasesEnabled.Text = "Sign Aliases";
+            this.checkDKIMSignAliasesEnabled.UseVisualStyleBackColor = true;
+         // 
+         // tabPageAdvanced
+         // 
+         this.tabPageAdvanced.Controls.Add(this.textCatchAllAddress);
            this.tabPageAdvanced.Controls.Add(this.labelCatchAll);
            this.tabPageAdvanced.Controls.Add(this.comboPlusAddressingCharacter);
            this.tabPageAdvanced.Controls.Add(this.checkGreyListingEnabled);
@@ -926,6 +938,7 @@ namespace hMailServer.Administrator
         private System.Windows.Forms.Label labelDKIMPrivateKeyFile;
         private hMailServer.Shared.ucText textDKIMPrivateKeyFile;
         private hMailServer.Administrator.Controls.ucCheckbox checkDKIMSignEnabled;
+        private hMailServer.Administrator.Controls.ucCheckbox checkDKIMSignAliasesEnabled;
         private System.Windows.Forms.Label labelDKIMSigningAlgorithm;
         private System.Windows.Forms.Label labelDKIMBodyCanonicalizationMethod;
         private System.Windows.Forms.Label labelDKIMHeaderCanonicalizationMethod;

--- a/hmailserver/source/Tools/Administrator/Main panes/ucDomain.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucDomain.cs
@@ -105,6 +105,7 @@ namespace hMailServer.Administrator
             checkGreyListingEnabled.Checked = _domain.AntiSpamEnableGreylisting;
 
             checkDKIMSignEnabled.Checked = _domain.DKIMSignEnabled;
+            checkDKIMSignAliasesEnabled.Checked = _domain.DKIMSignAliasesEnabled;
             textDKIMPrivateKeyFile.Text = _domain.DKIMPrivateKeyFile;
             textDKIMSelector.Text = _domain.DKIMSelector;
 
@@ -183,6 +184,7 @@ namespace hMailServer.Administrator
             _domain.AntiSpamEnableGreylisting = checkGreyListingEnabled.Checked;
 
             _domain.DKIMSignEnabled = checkDKIMSignEnabled.Checked;
+            _domain.DKIMSignAliasesEnabled = checkDKIMSignAliasesEnabled.Checked;
             _domain.DKIMPrivateKeyFile = textDKIMPrivateKeyFile.Text;
             _domain.DKIMSelector = textDKIMSelector.Text;
 


### PR DESCRIPTION
Added option to allow DKIM signing for domain aliases using key and selector from the parent domain.
As requested https://www.hmailserver.com/forum/viewtopic.php?f=2&t=29029&p=208275
(main reason was that I needed it myself)