### PR TITLE
DNS resolver fixes

### DIFF
--- a/hmailserver/source/Server/Common/TCPIP/DNSResolver.h
+++ b/hmailserver/source/Server/Common/TCPIP/DNSResolver.h
@@ -23,6 +23,7 @@ namespace HM
       bool GetPTRRecords(const String &sIP, std::vector<String> &vecFoundNames);
    private:
 
+      bool GetEmailServersRecursive_(const String &sDomainName, std::vector<HostNameAndIpAddress> &saFoundNames, int recursionLevel);
       bool GetIpAddressesRecursive_(const String &hostName, std::vector<String> &addresses, int recursionLevel, bool followCnameRecords);
       bool GetTXTRecordsRecursive_(const String &sDomain, std::vector<String> &foundResult, int recursionLevel);
       bool GetMXRecordsRecursive_(const String &sDomain, std::vector<String> &vecFoundNames, int recursionLevel);


### PR DESCRIPTION
- Fix CNAME (domain) record, see: https://github.com/hmailserver/hmailserver/issues/462 
- Fix IP Address as MX, see: https://github.com/hmailserver/hmailserver/issues/462#issuecomment-1563173781 
- Enhancement Null MX

@martinknafve 

I created 3 (temporary) test in RegressionTests -> Infrastructure -> DnsResolution, which all pass


```
      [Test]
      public void NullMXRecordShouldNotResolve()
      {
         // If a MX record contains a Null MX no mail server should be returned
         var actualServer = _utilities.GetMailServer("test@allelassers.nl");

         Assert.AreEqual("", actualServer);
      }

      [Test]
      public void IPAddressAsMXRecordShouldResolve()
      {
         // Okay, this is an invalid MX record. The MX record should always contain 
         // a host name but in this case it appears an IP address. We'll be kind to
         // the domain owner and still deliver the email to him.
         var actualServer = _utilities.GetMailServer("test@ruud.allelassers.nl");

         Assert.AreEqual("89.20.83.133", actualServer);
      }

      [Test]
      public void CnameDomainRecordsShouldResolve()
      {
         // If a Domain name resolves to a CNAME record, the CNAME record should be followed.
         var actualServer = _utilities.GetMailServer("test@external.bankup.be");

         Assert.AreEqual("10.0.0.1", actualServer);
      }
```

FYI: One test i am unable to complete successfully, eg: InfinitelyRecursiveRecordsShouldNotResolve