### PR TITLE
Add events OnRecipientUnknown and OnTooManyInvalidCommands

### DIFF
--- a/hmailserver/source/Server/Common/Scripting/ScriptServer.cpp
+++ b/hmailserver/source/Server/Common/Scripting/ScriptServer.cpp
@@ -32,7 +32,9 @@ namespace HM
       has_on_smtpdata_(false),
       has_on_helo_(false),
       has_on_client_logon_(false),
-      has_on_client_validate_password_(false)
+      has_on_client_validate_password_(false),
+      has_on_recipient_unknown_(false),
+      has_on_too_many_invalid_comands_(false)
    {
       
    }
@@ -103,6 +105,8 @@ namespace HM
          has_on_helo_ = DoesFunctionExist_("OnHELO");
          has_on_client_logon_ = DoesFunctionExist_("OnClientLogon");
          has_on_client_validate_password_ = DoesFunctionExist_("OnClientValidatePassword");
+         has_on_recipient_unknown_ = DoesFunctionExist_("OnRecipientUnknown");
+         has_on_too_many_invalid_comands_ = DoesFunctionExist_("OnTooManyInvalidCommands");
       }
       catch (...)
       {
@@ -269,6 +273,16 @@ namespace HM
          if (!has_on_client_validate_password_)
             return;
          event_name = _T("OnClientValidatePassword");
+         break;
+      case EventOnRecipientUnknown:
+         if (!has_on_recipient_unknown_)
+            return;
+         event_name = _T("OnRecipientUnknown");
+         break;
+      case EventOnTooManyInvalidCommands:
+         if (!has_on_too_many_invalid_comands_)
+            return;
+         event_name = _T("OnTooManyInvalidCommands");
          break;
       case EventCustom:
          break;

--- a/hmailserver/source/Server/Common/Scripting/ScriptServer.h
+++ b/hmailserver/source/Server/Common/Scripting/ScriptServer.h
@@ -30,7 +30,9 @@ namespace HM
          EventOnSMTPData = 1012,
          EventOnHELO = 1013,
          EventOnClientLogon = 1014,
-         EventOnClientValidatePassword = 1015
+         EventOnClientValidatePassword = 1015,
+         EventOnRecipientUnknown = 1016,
+         EventOnTooManyInvalidCommands = 1017
       };
 
       ScriptServer(void);
@@ -70,6 +72,8 @@ namespace HM
       bool has_on_helo_;
       bool has_on_client_logon_;
       bool has_on_client_validate_password_;
+      bool has_on_recipient_unknown_;
+      bool has_on_too_many_invalid_comands_;
 
       String script_contents_;
       String script_extension_;


### PR DESCRIPTION
Experimental events OnRecipientUnknown(oClient, oMessage) and OnTooManyInvalidCommands(oClient, oMessage)

Can be usefull to monitor/block repeating offenders, I myself use this to invoke Søren's IDS script and add to the counter.