### PR TITLE
Revert "SASL deliminator from \t to \0 ref RFC4616"

### DIFF
--- a/hmailserver/source/Server/IMAP/IMAPCommandAuthenticate.cpp
+++ b/hmailserver/source/Server/IMAP/IMAPCommandAuthenticate.cpp
@@ -63,7 +63,7 @@ namespace HM
 
 		sParam = pParser->GetParamValue(pArgument, 1);
 		StringParser::Base64Decode(sParam, sDecode64);
-		std::vector<String> plain_args = StringParser::SplitString(sDecode64, "\0");
+		std::vector<String> plain_args = StringParser::SplitString(sDecode64, "\t");
 
 		if (plain_args.size() != 3)
 			return IMAPResult(IMAPResult::ResultBad, "Command has malformed base64 token.");


### PR DESCRIPTION
Reverts hmailserver/hmailserver#385

Indications that this merge causes memory consumption issues.