### PR TITLE
5.7.0 DomainMembers DistributionList mode

### DIFF
--- a/hmailserver/source/Server/COM/InterfaceDistributionList.cpp
+++ b/hmailserver/source/Server/COM/InterfaceDistributionList.cpp
@@ -323,6 +323,9 @@ STDMETHODIMP InterfaceDistributionList::get_Mode(eDistributionListMode *pVal)
       case HM::DistributionList::LMAnnouncement:
          *pVal = eLMAnnouncement;
          break;
+      case HM::DistributionList::LMDomainMembers:
+         *pVal = eLMDomainMembers;
+         break;
       default:
          *pVal = eLMPublic;
          break;
@@ -355,6 +358,9 @@ STDMETHODIMP InterfaceDistributionList::put_Mode(eDistributionListMode newVal)
          break;
       case eLMAnnouncement:
          iMode = HM::DistributionList::LMAnnouncement;
+         break;
+      case eLMDomainMembers:
+         iMode = HM::DistributionList::LMDomainMembers;
          break;
       }
    

--- a/hmailserver/source/Server/Common/BO/DistributionList.h
+++ b/hmailserver/source/Server/Common/BO/DistributionList.h
@@ -18,7 +18,8 @@ namespace HM
       {
          LMPublic = 0,
          LMMembership = 1,
-         LMAnnouncement = 2
+         LMAnnouncement = 2,
+         LMDomainMembers = 3,
       };
 
       String GetName() {return address_; }

--- a/hmailserver/source/Server/SMTP/RecipientParser.cpp
+++ b/hmailserver/source/Server/SMTP/RecipientParser.cpp
@@ -394,6 +394,26 @@ namespace HM
 
          // OK. The correct user is sending
       }
