### PR TITLE
Added integer overflow check for SPF macro segment count

### DIFF
--- a/hmailserver/source/Server/SMTP/SPF/RMSPF.cpp
+++ b/hmailserver/source/Server/SMTP/SPF/RMSPF.cpp
@@ -2372,6 +2372,7 @@ char** bufp, spfbool fordomain)
          // get max number of parts
          num = 0;
          while (ISDIGIT(*cp))
+         {
             if (num > (INT_MAX - (*cp - '0')) / 10)
                 return SPF_PermError;
 

--- a/hmailserver/source/Server/SMTP/SPF/RMSPF.cpp
+++ b/hmailserver/source/Server/SMTP/SPF/RMSPF.cpp
@@ -13,6 +13,7 @@
 #undef UNICODE
 
 #include <windns.h>
+#include <limits.h>
 #include <string.h>
 #include <stdlib.h>
 #include <time.h>
@@ -2371,7 +2372,9 @@ char** bufp, spfbool fordomain)
          // get max number of parts
          num = 0;
          while (ISDIGIT(*cp))
-         {
+            if (num > (INT_MAX - (*cp - '0')) / 10)
+                return SPF_PermError;
+
             num = num * 10 + *cp - '0';
             if (++cp >= s1)
                return SPF_PermError;


### PR DESCRIPTION
The current version of RMSPF.cpp allows for an arbitrary number of digits to be read into the SPF macro segment count; as a result, an SPF record with a macro such as %{d2147483648} would lead to integer overflow in the `num` variable. While this does not lead to any unexpected or dangerous behavior in the current version of the source, an added check would make sure that no future errors come up because of the overflow.

As well (just in case it's needed), I give full permission to license the modifications I've made to the source code under whatever license you use, with or without any attribution.