### PR TITLE
Optionally add X-Original-Rcpt-To-header to incoming email, #498

### DIFF
--- a/hmailserver/source/Server/Common/Application/IniFileSettings.cpp
+++ b/hmailserver/source/Server/Common/Application/IniFileSettings.cpp
@@ -21,6 +21,7 @@ namespace HM
       dbport_(0),
       no_of_dbconnections_(0),
       add_xauth_user_header_(false),
+      add_xoriginal_rcpt_to_header_(false),
       no_of_dbconnection_attempts_(6),
       no_of_dbconnection_attempts_Delay(5),
       max_no_of_external_fetch_threads_(15),
@@ -167,6 +168,7 @@ namespace HM
       smtpdmax_size_drop_ =  ReadIniSettingInteger_("Settings", "SMTPDMaxSizeDrop",0);
       backup_messages_dbonly_ =  ReadIniSettingInteger_("Settings", "BackupMessagesDBOnly",0) == 1;
       add_xauth_user_ip_ =  ReadIniSettingInteger_("Settings", "AddXAuthUserIP",1) == 1;
+      add_xoriginal_rcpt_to_header_ = ReadIniSettingInteger_("Settings", "AddXOriginalRcptTo", 0) == 1;
 
       rewrite_envelope_from_when_forwarding_ = ReadIniSettingInteger_("Settings", "RewriteEnvelopeFromWhenForwarding", 0) == 1;
       m_sDisableAUTHList = ReadIniSettingString_("Settings", "DisableAUTHList", "");

--- a/hmailserver/source/Server/Common/Application/IniFileSettings.h
+++ b/hmailserver/source/Server/Common/Application/IniFileSettings.h
@@ -71,6 +71,7 @@ namespace HM
       int GetDBConnectionAttemptsDelay() const;
       
       bool GetAddXAuthUserHeader() {return add_xauth_user_header_; }
+      bool GetAddXOriginalRcptToHeader() { return add_xoriginal_rcpt_to_header_; }
       int GetMaxNumberOfExternalFetchThreads() {return max_no_of_external_fetch_threads_ ;}
       bool GetGreylistingEnabledDuringRecordExpiration() {return greylisting_enabled_during_record_expiration_;}
       int GetGreylistingExpirationInterval() {return greylisting_expiration_interval_; }
@@ -141,6 +142,7 @@ namespace HM
       int no_of_dbconnection_attempts_;
       int no_of_dbconnection_attempts_Delay;
       bool add_xauth_user_header_;
+      bool add_xoriginal_rcpt_to_header_;
       int max_no_of_external_fetch_threads_;
 
       bool greylisting_enabled_during_record_expiration_;

--- a/hmailserver/source/Server/SMTP/SMTPConnection.cpp
+++ b/hmailserver/source/Server/SMTP/SMTPConnection.cpp
@@ -832,7 +832,7 @@ namespace HM
       {
          std::shared_ptr<MimeHeader> original_headers = Utilities::GetMimeHeader(transmission_buffer_->GetBuffer()->GetBuffer(), transmission_buffer_->GetBuffer()->GetSize());
 
-         SMTPMessageHeaderCreator header_creator(username_, GetIPAddressString(), isAuthenticated_, helo_host_, original_headers);
+         SMTPMessageHeaderCreator header_creator(username_, GetIPAddressString(), isAuthenticated_, helo_host_, original_headers, current_message_);
          
          if (IsSSLConnection())
             header_creator.SetCipherInfo(GetCipherInfo());

--- a/hmailserver/source/Server/SMTP/SMTPMessageHeaderCreator.cpp
+++ b/hmailserver/source/Server/SMTP/SMTPMessageHeaderCreator.cpp
@@ -5,6 +5,10 @@
 
 #include "SMTPMessageHeaderCreator.h"
 
+#include "../Common/BO/Message.h"
+#include "../Common/BO/MessageRecipients.h"
+#include "../Common/BO/MessageRecipient.h"
+
 #include "../Common/TCPIP/CipherInfo.h"
 #include "../Common/TCPIP/DNSResolver.h"
 
@@ -20,13 +24,14 @@
 
 namespace HM
 {
-   SMTPMessageHeaderCreator::SMTPMessageHeaderCreator(const String &username, const AnsiString &remote_ip_address, bool is_authenticated, String helo_host, std::shared_ptr<MimeHeader> original_headers) :
+   SMTPMessageHeaderCreator::SMTPMessageHeaderCreator(const String &username, const AnsiString &remote_ip_address, bool is_authenticated, String helo_host, std::shared_ptr<MimeHeader> original_headers, std::shared_ptr<Message> message) :
       username_(username),
       remote_ip_address_(remote_ip_address),
       is_authenticated_(is_authenticated),
       original_headers_(original_headers),
       helo_host_(helo_host),
-      is_tls_(false)
+      is_tls_(false),
+      message_(message)
    {
 
    }
@@ -78,6 +83,39 @@ namespace HM
       {
          if (!original_headers_->FieldExists("X-AuthUser"))
             new_header_lines += "X-AuthUser: " + username_ + "\r\n";
+      }
+
+      if (IniFileSettings::Instance()->GetAddXOriginalRcptToHeader() && message_)
+      {
+         auto recipients = message_->GetRecipients()->GetVector();
+         auto recipientIter = recipients.begin();
+
+         std::vector<String> originalLocalAddresses;
+
+         while (recipientIter != recipients.end())
+         {
+            auto recipient = *recipientIter;
+
+            if (recipient->GetIsLocalName())
+            {
+               auto originalAddress = recipient->GetOriginalAddress();
+
+               if (!originalAddress.IsEmpty())
+               {
+                  originalLocalAddresses.push_back(originalAddress);
+               }
+            }
+
+            recipientIter++;
+         }
+
+         if (originalLocalAddresses.size() > 0)
+         {
+            String header = "X-Original-Rcpt-To: ";
+
+            String sRcptToAddresses = JoinWithFolding_(originalLocalAddresses, ",", header.GetLength());
+            new_header_lines += header + sRcptToAddresses + "\r\n";
+         }
       }
 
       // Now add x- header for AUTH user if enabled since it was replaced above if so
@@ -142,6 +180,47 @@ namespace HM
 
       return sResult;
 
+   }
+
+   String
+   SMTPMessageHeaderCreator::JoinWithFolding_(const std::vector<String> &sVector, const String &sSeperator, int initialLineLength)
+   //---------------------------------------------------------------------------()
+   // DESCRIPTION:
+   // Joins contents of a vector into a string, with a separator. If the join string exceeds the max
+   // line length, it will be split across multiple lines.
+   //---------------------------------------------------------------------------()
+   {
+      auto iterVec = sVector.begin();
+      auto iterEnd = sVector.end();
+
+      String result;
+
+      const int maxLineLength = 70;
+      int currentLineLength = initialLineLength;
+
+      for (; iterVec != iterEnd; iterVec++)
+      {
+         String value = (*iterVec);
+         int valueLength = value.GetLength();
+
+         if (result.GetLength() > 0 && currentLineLength + value.GetLength() > maxLineLength)
+         {
+            // Break the line
+            result += "\r\n\t";
+            currentLineLength = 1;
+         }
+
+         result += value;
+         currentLineLength += valueLength;
+
+         if (iterVec + 1 != iterEnd)
+         {
+            result += sSeperator;
+            currentLineLength += sSeperator.GetLength();
+         }
+      }
+
+      return result;
    }
 
 }

