### PR TITLE
5.7.0 Restore X-hMailServer-Reason-Score 5.6.x behaviour

### DIFF
--- a/hmailserver/source/Server/ExternalFetcher/POP3ClientConnection.cpp
+++ b/hmailserver/source/Server/ExternalFetcher/POP3ClientConnection.cpp
@@ -842,13 +842,18 @@ namespace HM
       
       bool classifiedAsSpam = iTotalSpamScore >= Configuration::Instance()->GetAntiSpamConfiguration().GetSpamMarkThreshold();
       
-      std::shared_ptr<MessageData> messageData = SpamProtection::AddSpamScoreHeaders(current_message_, setSpamTestResults, classifiedAsSpam);
+      std::shared_ptr<MessageData> messageData; 
+
+      if (classifiedAsSpam)
+      {
+         messageData = SpamProtection::AddSpamScoreHeaders(current_message_, setSpamTestResults, classifiedAsSpam);
+         
+         // Increase the spam-counter
+         ServerStatus::Instance()->OnSpamMessageDetected();
+      }
 
       if (messageData)
          messageData->Write(fileName);
-
-      if (classifiedAsSpam)
-         ServerStatus::Instance()->OnSpamMessageDetected();
 
       return true;
    }

--- a/hmailserver/source/Server/ExternalFetcher/POP3ClientConnection.cpp
+++ b/hmailserver/source/Server/ExternalFetcher/POP3ClientConnection.cpp
@@ -842,18 +842,16 @@ namespace HM
       
       bool classifiedAsSpam = iTotalSpamScore >= Configuration::Instance()->GetAntiSpamConfiguration().GetSpamMarkThreshold();
       
-      std::shared_ptr<MessageData> messageData; 
-
       if (classifiedAsSpam)
       {
-         messageData = SpamProtection::AddSpamScoreHeaders(current_message_, setSpamTestResults, classifiedAsSpam);
+         std::shared_ptr<MessageData> messageData = SpamProtection::AddSpamScoreHeaders(current_message_, setSpamTestResults, classifiedAsSpam);
          
          // Increase the spam-counter
          ServerStatus::Instance()->OnSpamMessageDetected();
-      }
 
-      if (messageData)
-         messageData->Write(fileName);
+         if (messageData)
+            messageData->Write(fileName);
+      }
 
       return true;
    }

--- a/hmailserver/source/Server/SMTP/SMTPConnection.cpp
+++ b/hmailserver/source/Server/SMTP/SMTPConnection.cpp
@@ -1145,10 +1145,12 @@ namespace HM
 
       bool classifiedAsSpam = iTotalSpamScore >= iSpamMarkThreshold;
 
-      pMsgData = SpamProtection::AddSpamScoreHeaders(current_message_, spam_test_results_, classifiedAsSpam);
+      if (classifiedAsSpam) {
+         pMsgData = SpamProtection::AddSpamScoreHeaders(current_message_, spam_test_results_, classifiedAsSpam);
 
-      if (classifiedAsSpam)
+         // Increase the spam-counter
          ServerStatus::Instance()->OnSpamMessageDetected();
+      }
 
       SetMessageSignature_(pMsgData);
 


### PR DESCRIPTION
5.7 always included the X-hMailServer-Reason-Score: 0 header for any incoming/outgoing message.
To restore compatibility with 5.6 and scripts this fix only includes those headers when X-hMailServer-Spam: YES