### PR TITLE
Fix: DKIM verification fails when an email is recieved with no subject from Gmail, #245

### DIFF
--- a/hmailserver/source/Server/Common/AntiSpam/DKIM/Canonicalization.cpp
+++ b/hmailserver/source/Server/Common/AntiSpam/DKIM/Canonicalization.cpp
@@ -128,6 +128,11 @@ namespace HM
                fields.erase(fields.begin() + fieldIndex);
 
                value = field.GetValue();
+               // Fix for DKIM Header verification failing on empty header value, for example: subject header
+               if (value.GetLength() == 0)
+               {
+                  value += "\r\n";
+               }
                break;
             }
          }


### PR DESCRIPTION
If a subject (or any other header for that matter) value is empty, eg: the header exist but it had no value DKIM verification failed

https://github.com/hmailserver/hmailserver/issues/245