--- a/hmailserver/source/Server/SMTP/SMTPMessageHeaderCreator.h
+++ b/hmailserver/source/Server/SMTP/SMTPMessageHeaderCreator.h
@@ -9,12 +9,13 @@ namespace HM
 {
    class CipherInfo;
    class MimeHeader;
+   class Message;
 
    class SMTPMessageHeaderCreator
    {
    public:
       
-      SMTPMessageHeaderCreator(const String &username, const AnsiString &remote_ip_address, bool is_authenticated, String helo_host, std::shared_ptr<MimeHeader> original_headers);
+      SMTPMessageHeaderCreator(const String &username, const AnsiString &remote_ip_address, bool is_authenticated, String helo_host, std::shared_ptr<MimeHeader> original_headers, std::shared_ptr<Message> message);
 
       AnsiString Create();
 
@@ -23,11 +24,13 @@ namespace HM
    private:
 
       String GenerateReceivedHeader_(const String &overriden_received_ip);
+      String JoinWithFolding_(const std::vector<String> &sVector, const String &sSeperator, int initialLineLength);
 
       String username_;
       AnsiString remote_ip_address_;
       AnsiString helo_host_;
       std::shared_ptr<MimeHeader> original_headers_;
+      std::shared_ptr<Message> message_;
       CipherInfo cipher_info_;
       bool is_tls_;
       bool is_authenticated_;

--- a/hmailserver/test/RegressionTests/API/Events.cs
+++ b/hmailserver/test/RegressionTests/API/Events.cs
@@ -17,6 +17,8 @@ namespace RegressionTests.API
       [Test]
       public void TestOnAcceptMessageJScript()
       {
+         LogHandler.DeleteEventLog();
+
          _settings.Scripting.Language = "JScript";
          // First set up a script
          string script =
@@ -47,9 +49,7 @@ namespace RegressionTests.API
       [Test]
       public void TestOnAcceptMessageVBScript()
       {
-         string eventLogFile = _settings.Logging.CurrentEventLog;
-         if (File.Exists(eventLogFile))
-            File.Delete(eventLogFile);
+         LogHandler.DeleteEventLog();
 
          // First set up a script
          string script =
@@ -80,18 +80,20 @@ namespace RegressionTests.API
 
 
          // Check that the message exists
-         message = TestSetup.ReadExistingTextFile(eventLogFile);
+         string eventLogText = TestSetup.ReadExistingTextFile(LogHandler.GetEventLogFileName());
 
-         Assert.IsNotEmpty(message);
-         Assert.IsTrue(message.Contains("Port: 25"));
-         Assert.IsTrue(message.Contains("Address: 127"));
-         Assert.IsTrue(message.Contains("Username: \"")); // Should be empty, Username isn't available at this time.
+         Assert.IsNotEmpty(eventLogText);
+         Assert.IsTrue(eventLogText.Contains("Port: 25"));
+         Assert.IsTrue(eventLogText.Contains("Address: 127"));
+         Assert.IsTrue(eventLogText.Contains("Username: \"")); // Should be empty, Username isn't available at this time.
       }
 
 
       [Test]
       public void TestOnBackupCompletedJScript()
       {
+         LogHandler.DeleteEventLog();
+
          Scripting scripting = _settings.Scripting;
          scripting.Language = "JScript";
 
@@ -120,6 +122,8 @@ namespace RegressionTests.API
       [Test]
       public void TestOnBackupCompletedVBScript()
       {
+         LogHandler.DeleteEventLog();
+
          // First set up a script
          string script =
             @"Sub OnBackupCompleted()
@@ -144,6 +148,8 @@ namespace RegressionTests.API
       [Test]
       public void TestOnBackupFailedJScript()
       {
+         LogHandler.DeleteEventLog();
+
          Scripting scripting = _settings.Scripting;
          scripting.Language = "JScript";
 
@@ -173,6 +179,8 @@ namespace RegressionTests.API
       [Test]
       public void TestOnBackupFailedVBScript()
       {
+         LogHandler.DeleteEventLog();
+
          // First set up a script
          string script =
             @"Sub OnBackupFailed(reason)
@@ -198,6 +206,8 @@ namespace RegressionTests.API
       [Test]
       public void TestOnClientConnectJScript()
       {
+         LogHandler.DeleteEventLog();
+
          Application app = SingletonProvider<TestSetup>.Instance.GetApp();
          Scripting scripting = app.Settings.Scripting;
 
@@ -234,6 +244,8 @@ namespace RegressionTests.API
       [Test]
       public void TestOnClientConnectVBScript()
       {
+         LogHandler.DeleteEventLog();
+
          Application app = SingletonProvider<TestSetup>.Instance.GetApp();
          Scripting scripting = app.Settings.Scripting;
 
@@ -248,25 +260,23 @@ namespace RegressionTests.API
          scripting.Enabled = true;
          scripting.Reload();
 
-         string eventLogFile = app.Settings.Logging.CurrentEventLog;
-         if (File.Exists(eventLogFile))
-            File.Delete(eventLogFile);
-
          var socket = new TcpConnection();
          Assert.IsTrue(socket.IsPortOpen(25));
 
          // Check that the message exists
-         string message = TestSetup.ReadExistingTextFile(eventLogFile);
+         string eventLogText = TestSetup.ReadExistingTextFile(LogHandler.GetEventLogFileName());
 
-         Assert.IsNotEmpty(message);
-         Assert.IsTrue(message.Contains("Port: 25"));
-         Assert.IsTrue(message.Contains("Address: 127"));
-         Assert.IsTrue(message.Contains("Username: \"")); // Should be empty, Username isn't available at this time.
+         Assert.IsNotEmpty(eventLogText);
+         Assert.IsTrue(eventLogText.Contains("Port: 25"));
+         Assert.IsTrue(eventLogText.Contains("Address: 127"));
+         Assert.IsTrue(eventLogText.Contains("Username: \"")); // Should be empty, Username isn't available at this time.
       }
 
       [Test]
       public void TestOnDeliverMessageJScript()
       {
+         LogHandler.DeleteEventLog();
+
          Scripting scripting = _settings.Scripting;
          scripting.Language = "JScript";
          // First set up a script
@@ -298,6 +308,8 @@ namespace RegressionTests.API
       [Test]
       public void TestOnDeliveryFailedJScript()
       {
+         LogHandler.DeleteEventLog();
+
          Scripting scripting = _settings.Scripting;
          scripting.Language = "JScript";
 
@@ -324,12 +336,15 @@ namespace RegressionTests.API
          string eventLogText = TestSetup.ReadExistingTextFile(LogHandler.GetEventLogFileName());
          Assert.IsTrue(eventLogText.Contains("File: "), eventLogText);
          Assert.IsTrue(eventLogText.Contains("Recipient: user@dummy.example.com"), eventLogText);
-         Assert.IsTrue(eventLogText.Contains("No mail servers appear to exists"), eventLogText);
+         Assert.IsTrue(eventLogText.Contains("No mail servers appear to exists") ||
+                               eventLogText.Contains("Unable to find the recipient's email server"), eventLogText);
       }
 
       [Test]
       public void TestOnDeliveryFailedVBScript()
       {
+         LogHandler.DeleteEventLog();
+
          // First set up a script
          string script = "Sub OnDeliveryFailed(oMessage, sRecipient, sErrorMessage)" + Environment.NewLine +
                          " EventLog.Write(\"File: \" & oMessage.FileName) " + Environment.NewLine +
@@ -353,12 +368,16 @@ namespace RegressionTests.API
          string eventLogText = TestSetup.ReadExistingTextFile(LogHandler.GetEventLogFileName());
          Assert.IsTrue(eventLogText.Contains("File: "));
          Assert.IsTrue(eventLogText.Contains("Recipient: user@dummy.example.com"));
-         Assert.IsTrue(eventLogText.Contains("No mail servers appear to exists"));
+         Assert.IsTrue(eventLogText.Contains("No mail servers appear to exists") ||
+                       eventLogText.Contains("Unable to find the recipient's email server"), eventLogText);
+
       }
 
       [Test]
       public void TestOnDeliveryStartVBScript()
       {
+         LogHandler.DeleteEventLog();
+
          Application app = SingletonProvider<TestSetup>.Instance.GetApp();
          Scripting scripting = app.Settings.Scripting;
 
@@ -384,6 +403,8 @@ namespace RegressionTests.API
       [Test]
       public void TestOnErrorJScript()
       {
+         LogHandler.DeleteEventLog();
+
          Application app = SingletonProvider<TestSetup>.Instance.GetApp();
          Scripting scripting = app.Settings.Scripting;
          scripting.Language = "JScript";
@@ -420,6 +441,8 @@ namespace RegressionTests.API
       [Test]
       public void TestOnErrorVBScript()
       {
+         LogHandler.DeleteEventLog();
+
          Application app = SingletonProvider<TestSetup>.Instance.GetApp();
          Scripting scripting = app.Settings.Scripting;
 
@@ -457,7 +480,6 @@ namespace RegressionTests.API
       public void TestOnExternalAccountDownload()
       {
          LogHandler.DeleteCurrentDefaultLog();
-
 
          var messages = new List<string>();
 

--- a/hmailserver/test/RegressionTests/AntiSpam/DKIM/Verification.cs
+++ b/hmailserver/test/RegressionTests/AntiSpam/DKIM/Verification.cs
@@ -13,7 +13,7 @@ namespace RegressionTests.AntiSpam.DKIM
    public class Verification : TestFixtureBase
    {
       #region Setup/Teardown
-
+      
       [SetUp]
       public new void SetUp()
       {
@@ -33,35 +33,10 @@ namespace RegressionTests.AntiSpam.DKIM
          _antiSpam.DKIMVerificationEnabled = true;
          _antiSpam.DKIMVerificationFailureScore = 100;
 
-         string messageText = @"DKIM-Signature: v=1; a=rsa-sha1; c=simple; d=messiah.edu; h=from:to" + "\r\n" +
-                              "	:subject:date; s=test3; i==6Along@messiah.edu; bh=PW2otvzd7V2TO8" + "\r\n" +
-                              "	w056SjbYRFCa0=; b=Vfr8HgUlyVf1ZaRVMV8VJNSDXn7f1j2N/rFM4PPmYIC2GD" + "\r\n" +
-                              "	pSelCRrdA979Buuu/Mmx9FTWoZJBL+s5tafFM8bw==" + "\r\n" +
-                              "Received: from x.y.test" + "\r\n" +
-                              "   by example.net" + "\r\n" +
-                              "   via TCP" + "\r\n" +
-                              "   with ESMTP" + "\r\n" +
-                              "   id ABC12345" + "\r\n" +
-                              "   for <mary@example.net>;  21 Nov 1997 10:05:43 -0600" + "\r\n" +
-                              "Received: from machine.example by x.y.test; 21 Nov 1997 10:01:22 -0600" + "\r\n" +
-                              "From: Jason Long <jlong@messiah.edu>" + "\r\n" +
-                              "To: Nobody <nobody@messiah.edu>" + "\r\n" +
-                              "Subject: dkim test (i= uses quoted-printable)" + "\r\n" +
-                              "Date: Wed, 9 Apr 2008 09:11:00 -0500" + "\r\n" +
-                              "" + "\r\n" +
-                              "Should pass." + "\r\n" +
-                              "" + "\r\n" +
-                              "This is a test" + "\r\n" +
-                              "  More lines here" + "\r\n" +
-                              "" + "\r\n" +
-                              "Blah  blah  blah" + "\r\n" +
-                              "" + "\r\n" +
-                              "" + "\r\n" +
-                              "" + "\r\n" +
-                              "" + "\r\n";
+         
 
          Account account1 = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "test@test.com", "test");
-         CustomAsserts.Throws<DeliveryFailedException>(() => SmtpClientSimulator.StaticSendRaw(account1.Address, account1.Address, messageText));
+         CustomAsserts.Throws<DeliveryFailedException>(() => SmtpClientSimulator.StaticSendRaw(account1.Address, account1.Address, TestResources.MessageWithInvalidDkim));
       }
 
       [Test]
@@ -73,35 +48,8 @@ namespace RegressionTests.AntiSpam.DKIM
          _antiSpam.DKIMVerificationEnabled = true;
          _antiSpam.DKIMVerificationFailureScore = 6;
 
-         string messageText = @"DKIM-Signature: v=1; a=rsa-sha1; c=simple; d=messiah.edu; h=from:to" + "\r\n" +
-                              "	:subject:date; s=test3; i==6Along@messiah.edu; bh=OW2otvzd7V2TO8" + "\r\n" +
-                              "	w056SjbYRFCa0=; b=Vfr8HgUlyVf1ZaRVMV8VJNSDXn7f1j2N/rFM4PPmYIC2GD" + "\r\n" +
-                              "	pSelCRrdA979Buuu/Mmx9FTWoZJBL+s5tafFM8bw==" + "\r\n" +
-                              "Received: from x.y.test" + "\r\n" +
-                              "   by example.net" + "\r\n" +
-                              "   via TCP" + "\r\n" +
-                              "   with ESMTP" + "\r\n" +
-                              "   id ABC12345" + "\r\n" +
-                              "   for <mary@example.net>;  21 Nov 1997 10:05:43 -0600" + "\r\n" +
-                              "Received: from machine.example by x.y.test; 21 Nov 1997 10:01:22 -0600" + "\r\n" +
-                              "From: Jason Long <jlong@messiah.edu>" + "\r\n" +
-                              "To: Nobody <nobody@messiah.edu>" + "\r\n" +
-                              "Subject: dkim test (i= uses quoted-printable)" + "\r\n" +
-                              "Date: Wed, 9 Apr 2008 09:11:00 -0500" + "\r\n" +
-                              "" + "\r\n" +
-                              "Should pass." + "\r\n" +
-                              "" + "\r\n" +
-                              "This is a test" + "\r\n" +
-                              "  More lines here" + "\r\n" +
-                              "" + "\r\n" +
-                              "Blah  blah  blah" + "\r\n" +
-                              "" + "\r\n" +
-                              "" + "\r\n" +
-                              "" + "\r\n" +
-                              "" + "\r\n";
-
          Account account1 = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "test@test.com", "test");
-         SmtpClientSimulator.StaticSendRaw(account1.Address, account1.Address, messageText);
+         SmtpClientSimulator.StaticSendRaw(account1.Address, account1.Address, TestResources.MessageWithInvalidDkim);
          string text = Pop3ClientSimulator.AssertGetFirstMessageText(account1.Address, "test");
 
          Assert.IsTrue(text.Contains("Rejected by DKIM. - (Score: 6)"));
@@ -114,35 +62,8 @@ namespace RegressionTests.AntiSpam.DKIM
          _antiSpam.DKIMVerificationEnabled = true;
          _antiSpam.DKIMVerificationFailureScore = 100;
 
-         string messageText = @"DKIM-Signature: v=1; a=rsa-sha1; c=simple; d=messiah.edu; h=from:to" + "\r\n" +
-                              "	:subject:date; s=test3; i==6Along@messiah.edu; bh=OW2otvzd7V2TO8" + "\r\n" +
-                              "	w056SjbYRFCa0=; b=Vfr9HgUlyVf1ZaRVMV8VJNSDXn7f1j2N/rFM4PPmYIC2GF" + "\r\n" +
-                              "	pSelCRrdA979Buuu/Mmx9FTWoZJBL+s5tafFM8bw==" + "\r\n" +
-                              "Received: from x.y.test" + "\r\n" +
-                              "   by example.net" + "\r\n" +
-                              "   via TCP" + "\r\n" +
-                              "   with ESMTP" + "\r\n" +
-                              "   id ABC12345" + "\r\n" +
-                              "   for <mary@example.net>;  21 Nov 1997 10:05:43 -0600" + "\r\n" +
-                              "Received: from machine.example by x.y.test; 21 Nov 1997 10:01:22 -0600" + "\r\n" +
-                              "From: Jason Long <jlong@messiah.edu>" + "\r\n" +
-                              "To: Nobody <nobody@messiah.edu>" + "\r\n" +
-                              "Subject: dkim test (i= uses quoted-printable)" + "\r\n" +
-                              "Date: Wed, 9 Apr 2008 09:11:00 -0500" + "\r\n" +
-                              "" + "\r\n" +
-                              "Should pass." + "\r\n" +
-                              "" + "\r\n" +
-                              "This is a test" + "\r\n" +
-                              "  More lines here" + "\r\n" +
-                              "" + "\r\n" +
-                              "Blah  blah  blah" + "\r\n" +
-                              "" + "\r\n" +
-                              "" + "\r\n" +
-                              "" + "\r\n" +
-                              "" + "\r\n";
-
          Account account1 = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "test@test.com", "test");
-         CustomAsserts.Throws<DeliveryFailedException>(() => SmtpClientSimulator.StaticSendRaw(account1.Address, account1.Address, messageText));
+         CustomAsserts.Throws<DeliveryFailedException>(() => SmtpClientSimulator.StaticSendRaw(account1.Address, account1.Address, TestResources.MessageWithInvalidDkim));
       }
 
       [Test]
@@ -151,36 +72,9 @@ namespace RegressionTests.AntiSpam.DKIM
       {
          _antiSpam.DKIMVerificationEnabled = true;
          _antiSpam.DKIMVerificationFailureScore = 100;
-
-         string messageText = @"Return-Path: <tony@att.com>" + "\r\n" +
-                              "X-Original-To: test@dkimtest.jason.long.name" + "\r\n" +
-                              "Delivered-To: dkimtest@mx2.messiah.edu" + "\r\n" +
-                              "Received: from voicemail.cis.att.net (unknown [12.34.200.188])" + "\r\n" +
-                              "	by mx2.messiah.edu (Postfix) with ESMTP id 02F12E15D8" + "\r\n" +
-                              "	for <test@dkimtest.jason.long.name>; Wed,  3 May 2006 15:06:32 -0400 (EDT)" + "\r\n" +
-                              "Received: from  (localhost[127.0.0.1]) by voicemail.cis.att.net (vm2) with SMTP" +
-                              "\r\n" +
-                              "          id <2006050319071918800spa0re>; Wed, 3 May 2006 19:07:19 +0000" + "\r\n" +
-                              "DKIM-Signature: a=rsa-sha256;  c=relaxed; d=vmt2.cis.att.net; t=1146680862; " + "\r\n" +
-                              " h=Date : From : MIME-Version : To : Subject : Content-Type : Content-Transfer-Encoding; bh=HryPFX2R6r7JPsX1Z7+yReZddQR2PjvCvdXgaxW5QYU=; s=shan; " +
-                              "\r\n" +
-                              " b=QXd8h2UbBO7fIPz/Iy3wNwbVU6dih6ozokPXqAvI6p9iG5SqFahyTXwqZeltC4az3Sjay7Vx+b5e" +
-                              "\r\n" +
-                              " 1s2rQuhT4SKD47gJYs4kw0JgV2WLanF3oR1hWD0tL0vuDeUgH6kr" + "\r\n" +
-                              "Date: Wed, 15 Feb 2006 17:32:54 -0500" + "\r\n" +
-                              "From: Tony Hansen <tony@att.com>" + "\r\n" +
-                              "MIME-Version: 1.0" + "\r\n" +
-                              "To: dkim-test@altn.org, sa-test@sendmail.net, autorespond+dkim@dk.elandsys.com" +
-                              "\r\n" +
-                              "Subject: this is a test message minimum.ietf-01.sha256-relaxed" + "\r\n" +
-                              "Content-Type: text/plain; charset=ISO-8859-1" + "\r\n" +
-                              "Content-Transfer-Encoding: 7bit" + "\r\n" +
-                              "Message-Id: <20060503190632.02F12E15D8@mx2.messiah.edu>" + "\r\n" +
-                              "" + "\r\n" +
-                              "The quick brown fox jumped over the lazy dog." + "\r\n";
-
+         
          Account account1 = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "test@test.com", "test");
-         SmtpClientSimulator.StaticSendRaw(account1.Address, account1.Address, messageText);
+         SmtpClientSimulator.StaticSendRaw(account1.Address, account1.Address, TestResources.MessageWithValidDkim);
          string text = Pop3ClientSimulator.AssertGetFirstMessageText(account1.Address, "test");
       }
    }

--- a/hmailserver/test/RegressionTests/IMAP/MessageIndexing.cs
+++ b/hmailserver/test/RegressionTests/IMAP/MessageIndexing.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) 2010 Martin Knafve / hMailServer.com.  
 // http://www.hmailserver.com
 
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using NUnit.Framework;
 using RegressionTests.Shared;
@@ -39,7 +42,7 @@ namespace RegressionTests.IMAP
             Thread.Sleep(20);
          }
 
-         Assert.Fail("Messages not indexed...");
+         Assert.Fail("Messages not indexed. Message count: " + _indexing.TotalMessageCount + ", indexed count: " + _indexing.TotalIndexedCount);
       }
 
       private void SendMessage(string subject, string body, string to, string cc)
@@ -61,7 +64,6 @@ namespace RegressionTests.IMAP
       [Description("Test message metadata date")]
       public void TestMetaDataSortCC()
       {
-         Application application = SingletonProvider<TestSetup>.Instance.GetApp();
          Account account = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "meta'data@test.com", "test");
 
          // disable...
@@ -80,7 +82,20 @@ namespace RegressionTests.IMAP
 
          string result = sim.Sort("(CC) UTF-8 ALL");
 
-         Assert.AreEqual("3 1 2", result);
+         var locale = GetSystemLocaleName();
+
+         switch (locale)
+         {
+            case "en-US":
+               Assert.AreEqual("1 3 2", result);
+               break;
+            case "sv-SE":
+               Assert.AreEqual("3 1 2", result);
+               break;
+            default:
+               throw new InvalidOperationException("Unsupported system locale: " + locale);
+         }
+         
 
          // Disable the indexing functionality
          _indexing.Enabled = false;
@@ -239,7 +254,19 @@ namespace RegressionTests.IMAP
 
          string result = sim.Sort("(SUBJECT) UTF-8 ALL");
 
-         Assert.AreEqual("3 1 2", result);
+         var locale = GetSystemLocaleName();
+
+         switch (locale)
+         {
+            case "en-US":
+               Assert.AreEqual("1 3 2", result);
+               break;
+            case "sv-SE":
+               Assert.AreEqual("3 1 2", result);
+               break;
+            default:
+               throw new InvalidOperationException("Unsupported system locale: " + locale);
+         }
 
          // Disable the indexing functionality
          _indexing.Enabled = false;
@@ -320,7 +347,19 @@ namespace RegressionTests.IMAP
 
          string result = sim.Sort("(TO) UTF-8 ALL");
 
-         Assert.AreEqual("1 3 2", result);
+         var locale = GetSystemLocaleName();
+
+         switch (locale)
+         {
+            case "en-US":
+               Assert.AreEqual("3 1 2", result);
+               break;
+            case "sv-SE":
+               Assert.AreEqual("1 3 2", result);
+               break;
+            default:
+               throw new InvalidOperationException("Unsupported system locale: " + locale);
+         }
 
          // Disable the indexing functionality
          _indexing.Enabled = false;
@@ -330,6 +369,30 @@ namespace RegressionTests.IMAP
          string resultAfter = sim.Sort("(TO) UTF-8 ALL");
 
          Assert.AreEqual(result, resultAfter);
+      }
+
+      // P/Invoke signature
+      [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+      private static extern int GetSystemDefaultLocaleName(
+         [Out] StringBuilder lpLocaleName,
+         int cchLocaleName
+      );
+
+
+      private string GetSystemLocaleName()
+      {
+         const int LOCALE_NAME_MAX_LENGTH = 85; // Max length per Windows API docs
+         StringBuilder localeName = new StringBuilder(LOCALE_NAME_MAX_LENGTH);
+
+         int result = GetSystemDefaultLocaleName(localeName, LOCALE_NAME_MAX_LENGTH);
+         if (result > 0)
+         {
+            return localeName.ToString();
+         }
+         else
+         {
+            throw new InvalidOperationException("Unable to read system locale.");
+         }
       }
    }
 }

--- a/hmailserver/test/RegressionTests/Infrastructure/Persistence/Basics.cs
+++ b/hmailserver/test/RegressionTests/Infrastructure/Persistence/Basics.cs
@@ -409,16 +409,16 @@ namespace RegressionTests.Infrastructure.Persistence
          alias3.Value = "external@external.com";
          alias3.Save();
 
-         _domain.Name = "example.com";
+         _domain.Name = "new1.example.com";
          _domain.Save();
 
-         Assert.AreEqual("alias1@example.com", _domain.Aliases[0].Name);
-         Assert.AreEqual("alias2@example.com", _domain.Aliases[0].Value);
+         Assert.AreEqual("alias1@new1.example.com", _domain.Aliases[0].Name);
+         Assert.AreEqual("alias2@new1.example.com", _domain.Aliases[0].Value);
 
-         Assert.AreEqual("alias2@example.com", _domain.Aliases[1].Name);
-         Assert.AreEqual("account@example.com", _domain.Aliases[1].Value);
+         Assert.AreEqual("alias2@new1.example.com", _domain.Aliases[1].Name);
+         Assert.AreEqual("account@new1.example.com", _domain.Aliases[1].Value);
 
-         Assert.AreEqual("alias3@example.com", _domain.Aliases[2].Name);
+         Assert.AreEqual("alias3@new1.example.com", _domain.Aliases[2].Name);
          Assert.AreEqual("external@external.com", _domain.Aliases[2].Value);
       }
 
@@ -443,13 +443,13 @@ namespace RegressionTests.Infrastructure.Persistence
          oRecipient.RecipientAddress = "recipient3@otherdomain.com";
          oRecipient.Save();
 
-         _domain.Name = "example.com";
+         _domain.Name = "new2.example.com";
          _domain.Save();
 
          DistributionList list = _domain.DistributionLists[0];
-         Assert.AreEqual("list@example.com", list.Address);
-         Assert.AreEqual("recipient1@example.com", list.Recipients[0].RecipientAddress);
-         Assert.AreEqual("recipient2@example.com", list.Recipients[1].RecipientAddress);
+         Assert.AreEqual("list@new2.example.com", list.Address);
+         Assert.AreEqual("recipient1@new2.example.com", list.Recipients[0].RecipientAddress);
+         Assert.AreEqual("recipient2@new2.example.com", list.Recipients[1].RecipientAddress);
          Assert.AreEqual("recipient3@otherdomain.com", list.Recipients[2].RecipientAddress);
       }
 
@@ -464,10 +464,10 @@ namespace RegressionTests.Infrastructure.Persistence
          SmtpClientSimulator.StaticSend(account.Address, account.Address, "Subj", messageBody);
          Pop3ClientSimulator.AssertMessageCount(account.Address, "test", 1);
 
-         _domain.Name = "example.com";
+         _domain.Name = "new3.example.com";
          _domain.Save();
 
-         string messageText = Pop3ClientSimulator.AssertGetFirstMessageText("account1@example.com", "test");
+         string messageText = Pop3ClientSimulator.AssertGetFirstMessageText("account1@new3.example.com", "test");
          Assert.IsTrue(messageText.Contains(messageBody), messageText);
       }
 

