### PR TITLE
Include List-Unsubscribe-Post and X-CSA-Complaints in DKIM signing, #465

### DIFF
--- a/hmailserver/source/Server/Common/AntiSpam/DKIM/DKIM.cpp
+++ b/hmailserver/source/Server/Common/AntiSpam/DKIM/DKIM.cpp
@@ -70,10 +70,14 @@ namespace HM
       recommendedHeaderFields_.push_back("List-Id");
       recommendedHeaderFields_.push_back("List-Help");
       recommendedHeaderFields_.push_back("List-Unsubscribe");
+      recommendedHeaderFields_.push_back("List-Unsubscribe-Post");
       recommendedHeaderFields_.push_back("List-Subscribe");
       recommendedHeaderFields_.push_back("List-Post");
       recommendedHeaderFields_.push_back("List-Owner");
       recommendedHeaderFields_.push_back("List-Archive");
+
+      // Addition for CSA-Compliant Mail Headers
+      recommendedHeaderFields_.push_back("X-CSA-Complaints");
    }
 
    // helper.


### PR DESCRIPTION
CSA-compliance requires 2 additional headers to be included into the DKIM header tag list: X-CSA-Complaints & List-Unsubscribe-Post

https://certified-senders.org/wp-content/uploads/2019/10/CSA-Compliant-Mail-Headers_Update.pdf