### PR TITLE
hMailServer reports incorrect RFC822.SIZE

### DIFF
--- a/hmailserver/source/Server/SMTP/LocalDelivery.cpp
+++ b/hmailserver/source/Server/SMTP/LocalDelivery.cpp
@@ -154,6 +154,8 @@ namespace HM
       // not add any rows to the database in this scenario. To ensure this, InterfaceMessage checks the
       // message state. If it's "Delivering", it won't save the changes to the database.
       accountLevelMessage->SetState(Message::Delivered); 
+      // Recalculate filesize after Return-Path and optionally Delivered-To header(s) are added
+      accountLevelMessage->SetSize(FileUtilities::FileSize(PersistentMessage::GetFileName(account, accountLevelMessage)));
 
       PersistentMessage::SaveObject(accountLevelMessage);
 


### PR DESCRIPTION
https://github.com/hmailserver/hmailserver/issues/476

File size needs to be updated after Return-Path and optionally Delivered-To header(s) are added