### PR TITLE
Automatically append ESMTP to Welcome-message if user has not specified it

### DIFF
--- a/hmailserver/source/Server/SMTP/SMTPConnection.cpp
+++ b/hmailserver/source/Server/SMTP/SMTPConnection.cpp
@@ -166,11 +166,15 @@ namespace HM
    {
 
       String sWelcome = Configuration::Instance()->GetSMTPConfiguration()->GetWelcomeMessage();
+      
+      String sESMTP = " ESMTP";
 
       String sData = "220 ";
 
       if (sWelcome.IsEmpty())
-         sData += Utilities::ComputerName() + " ESMTP";
+         sData += Utilities::ComputerName() + sESMTP;
+      else if (!sWelcome.EndsWith(sESMTP))
+         sData += sWelcome + sESMTP;
       else
          sData += sWelcome;
 


### PR DESCRIPTION
SMTPConnection::SendBanner_() fixes, check if ends with " ESMTP" and if not append it