--- a/hmailserver/test/RegressionTests/POP3/Fetching/Basics.cs
+++ b/hmailserver/test/RegressionTests/POP3/Fetching/Basics.cs
@@ -1004,12 +1004,12 @@ namespace RegressionTests.POP3.Fetching
 
          var messages = new List<string>();
 
-         string message = "Received: from example.com (example.com [1.2.3]) by mail.example.com\r\n" +
-                          "From: example@example.com\r\n" +
+         string message = "Received: from nonexistent.hmailserver.com (nonexistent.hmailserver.com [1.2.3]) by nonexistent.hmailserver.com\r\n" +
+                          "From: example@nonexistent.hmailserver.com\r\n" +
                           "To: Martin@example.com\r\n" +
                           "Subject: Test\r\n" +
                           "\r\n" +
-                          "Should be blocked by SPF.";
+                          "Should NOT be blocked by SPF.";
 
          messages.Add(message);
 

--- a/hmailserver/test/RegressionTests/RegressionTests.csproj
+++ b/hmailserver/test/RegressionTests/RegressionTests.csproj
@@ -77,6 +77,8 @@
     <Compile Include="Infrastructure\Persistence\AccountNameValidation.cs" />
     <Compile Include="Infrastructure\Persistence\AliasNameValidation.cs" />
     <Compile Include="Infrastructure\Persistence\DomainNameValidation.cs" />
