### PR TITLE
SASL deliminator from \t to \0 ref RFC4616

### DIFF
--- a/hmailserver/source/Server/IMAP/IMAPCommandAuthenticate.cpp
+++ b/hmailserver/source/Server/IMAP/IMAPCommandAuthenticate.cpp
@@ -63,7 +63,7 @@ namespace HM
 
 		sParam = pParser->GetParamValue(pArgument, 1);
 		StringParser::Base64Decode(sParam, sDecode64);
-		std::vector<String> plain_args = StringParser::SplitString(sDecode64, "\t");
+		std::vector<String> plain_args = StringParser::SplitString(sDecode64, "\0");
 
 		if (plain_args.size() != 3)
 			return IMAPResult(IMAPResult::ResultBad, "Command has malformed base64 token.");


### PR DESCRIPTION
RFC4616 describe the deliminator to be NUL not TAB

From chapter 2, ref https://tools.ietf.org/search/rfc4616:
"The authorization identity (authzid), authentication identity
(authcid), password (passwd), and NUL character deliminators SHALL be
transferred as [UTF-8] encoded strings of [Unicode] characters. As
the NUL (U+0000) character is used as a deliminator, the NUL (U+0000)
character MUST NOT appear in authzid, authcid, or passwd productions"

Test server with GSASL: http://ftp.gnu.org/gnu/gsasl/

Did not understand what happened before I saw the code, see forum thread
https://www.hmailserver.com/forum/viewtopic.php?f=7&t=37063