### PR TITLE
5.7.0-DNSServer INI Setting(s)

### DIFF
--- a/hmailserver/source/Server/Common/Application/IniFileSettings.cpp
+++ b/hmailserver/source/Server/Common/Application/IniFileSettings.cpp
@@ -59,7 +59,8 @@ namespace HM
       blocked_iphold_seconds_(0),
       smtpdmax_size_drop_(0),
       backup_messages_dbonly_(false),
-      add_xauth_user_ip_(false)
+      add_xauth_user_ip_(false),
+      use_dns_cache_(true)
       
    {
 
@@ -194,7 +195,8 @@ namespace HM
       smtpdmax_size_drop_ =  ReadIniSettingInteger_("Settings", "SMTPDMaxSizeDrop",0);
       backup_messages_dbonly_ =  ReadIniSettingInteger_("Settings", "BackupMessagesDBOnly",0) == 1;
       add_xauth_user_ip_ =  ReadIniSettingInteger_("Settings", "AddXAuthUserIP",1) == 1;
-
+      use_dns_cache_ = ReadIniSettingInteger_("Settings", "UseDNSCache", 1) == 1;
+      dns_server_ = ReadIniSettingString_("Settings", "DNSServer", "");
       rewrite_envelope_from_when_forwarding_ = ReadIniSettingInteger_("Settings", "RewriteEnvelopeFromWhenForwarding", 0) == 1;
       m_sDisableAUTHList = ReadIniSettingString_("Settings", "DisableAUTHList", "");
    }

--- a/hmailserver/source/Server/Common/Application/IniFileSettings.h
+++ b/hmailserver/source/Server/Common/Application/IniFileSettings.h
@@ -110,6 +110,8 @@ namespace HM
       bool GetBackupMessagesDBOnly () const { return backup_messages_dbonly_; }
       bool GetAddXAuthUserIP () const { return add_xauth_user_ip_; }
       bool GetRewriteEnvelopeFromWhenForwarding() const { return rewrite_envelope_from_when_forwarding_; }
+      bool GetUseDNSCache() const { return use_dns_cache_; }
+      String GetDNSServer() const { return dns_server_; }
       std::set<int> GetAuthDisabledOnPorts();
 
    private:   
@@ -188,6 +190,8 @@ namespace HM
       bool backup_messages_dbonly_;
       bool add_xauth_user_ip_;
       bool rewrite_envelope_from_when_forwarding_;
+      bool use_dns_cache_;
+      String dns_server_;
       String database_provider_;
 
       String m_sDisableAUTHList;


### PR DESCRIPTION
_Boolean_ **UseDNSCache** (not mine, but something Søren Raagaard Rathje created to bypass use of systems dnscache)

_String_ **DNSServer**
I have a local BIND9 caching en forwarding server, unfortunately Hmailserver by default uses system's default DNS 
This setting can be used to supply a single (local) ip4 IP-Address to force Hmailserver to use that DNS server without having to change system default DNS settings

Eg: in my case both hmailserver as spamassassin are configured to use the same local (ubuntu VM) Bind9 DNS caching en forwarding server instance, this way repeating lookups are cached and forwarding rules are shared, there are a few DNSBL's that require this.

```
/* Disable forwarding for DNSBL queries */

zone "multi.uribl.com" { type forward; forward first; forwarders {}; };
zone "multi.surbl.org" { type forward; forward first; forwarders {}; };
zone "list.dnswl.org" { type forward; forward first; forwarders {}; };
zone "all.spamrats.com" { type forward; forward first; forwarders {}; };
zone "grey.uribl.com" { type forward; forward first; forwarders {}; };
zone "black.uribl.com" { type forward; forward first; forwarders {}; };
```