+    <None Include="Resources\MessageWithInvalidDkim.eml" />
+    <None Include="Resources\MessageWithValidDkim.eml" />
     <Compile Include="Shared\DeliveryFailedException.cs" />
     <Compile Include="Shared\ServiceRestartDetector.cs" />
     <Compile Include="Shared\SslVersions.cs" />
@@ -222,6 +224,7 @@
     <EmbeddedResource Include="TestResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>TestResources.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/hmailserver/test/RegressionTests/Resources/MessageWithInvalidDkim.eml
+++ b/hmailserver/test/RegressionTests/Resources/MessageWithInvalidDkim.eml
@@ -1,0 +1,35 @@
+﻿DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=outlook.com; s=selector1; h=From:Date:Subject:Message-ID:Content-Type:MIME-Version:X-MS-Exchange-SenderADCheck; bh=syNc2SLm55vlwN6IjdVrbij1wTNuoXAo8x12RY/gyIU=; b=hWRmlUPrqWbCw+W27/cfsY0gTs06oYYNVTAPYhz+PlV4jKaz/ArzaMEkz9AimJVYzoS6sspI0JB21Z/VKlbiU+iH4lQcmPS7xF3+yKv2lODPuoioWtrGSS+nWYRhImYri8718yWPZPQlBEZ4wutFs80EJK9ASMmREOPfLN/wfjMVszqa18IRCvHNJD1Ed+YMCgyPV3/NzhrldTwzIbNBz8gBHYYeqmTIIZRWm549Hc/57DIJI9Yef7HtOyZjqpszLavp3sMvKqPtjU7VWChxaO9FkMkZBDGZSkUUkNG45J2QfmfgdPDRhf4ACf50xRT3mMngtXeRIFvxJdFwrq3YQQFOO==
+From: Martin Knafve <Martin.Knafve@outlook.com>
+To: "martintestaddress12345@gmail.com" <martintestaddress12345@gmail.com>
+Subject: test
+Date: Sun, 6 Jul 2025 11:07:13 +0000
+Message-ID: <VI1PR08MB3728323CBDD4076936E1801FEE4CA@VI1PR08MB3728.eurprd08.prod.outlook.com>
+Content-Type: multipart/alternative; boundary="_000_VI1PR08MB3728323CBDD4076936E1801FEE4CAVI1PR08MB3728eurp_"
+MIME-Version: 1.0
+
+--_000_VI1PR08MB3728323CBDD4076936E1801FEE4CAVI1PR08MB3728eurp_
+Content-Type: text/plain; charset="iso-8859-1"
+Content-Transfer-Encoding: quoted-printable
+
+test
+
+--_000_VI1PR08MB3728323CBDD4076936E1801FEE4CAVI1PR08MB3728eurp_
+Content-Type: text/html; charset="iso-8859-1"
+Content-Transfer-Encoding: quoted-printable
+
+<html>
+<head>
+<meta http-equiv=3D"Content-Type" content=3D"text/html; charset=3Diso-8859-=
+1">
+<style type=3D"text/css" style=3D"display:none;"> P {margin-top:0;margin-bo=
+ttom:0;} </style>
+</head>
+<body dir=3D"ltr">
+<div class=3D"elementToProof" style=3D"font-family: Aptos, Aptos_EmbeddedFo=
+nt, Aptos_MSFontService, Calibri, Helvetica, sans-serif; font-size: 12pt; c=
+olor: rgb(0, 0, 0);">
+test</div>
+</body>
+</html>
+
+--_000_VI1PR08MB3728323CBDD4076936E1801FEE4CAVI1PR08MB3728eurp_--

