### PR TITLE
Update SMTPConnection.cpp

### DIFF
--- a/hmailserver/source/Server/SMTP/SMTPConnection.cpp
+++ b/hmailserver/source/Server/SMTP/SMTPConnection.cpp
@@ -1786,6 +1786,14 @@ namespace HM
          SendErrorResponse_(530, "A SSL/TLS-connection is required for authentication.");
          return;
       }
+	  
+      // rfc4954 restrictions, After a successful AUTH command completes, 
+      // a server MUST reject any further AUTH commands with a 503 reply.
+      if (isAuthenticated_) 
+      {
+         SendErrorResponse_(503, "Already authenticated.");
+         return;
+      }
 
       requestedAuthenticationType_ = AUTH_NONE;
 


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc4954

  Restrictions:
      After an AUTH command has been successfully completed, no more
      AUTH commands may be issued in the same session.  After a
      successful AUTH command completes, a server MUST reject any
      further AUTH commands with a 503 reply.