### PR TITLE
Fix: Emails stored without trailing newline

### DIFF
--- a/hmailserver/source/Server/Common/Mime/Mime.cpp
+++ b/hmailserver/source/Server/Common/Mime/Mime.cpp
@@ -58,20 +58,32 @@ namespace HM
    }
 
    // search for string2 in string1 (strstr)
-   static const char* FindString(const char* pszStr1, const char* pszStr2, const char* pszEnd)
+   const char* FindString(const char* haystack,
+      const char* needle,
+      const char* haystackEnd) // one past last valid char
    {
-      pszEnd -= ::strlen(pszStr2);
-      const char *s1, *s2;
-      while (pszStr1 <= pszEnd)
+      if (haystack == NULL || needle == NULL || haystackEnd == NULL)
+         return NULL;
+
+      const size_t needleLength = std::strlen(needle);
+      if (needleLength == 0)
+         return haystack;
+
+      if (haystackEnd <= haystack)
+         return NULL;
+
+      const size_t haystackLength = static_cast<size_t>(haystackEnd - haystack);
+      if (needleLength > haystackLength)
+         return NULL;
+
+      const char* const lastStart = haystack + (haystackLength - needleLength);
+      while (haystack <= lastStart)
       {
-         s1 = pszStr1;
-         s2 = pszStr2;
-         while (*s1 == *s2 && *s2)
-            s1++, s2++;
-         if (!*s2)
-            return pszStr1;
-         pszStr1++;
+         if (std::memcmp(haystack, needle, needleLength) == 0)
+            return haystack;
+         ++haystack;
       }
+
       return NULL;
    }
 
@@ -1137,9 +1149,10 @@ namespace HM
             size_t nLoaded = Load(pFileContents->GetCharBuffer(), pFileContents->GetSize() - 1, index, part_loaded);
 
             // Record source file and body offset for body preservation during save.
-            // For multipart messages, last_multipart_end_ is the position right after
-            // "--boundary--", excluding any trailing CRLF added by the SMTP transport.
-            // For simple messages, use the full Load() return value.
+            // For multipart messages, last_multipart_end_ mirrors what the parser
+            // actually consumed for the closing boundary, including the trailing
+            // CRLF when present in the source file. For simple messages, use the
+            // full Load() return value.
             source_file_ = pszFilename;
             body_byte_offset_ = last_header_size_;
             body_byte_end_ = (last_multipart_end_ > 0) ? last_multipart_end_ : nLoaded;