--- a/hmailserver/test/RegressionTests/Resources/MessageWithValidDkim.eml
+++ b/hmailserver/test/RegressionTests/Resources/MessageWithValidDkim.eml
@@ -1,0 +1,35 @@
+﻿DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=outlook.com; s=selector1; h=From:Date:Subject:Message-ID:Content-Type:MIME-Version:X-MS-Exchange-SenderADCheck; bh=syNc2SLm55vlwN6IjdVrbij1wTNuoXAo8x12RY/gyIU=; b=hWRmlUPrqWbCw+W27/cfsY0gTs06oYYNVTAPYhz+PlV4jKaz/ArzaMEkz9AimJVYzoS6sspI0JB21Z/VKlbiU+iH4lQcmPS7xF3+yKv2lODPuoioWtrGSS+nWYRhImYri8718yWPZPQlBEZ4wutFs80EJK9ASMmREOPfLN/wfjMVszqa18IRCvHNJD1Ed+YMCgyPV3/NzhrldTwzIbNBz8gBHYYeqmTIIZRWm549Hc/57DIJI9Yef7HtOyZjqpszLavp3sMvKqPtjU7VWChxaO9FkMkZBDGZSkUUkNG45J2QfmfgdPDRhf4ACf50xRT3mMngtXeRIFvxJdFwrq3YQQ==
+From: Martin Knafve <Martin.Knafve@outlook.com>
+To: "martintestaddress12345@gmail.com" <martintestaddress12345@gmail.com>
+Subject: test
+Date: Sun, 6 Jul 2025 11:07:13 +0000
+Message-ID: <VI1PR08MB3728323CBDD4076936E1801FEE4CA@VI1PR08MB3728.eurprd08.prod.outlook.com>
+Content-Type: multipart/alternative; boundary="_000_VI1PR08MB3728323CBDD4076936E1801FEE4CAVI1PR08MB3728eurp_"
+MIME-Version: 1.0
+
+--_000_VI1PR08MB3728323CBDD4076936E1801FEE4CAVI1PR08MB3728eurp_
+Content-Type: text/plain; charset="iso-8859-1"
+Content-Transfer-Encoding: quoted-printable
+
+test
+
+--_000_VI1PR08MB3728323CBDD4076936E1801FEE4CAVI1PR08MB3728eurp_
+Content-Type: text/html; charset="iso-8859-1"
+Content-Transfer-Encoding: quoted-printable
+
+<html>
+<head>
+<meta http-equiv=3D"Content-Type" content=3D"text/html; charset=3Diso-8859-=
+1">
+<style type=3D"text/css" style=3D"display:none;"> P {margin-top:0;margin-bo=
+ttom:0;} </style>
+</head>
+<body dir=3D"ltr">
+<div class=3D"elementToProof" style=3D"font-family: Aptos, Aptos_EmbeddedFo=
+nt, Aptos_MSFontService, Calibri, Helvetica, sans-serif; font-size: 12pt; c=
+olor: rgb(0, 0, 0);">
+test</div>
+</body>
+</html>
+
+--_000_VI1PR08MB3728323CBDD4076936E1801FEE4CAVI1PR08MB3728eurp_--

