### PR TITLE
SpamTestHeloHost IPv6 Fix

### DIFF
--- a/hmailserver/source/Server/Common/AntiSpam/SpamTestHeloHost.cpp
+++ b/hmailserver/source/Server/Common/AntiSpam/SpamTestHeloHost.cpp
@@ -107,7 +107,8 @@ namespace HM
          // Check that the IP address is one of these A records.
          for (auto iter = saFoundNames.begin(); iter < saFoundNames.end(); iter++)
          {
-            if ((*iter) == sIPAddress)
+            // IPv6 is alphanumeric therefore uppercase and lowercase characters are equivalent
+            if (boost::iequals((*iter), sIPAddress))
             {
                return true;
             }

--- a/hmailserver/source/Server/Common/AntiSpam/SpamTestHeloHost.cpp
+++ b/hmailserver/source/Server/Common/AntiSpam/SpamTestHeloHost.cpp
@@ -51,7 +51,7 @@ namespace HM
          return setSpamTestResults;
       }
 
-      if (LocalIPAddresses::Instance()->IsLocalIPAddress(iIPAdress))
+      if (LocalIPAddresses::Instance()->IsWithinLoopbackRange(iIPAdress))
       {
          // Ignore this test if send thru localhost.
          return setSpamTestResults;
@@ -104,7 +104,7 @@ namespace HM
             return true;
          }
 
-         // Check that the IP address is one of these A records.
+         // Check that the IP address is one of these A or AAAA records.
          for (auto iter = saFoundNames.begin(); iter < saFoundNames.end(); iter++)
          {
             // IPv6 is alphanumeric therefore uppercase and lowercase characters are equivalent

--- a/hmailserver/source/Server/Common/AntiSpam/SpamTestHeloHost.cpp
+++ b/hmailserver/source/Server/Common/AntiSpam/SpamTestHeloHost.cpp
@@ -13,6 +13,7 @@
 #include "../TCPIP/DNSResolver.h"
 #include "../TCPIP/IPAddress.h"
 #include "../TCPIP/LocalIPAddresses.h"
+#include <boost/algorithm/string/predicate.hpp>
 
 #ifdef _DEBUG
 #define DEBUG_NEW new(_NORMAL_BLOCK, __FILE__, __LINE__)
@@ -60,7 +61,7 @@ namespace HM
       {
          // Incorrect host in helo
          String sMessage = "The host name specified in HELO does not match IP address.";
-         int iScore = Configuration::Instance()->GetAntiSpamConfiguration().GetCheckHostInHeloScore();;
+         int iScore = Configuration::Instance()->GetAntiSpamConfiguration().GetCheckHostInHeloScore();
 
          std::shared_ptr<SpamTestResult> pResult = std::shared_ptr<SpamTestResult>(new SpamTestResult(GetName(), SpamTestResult::Fail, iScore, sMessage));
          setSpamTestResults.insert(pResult);   
@@ -76,15 +77,17 @@ namespace HM
    {
       String sIPAddress = address.ToString();
 
-      bool bMatch = false;
-
       if (sHeloHost.Left(1) == _T("["))
       {
          String sTempHost = sHeloHost;
          sTempHost.TrimLeft(_T("["));
+         // IPv6 
+         if (sTempHost.Left(5) == _T("IPv6:"))
+            sTempHost.TrimLeft(_T("IPv6:"));
          sTempHost.TrimRight(_T("]"));
 
-         if (sTempHost == sIPAddress)
+         // IPv6 is alphanumeric therefore uppercase and lowercase characters are equivalent
+         if (boost::iequals(sTempHost, sIPAddress))
          {
             return true;
          }


### PR DESCRIPTION
IPv6 fix for HELO check

Valid HELOs are according to RFC2821 4.1.1.1:

```
some.domain.name
[<ipv4-address>]
[IPv6:<ipv6-address>]
```