@@ -1534,11 +1547,12 @@ namespace HM
       {
          counter--;
 
-         // return if the string after the boundary is either a newline, or a --.
-         // this is to prevent the problem that we return incorrect boundaries
-         // if the boundary string is a part of another boundary string.
-         size_t sizeRemainingAfterBoundaryString = endSearch - possibleEnding;
-         if (sizeRemainingAfterBoundaryString <= 2)
+         // We inspect the 2 bytes immediately following the full boundary text
+         // to verify that this is a real boundary line ("--" or "\r\n"), not
+         // just a boundary prefix found inside other content.
+         size_t bytesRemainingFromCandidate = endSearch - possibleEnding;
+         size_t bytesRequiredForBoundaryAndSuffix = boundary.length() + 2;
+         if (bytesRemainingFromCandidate < bytesRequiredForBoundaryAndSuffix)
          {
             // malformed message. the end of the character string is the boundary line with no trailing crlf or --.
             return 0;
@@ -1634,19 +1648,44 @@ namespace HM
       while (pszBound1 != NULL && pszBound1 < pszEnd && counter > 0)
       {
          counter--;
-         const char* pszStart = FindString(pszBound1+2, "\r\n", pszEnd);
-         if (pszBound1[strBoundary.size()] == '-' && pszBound1[strBoundary.size()+1] == '-')
-         {
-            // Closing boundary: record end right after "--boundary--" (before any trailing CRLF)
-            last_multipart_end_ = (pszBound1 + strBoundary.size() + 2) - pszDataBegin;
-            if (!pszStart)
-               break;
-            pszStart += 2;
-            return (int)(pszStart - pszDataBegin);	// reach the closing boundary
-         }
-         if (!pszStart)
+         // pszBound1 points at the start of "\r\n--boundary". Move past the
+         // boundary text so we can inspect what terminates this boundary line.
+         const char* pszAfterBoundary = pszBound1 + strBoundary.size();
+
+         // Need at least 2 bytes available to distinguish a closing boundary
+         // ("--") from a normal part boundary ("\r\n").
+         if (pszAfterBoundary + 2 > pszEnd)
             break;
-         pszStart += 2;
+
+         if (pszAfterBoundary[0] == '-' && pszAfterBoundary[1] == '-')
+         {
+            const char* pszAfterClosingBoundary = pszAfterBoundary + 2;
+
+            // Preserve the trailing CRLF after the closing boundary when it
+            // exists in the source file. Some malformed messages end directly
+            // at "--boundary--", so accept EOF there as well.
+            if (pszAfterClosingBoundary + 2 <= pszEnd &&
+                pszAfterClosingBoundary[0] == '\r' &&
+                pszAfterClosingBoundary[1] == '\n')
+            {
+               // Include the trailing CRLF after "--boundary--" in the preserved byte range.
+               last_multipart_end_ = (pszAfterClosingBoundary + 2) - pszDataBegin;
+               return (int)(pszAfterClosingBoundary + 2 - pszDataBegin);	// reach the closing boundary
+            }
+
+            // Preserve EOF exactly as it appeared on disk when the closing
+            // boundary is the final bytes in the file.
+            last_multipart_end_ = pszAfterClosingBoundary - pszDataBegin;
+            return (int)(pszAfterClosingBoundary - pszDataBegin);
+         }
+
+         // A non-closing part boundary must be followed by CRLF before the
+         // next part headers begin. If not, stop parsing rather than scanning
+         // past the valid input range looking for a newline.
+         if (pszAfterBoundary[0] != '\r' || pszAfterBoundary[1] != '\n')
+            break;
+
+         const char* pszStart = pszAfterBoundary + 2;
 
          // look for the next boundary
          string strBoundaryLine = strBoundary + "\r\n";

--- a/hmailserver/source/Server/Common/Mime/Mime.h
+++ b/hmailserver/source/Server/Common/Mime/Mime.h
@@ -35,6 +35,8 @@ using namespace std;
 // RFC 822 - Standard For The Format of ARPA Internet Text Message
 namespace HM
 {
+   const char* FindString(const char* pszStr1, const char* pszStr2, const char* pszEnd);
+
    class CMimeConst
    {
    public:

--- a/hmailserver/source/Server/Common/Mime/MimeTester.cpp
+++ b/hmailserver/source/Server/Common/Mime/MimeTester.cpp
@@ -21,6 +21,224 @@
 
 namespace HM
 {
+   namespace
+   {
+      bool TestFindStringEdgeCases()
+      {
+         const char* sample = "abc\r\ndef";
+         const char* repeated = "abcabc";
+         const char* beginning = "\r\nheader";
+         const char* emptyNeedleSample = "payload";
+
+         // Finds CRLF in the middle of the buffer.
+         if (HM::FindString(sample, "\r\n", sample + strlen(sample)) != sample + 3)
+            return false;
+
+         // Returns the first occurrence when the haystack contains repeated matches.
+         if (HM::FindString(repeated, "abc", repeated + strlen(repeated)) != repeated)
+            return false;
+
+         // Respects the provided start pointer and finds a later occurrence.
+         if (HM::FindString(repeated + 1, "abc", repeated + strlen(repeated)) != repeated + 3)
+            return false;
+
+         // Finds a match located at the very beginning of the haystack.
+         if (HM::FindString(beginning, "\r\n", beginning + strlen(beginning)) != beginning)
+            return false;
+
+         // Finds a match located at the very end of the haystack.
+         if (HM::FindString(sample, "def", sample + strlen(sample)) != sample + 5)
+            return false;
+
+         // Returns the haystack start for an empty needle.
+         if (HM::FindString(emptyNeedleSample, "", emptyNeedleSample + strlen(emptyNeedleSample)) != emptyNeedleSample)
+            return false;
+
+         // Returns NULL when searching past the only CRLF in the buffer.
+         if (HM::FindString(sample + 5, "\r\n", sample + strlen(sample)) != NULL)
+            return false;
+
+         // Returns NULL when the allowed search range is too short to contain the needle.
+         if (HM::FindString(sample + 3, "\r\n", sample + 4) != NULL)
+            return false;
+
+         // Returns NULL when the needle is longer than the haystack range.
+         if (HM::FindString(sample, "abcdefghi", sample + 3) != NULL)
+            return false;
+
+         // Returns NULL when the needle does not exist in the haystack.
+         if (HM::FindString(sample, "xyz", sample + strlen(sample)) != NULL)
+            return false;
+
+         // Returns NULL when the match would start exactly at haystackEnd.
+         if (HM::FindString(sample, "\r\n", sample + 3) != NULL)
+            return false;
+
+         // Returns NULL when the haystack pointer is NULL.
+         if (HM::FindString(NULL, "\r\n", sample + strlen(sample)) != NULL)
+            return false;
+
+         // Returns NULL when the needle pointer is NULL.
+         if (HM::FindString(sample, NULL, sample + strlen(sample)) != NULL)
+            return false;
+
+         // Returns NULL when the haystack end pointer is NULL.
+         if (HM::FindString(sample, "\r\n", NULL) != NULL)
+            return false;
+
+         // Returns NULL when haystackEnd points before haystack.
+         if (HM::FindString(sample + 4, "\r\n", sample + 3) != NULL)
+            return false;
+
+         // Returns NULL for a closing MIME boundary at EOF with no trailing CRLF.
+         if (HM::FindString("--------------9RmO0bL0Xu1K5PGiz2FQ63S5--",
+            "\r\n",
+            "--------------9RmO0bL0Xu1K5PGiz2FQ63S5--" + strlen("--------------9RmO0bL0Xu1K5PGiz2FQ63S5--")) != NULL)
+            return false;
+
+         return true;
+      }
+
+      bool TestMultipartWithoutFinalCrlf()
+      {
+         const char* multipartWithoutFinalCrlf =
+            "Content-Type: multipart/mixed; boundary=\"boundary42\"\r\n"
+            "\r\n"
+            "--boundary42\r\n"
+            "Content-Type: text/plain\r\n"
+            "\r\n"
+            "hello\r\n"
+            "--boundary42--";
+
+         MimeBody message;
+         size_t index = 0;
+         bool part_loaded = false;
+         size_t loaded = message.Load(multipartWithoutFinalCrlf, strlen(multipartWithoutFinalCrlf), index, part_loaded);
+
+         if (!part_loaded)
+            return false;
+
+         if (loaded != strlen(multipartWithoutFinalCrlf))
+            return false;
+
+         if (message.GetPartCount() != 1)
+            return false;
+
+         return true;
+      }
+
+      bool TestMultipartWithFinalCrlf()
+      {
+         const char* multipartWithFinalCrlf =
+            "Content-Type: multipart/mixed; boundary=\"boundary42\"\r\n"
+            "\r\n"
+            "--boundary42\r\n"
+            "Content-Type: text/plain\r\n"
+            "\r\n"
+            "hello\r\n"
+            "--boundary42--\r\n";
+
+         MimeBody message;
+         size_t index = 0;
+         bool part_loaded = false;
+         size_t loaded = message.Load(multipartWithFinalCrlf, strlen(multipartWithFinalCrlf), index, part_loaded);
+
+         if (!part_loaded)
+            return false;
+
+         if (loaded != strlen(multipartWithFinalCrlf))
+            return false;
+
+         if (message.GetPartCount() != 1)
+            return false;
+
+         return true;
+      }
+
+      bool TestMultipartWithoutClosingBoundary()
+      {
+         const char* multipartWithoutClosingBoundary =
+            "Content-Type: multipart/mixed; boundary=\"boundary42\"\r\n"
+            "\r\n"
+            "--boundary42\r\n"
+            "Content-Type: text/plain\r\n"
+            "\r\n"
+            "hello\r\n";
+
+         MimeBody message;
+         size_t index = 0;
+         bool part_loaded = false;
+         size_t loaded = message.Load(multipartWithoutClosingBoundary, strlen(multipartWithoutClosingBoundary), index, part_loaded);
+
+         if (!part_loaded)
+            return false;
+
+         if (loaded != strlen(multipartWithoutClosingBoundary))
+            return false;
+
+         if (message.GetPartCount() != 1)
+            return false;
+
+         return true;
+      }
+
+      bool TestMultipartWithClosingBoundaryMissingSeparator()
+      {
+         const char* multipartWithClosingBoundaryMissingSeparator =
+            "Content-Type: multipart/mixed; boundary=\"boundary42\"\r\n"
+            "\r\n"
+            "--boundary42\r\n"
+            "Content-Type: text/plain\r\n"
+            "\r\n"
+            "hello\r\n"
+            "--boundary42--garbage";
+
+         MimeBody message;
+         size_t index = 0;
+         bool part_loaded = false;
+         size_t loaded = message.Load(multipartWithClosingBoundaryMissingSeparator, strlen(multipartWithClosingBoundaryMissingSeparator), index, part_loaded);
+
+         if (!part_loaded)
+            return false;
+
+         if (loaded != strlen(multipartWithClosingBoundaryMissingSeparator))
+            return false;
+
+         if (message.GetPartCount() != 1)
+            return false;
+
+         return true;
+      }
+
+      bool TestMultipartWithPartBoundaryMissingCrlf()
+      {
+         const char* multipartWithPartBoundaryMissingCrlf =
+            "Content-Type: multipart/mixed; boundary=\"boundary42\"\r\n"
+            "\r\n"
+            "--boundary42"
+            "Content-Type: text/plain\r\n"
+            "\r\n"
+            "hello\r\n"
+            "--boundary42--";
+
+         MimeBody message;
+         size_t index = 0;
+         bool part_loaded = false;
+         size_t loaded = message.Load(multipartWithPartBoundaryMissingCrlf, strlen(multipartWithPartBoundaryMissingCrlf), index, part_loaded);
+
+         if (!part_loaded)
+            return false;
+
+         if (loaded != strlen(multipartWithPartBoundaryMissingCrlf))
+            return false;
+
+         if (message.GetPartCount() != 0)
+            return false;
+
+         return true;
+      }
+   }
+
    MimeTester::MimeTester(void)
    {
    }
@@ -29,6 +247,32 @@ namespace HM
    {
    }
    
+   bool
+   MimeTester::Test()
+   {
+      if (!TestFindStringEdgeCases())
+         return false;
+
+      if (!TestMultipartWithoutFinalCrlf())
+         return false;
+
+      if (!TestMultipartWithFinalCrlf())
+         return false;
+
+      if (!TestMultipartWithoutClosingBoundary())
+         return false;
+
+      if (!TestMultipartWithClosingBoundaryMissingSeparator())
+         return false;
+
+      if (!TestMultipartWithPartBoundaryMissingCrlf())
+         return false;
+
+      return true;
+   }
+
+
+
    bool 
    MimeTester::TestFolder(const String &sFolderName)
    {

--- a/hmailserver/source/Server/Common/Mime/MimeTester.h
+++ b/hmailserver/source/Server/Common/Mime/MimeTester.h
@@ -11,6 +11,7 @@ namespace HM
       MimeTester(void);
       ~MimeTester(void);
 
+      bool Test();
       bool TestFolder(const String &sFolderName);
       void TestFile(const String &sFilename);
 	  void TestLoadFile(const String &sFilename);

--- a/hmailserver/source/Server/Common/Util/ClassTester.cpp
+++ b/hmailserver/source/Server/Common/Util/ClassTester.cpp
@@ -56,6 +56,7 @@ namespace HM
 
       OutputDebugString(_T("hMailServer: Testing mime parser\n"));
 	   MimeTester *pMimeTester = new MimeTester;
+      pMimeTester->Test();
       pMimeTester->TestFolder("C:\\Temp\\Testdata\\martin");
 	   delete pMimeTester;
 

--- a/hmailserver/test/RegressionTests/MIME/RoundTrip.cs
+++ b/hmailserver/test/RegressionTests/MIME/RoundTrip.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text.RegularExpressions;
 using hMailServer;
 using NUnit.Framework;
+using RegressionTests.Infrastructure;
 using RegressionTests.Shared;
 
 namespace RegressionTests.MIME
@@ -66,7 +67,7 @@ namespace RegressionTests.MIME
 
          var storedFilename = account.IMAPFolders.get_ItemByName("Inbox").Messages[0].Filename;
          var storedContent = File.ReadAllText(storedFilename);
-         var originalContent = TestResources.MessageWithValidDkim;
+         var originalContent = ToSmtpWireMessage(TestResources.MessageWithValidDkim);
 
          StringAssert.Contains("X-Test: test-value", storedContent,
             "The rule should have added the X-Test header");
@@ -197,7 +198,7 @@ namespace RegressionTests.MIME
 
          var storedFilename = account.IMAPFolders.get_ItemByName("Inbox").Messages[0].Filename;
          var storedContent = File.ReadAllText(storedFilename);
-         var originalContent = TestResources.MessageWithValidDkim;
+         var originalContent = ToSmtpWireMessage(TestResources.MessageWithValidDkim);
 
          var originalContentType = ExtractHeaderValue(originalContent, "Content-Type");
          var storedContentType = ExtractHeaderValue(storedContent, "Content-Type");
@@ -208,6 +209,39 @@ namespace RegressionTests.MIME
          var storedBody = ExtractBody(storedContent);
          Assert.AreEqual(originalBody, storedBody,
             "Multipart body content was modified during re-serialization");
+         StringAssert.EndsWith("\r\n", storedContent,
+            "Multipart message should retain the trailing CRLF after the closing boundary");
+      }
+
+      [Test]
+      [Description("A multipart message fixture with no final CRLF must still be fetchable after round-tripping through rules.")]
+      public void TestMultipartWithoutFinalFixtureCrlfCanBeParsedAfterRoundTrip()
+      {
+         var account = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "roundtrip7@example.test", "test");
+         AddSetHeaderRule(account, "X-Test", "test-value");
+
+         SmtpClientSimulator.StaticSendRaw(account.Address, account.Address, TestResources.EmailWith_TextPlainBody_TextHtmlBody_TextHtmlAttachment);
+
+         Pop3ClientSimulator.AssertMessageCount(account.Address, "test", 1);
+
+         var storedFilename = account.IMAPFolders.get_ItemByName("Inbox").Messages[0].Filename;
+         var storedContent = File.ReadAllText(storedFilename);
+         StringAssert.Contains("X-Test: test-value", storedContent,
+            "The rule should have added the X-Test header before the message is parsed again");
+
+         var imapSim = new ImapClientSimulator(account.Address, "test", "INBOX");
+         var result = imapSim.Fetch("1 BODYSTRUCTURE");
+         imapSim.Logout();
+
+         StringAssert.Contains("A17 OK FETCH completed", result,
+            "The round-tripped multipart message should still be parseable over IMAP");
+
+         CustomAsserts.AssertNoReportedError();
+      }
+
+      private static string ToSmtpWireMessage(string message)
+      {
+         return message.EndsWith("\r\n") ? message : message + "\r\n";
       }
    }
 }


### PR DESCRIPTION
The fix for #500 introduced an issue where email messages were sometimes missing a trailing newline on disk. This later lead to issues parsing the content.

The code has been updated so that the trailing newline is added, and the parsing has been made more robust.