--- a/hmailserver/test/RegressionTests/TestResources.Designer.cs
+++ b/hmailserver/test/RegressionTests/TestResources.Designer.cs
@@ -189,6 +189,24 @@ namespace RegressionTests {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=outlook.com; s=selector1; h=From:Date:Subject:Message-ID:Content-Type:MIME-Version:X-MS-Exchange-SenderADCheck; bh=syNc2SLm55vlwN6IjdVrbij1wTNuoXAo8x12RY/gyIU=; b=hWRmlUPrqWbCw+W27/cfsY0gTs06oYYNVTAPYhz+PlV4jKaz/ArzaMEkz9AimJVYzoS6sspI0JB21Z/VKlbiU+iH4lQcmPS7xF3+yKv2lODPuoioWtrGSS+nWYRhImYri8718yWPZPQlBEZ4wutFs80EJK9ASMmREOPfLN/wfjMVszqa18IRCvHNJD1Ed+YMCgyPV3/NzhrldTwzIbNBz8gBHYYeqmTIIZRWm549Hc/57DIJI9Yef7HtOyZjqpszLavp3sMvKqPtjU7VWChxaO9FkMkZBDGZSkUUk [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string MessageWithInvalidDkim {
+            get {
+                return ResourceManager.GetString("MessageWithInvalidDkim", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=outlook.com; s=selector1; h=From:Date:Subject:Message-ID:Content-Type:MIME-Version:X-MS-Exchange-SenderADCheck; bh=syNc2SLm55vlwN6IjdVrbij1wTNuoXAo8x12RY/gyIU=; b=hWRmlUPrqWbCw+W27/cfsY0gTs06oYYNVTAPYhz+PlV4jKaz/ArzaMEkz9AimJVYzoS6sspI0JB21Z/VKlbiU+iH4lQcmPS7xF3+yKv2lODPuoioWtrGSS+nWYRhImYri8718yWPZPQlBEZ4wutFs80EJK9ASMmREOPfLN/wfjMVszqa18IRCvHNJD1Ed+YMCgyPV3/NzhrldTwzIbNBz8gBHYYeqmTIIZRWm549Hc/57DIJI9Yef7HtOyZjqpszLavp3sMvKqPtjU7VWChxaO9FkMkZBDGZSkUUk [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string MessageWithValidDkim {
+            get {
+                return ResourceManager.GetString("MessageWithValidDkim", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ----------------------------------------------------------------------
         ///
         ///The final version of the CSI 6.0 has been released. 

--- a/hmailserver/test/RegressionTests/TestResources.resx
+++ b/hmailserver/test/RegressionTests/TestResources.resx
@@ -112,12 +112,12 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="EmailWith_TextHtmlBody_TextHtmlContentType" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>resources\emailwith-texthtmlbody-texthtmlcontenttype.txt;System.String, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
@@ -135,6 +135,12 @@
   </data>
   <data name="EmailWith_TextPlainBody_TextPlainContentType" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>resources\emailwith-textplainbody-textplaincontenttype.txt;System.String, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="MessageWithInvalidDkim" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>resources\messagewithinvaliddkim.eml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="MessageWithValidDkim" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>resources\messagewithvaliddkim.eml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="SecuniaBody1" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>Resources\SecuniaBody1.txt;System.String, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>


### PR DESCRIPTION
If the setting is enabled in hMailServer.ini, a X-Original-Rcpt-To-header should be added with the local original addresses.

This is used in a specific integration and likely not generally useful. The setting is disabled by default.