### PR TITLE
Include Google Feedback Loop header Feedback-ID in DKIM signing

### DIFF
--- a/hmailserver/source/Server/Common/AntiSpam/DKIM/DKIM.cpp
+++ b/hmailserver/source/Server/Common/AntiSpam/DKIM/DKIM.cpp
@@ -78,6 +78,9 @@ namespace HM
 
       // Addition for CSA-Compliant Mail Headers
       recommendedHeaderFields_.push_back("X-CSA-Complaints");
+
+      // Addition for Google Feedback Loop
+      recommendedHeaderFields_.push_back("Feedback-ID");
    }
 
    // helper.


### PR DESCRIPTION
To support the Google Feedback Loop it is mandatory to include the Feedback-ID header with DKIM signing

For more information, see https://support.google.com/a/answer/6254652?hl=en