+      else if (lm == DistributionList::LMDomainMembers)
+      {
+         Logger::Instance()->LogDebug("DistributionList::LMDomainMembers");
+
+         String sFormattedSender = pDA->ApplyAliasesOnAddress(sSender);
+         String sFormattedDomain = StringParser::ExtractDomain(sFormattedSender);
+
+         __int64 iDomainID = pList->GetDomainID();
+         std::shared_ptr<const Domain> pDomain = CacheContainer::Instance()->GetDomain(iDomainID);
+
+         if (sFormattedDomain.CompareNoCase(pDomain->GetName()) != 0)
+         {
+            // Let's adjust reason to better explain sender is not seen as OWNER
+            // and differentiate from SENDER like list member etc
+            sErrMsg = "Not authorized domain.";
+            return DP_PermissionDenied;
+         }
+
+         // OK. The correct domain is sending
+      }
       else if (lm == DistributionList::LMPublic)
       {
          // Anyone can send. OK

--- a/hmailserver/source/Tools/Administrator/Main panes/ucDistributionList.Designer.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucDistributionList.Designer.cs
@@ -35,6 +35,7 @@ namespace hMailServer.Administrator
            this.textRequireAddress = new hMailServer.Administrator.Controls.ucEmailEdit();
            this.optModeAnnouncements = new hMailServer.Administrator.Controls.ucRadioButton();
            this.radioModeMembership = new hMailServer.Administrator.Controls.ucRadioButton();
+         this.radioModeDomainMembers = new hMailServer.Administrator.Controls.ucRadioButton();
            this.radioModePublic = new hMailServer.Administrator.Controls.ucRadioButton();
            this.labelMode = new System.Windows.Forms.Label();
            this.checkEnabled = new hMailServer.Administrator.Controls.ucCheckbox();
@@ -70,6 +71,7 @@ namespace hMailServer.Administrator
            this.tabPage1.Controls.Add(this.labelSecurity);
            this.tabPage1.Controls.Add(this.textRequireAddress);
            this.tabPage1.Controls.Add(this.optModeAnnouncements);
+         this.tabPage1.Controls.Add(this.radioModeDomainMembers);
            this.tabPage1.Controls.Add(this.radioModeMembership);
            this.tabPage1.Controls.Add(this.radioModePublic);
            this.tabPage1.Controls.Add(this.labelMode);
@@ -87,7 +89,7 @@ namespace hMailServer.Administrator
            // checkRequireSMTPAuthentication
            // 
            this.checkRequireSMTPAuthentication.AutoSize = true;
-           this.checkRequireSMTPAuthentication.Location = new System.Drawing.Point(44, 242);
+         this.checkRequireSMTPAuthentication.Location = new System.Drawing.Point(44, 265);
            this.checkRequireSMTPAuthentication.Name = "checkRequireSMTPAuthentication";
            this.checkRequireSMTPAuthentication.Size = new System.Drawing.Size(167, 17);
            this.checkRequireSMTPAuthentication.TabIndex = 20;
@@ -98,7 +100,7 @@ namespace hMailServer.Administrator
            // 
            this.labelSecurity.AutoSize = true;
            this.labelSecurity.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-           this.labelSecurity.Location = new System.Drawing.Point(13, 215);
+         this.labelSecurity.Location = new System.Drawing.Point(13, 238);
            this.labelSecurity.Name = "labelSecurity";
            this.labelSecurity.Size = new System.Drawing.Size(53, 13);
            this.labelSecurity.TabIndex = 19;
@@ -106,7 +108,7 @@ namespace hMailServer.Administrator
            // 
            // textRequireAddress
            // 
-           this.textRequireAddress.Location = new System.Drawing.Point(61, 180);
+         this.textRequireAddress.Location = new System.Drawing.Point(61, 203);
            this.textRequireAddress.Name = "textRequireAddress";
            this.textRequireAddress.ReadOnlyHost = false;
            this.textRequireAddress.Size = new System.Drawing.Size(282, 25);
@@ -115,15 +117,26 @@ namespace hMailServer.Administrator
            // optModeAnnouncements
            // 
            this.optModeAnnouncements.AutoSize = true;
-           this.optModeAnnouncements.Location = new System.Drawing.Point(44, 157);
+         this.optModeAnnouncements.Location = new System.Drawing.Point(44, 180);
            this.optModeAnnouncements.Name = "optModeAnnouncements";
            this.optModeAnnouncements.Size = new System.Drawing.Size(337, 17);
-           this.optModeAnnouncements.TabIndex = 16;
+         this.optModeAnnouncements.TabIndex = 17;
            this.optModeAnnouncements.TabStop = true;
            this.optModeAnnouncements.Text = "Announcements - Only allow messages from the following address:";
            this.optModeAnnouncements.UseVisualStyleBackColor = true;
            this.optModeAnnouncements.CheckedChanged += new System.EventHandler(this.optModeAnnouncements_CheckedChanged);
            // 
+         // radioModeDomainMembers
+         // 
+         this.radioModeDomainMembers.AutoSize = true;
+         this.radioModeDomainMembers.Location = new System.Drawing.Point(44, 157);
+         this.radioModeDomainMembers.Name = "radioModeDomainMembers";
+         this.radioModeDomainMembers.Size = new System.Drawing.Size(307, 17);
+         this.radioModeDomainMembers.TabIndex = 16;
+         this.radioModeDomainMembers.TabStop = true;
+         this.radioModeDomainMembers.Text = "Domain - Anyone in the domain can send to the list";
+         this.radioModeDomainMembers.UseVisualStyleBackColor = true;
+         // 
            // radioModeMembership
            // 
            this.radioModeMembership.AutoSize = true;
@@ -309,6 +322,7 @@ namespace hMailServer.Administrator
        private System.Windows.Forms.Label labelMode;
        private hMailServer.Administrator.Controls.ucRadioButton radioModeMembership;
        private hMailServer.Administrator.Controls.ucRadioButton radioModePublic;
+      private hMailServer.Administrator.Controls.ucRadioButton radioModeDomainMembers;
        private hMailServer.Administrator.Controls.ucCheckbox checkRequireSMTPAuthentication;
        private System.Windows.Forms.Label labelSecurity;
        private hMailServer.Administrator.Controls.ucEmailEdit textRequireAddress;

--- a/hmailserver/source/Tools/Administrator/Main panes/ucDistributionList.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucDistributionList.cs
@@ -86,6 +86,7 @@ namespace hMailServer.Administrator
 
             radioModePublic.Checked = _representedObject.Mode == eDistributionListMode.eLMPublic;
             radioModeMembership.Checked = _representedObject.Mode == eDistributionListMode.eLMMembership;
+            radioModeDomainMembers.Checked = _representedObject.Mode == eDistributionListMode.eLMDomainMembers;
             optModeAnnouncements.Checked = _representedObject.Mode == eDistributionListMode.eLMAnnouncement;
 
             textRequireAddress.Text = _representedObject.RequireSenderAddress;
@@ -121,6 +122,9 @@ namespace hMailServer.Administrator
 
             if (optModeAnnouncements.Checked)
                 _representedObject.Mode = eDistributionListMode.eLMAnnouncement;
+
+            if (radioModeDomainMembers.Checked)
+               _representedObject.Mode = eDistributionListMode.eLMDomainMembers;
 
             _representedObject.RequireSenderAddress = textRequireAddress.Text;
             _representedObject.RequireSMTPAuth = checkRequireSMTPAuthentication.Checked;

--- a/hmailserver/source/WebAdmin/hm_distributionlist.php
+++ b/hmailserver/source/WebAdmin/hm_distributionlist.php
@@ -93,6 +93,7 @@ $listrequiresmtpauthchecked = hmailCheckedIf1($listrequiresmtpauth);
       				<select name="Mode" style="font-family: Trebuchet MS, Verdana, Arial, Helvetica, sans-serif">
       					<option value="0" <?php if ($Mode == 0) echo "selected";?> ><?php EchoTranslation("Public - Anyone can send to the list")?></option>
       					<option value="1" <?php if ($Mode == 1) echo "selected";?> ><?php EchoTranslation("Membership - Only members can send to the list")?></option>
+						<option value="3" <?php if ($Mode == 3) echo "selected";?> ><?php EchoTranslation("Domain - Anyone in the domain can send to the list")?></option>
       					<option value="2" <?php if ($Mode == 2) echo "selected";?> ><?php EchoTranslation("Announcements - Only allow messages from the following address:")?></option>
       				</select>
       		


### PR DESCRIPTION
Today a had to setup a distribution list for a client, and they asked if it was possible to allow anyone in their domain to send to the list (not being all members)
So i browsed through the code and noticed there are a few more distribution list modes listed in hMailServer.idl RecipientParser.cpp however doesn't contain those additional distribution list modes, the way i see it the mode listed as DomainMembers distribution list mode would fit this clients needs.