### PR TITLE
Remove-ImapAuthAllowPlainText

### DIFF
--- a/hmailserver/source/DBScripts/CreateTablesMSSQL.sql
+++ b/hmailserver/source/DBScripts/CreateTablesMSSQL.sql
@@ -938,8 +938,6 @@ insert into hm_settings (settingname, settingstring, settinginteger) values ('Ss
 
 insert into hm_settings (settingname, settingstring, settinginteger) values ('ImapMasterUser', '', 0)
 
-insert into hm_settings (settingname, settingstring, settinginteger) values ('ImapAuthAllowPlainText', '', 0)
-
 insert into hm_settings (settingname, settingstring, settinginteger) values ('EnableImapSASLPlain', '', 0)
 
 insert into hm_settings (settingname, settingstring, settinginteger) values ('EnableImapSASLInitialResponse', '', 0)

--- a/hmailserver/source/DBScripts/CreateTablesMYSQL.sql
+++ b/hmailserver/source/DBScripts/CreateTablesMYSQL.sql
@@ -763,8 +763,6 @@ insert into hm_settings (settingname, settingstring, settinginteger) values ('Ss
 
 insert into hm_settings (settingname, settingstring, settinginteger) values ('ImapMasterUser', '', 0);
 
-insert into hm_settings (settingname, settingstring, settinginteger) values ('ImapAuthAllowPlainText', '', 0);
-
 insert into hm_settings (settingname, settingstring, settinginteger) values ('EnableImapSASLPlain', '', 0);
 
 insert into hm_settings (settingname, settingstring, settinginteger) values ('EnableImapSASLInitialResponse', '', 0);

--- a/hmailserver/source/DBScripts/CreateTablesPGSQL.sql
+++ b/hmailserver/source/DBScripts/CreateTablesPGSQL.sql
@@ -779,8 +779,6 @@ insert into hm_settings (settingname, settingstring, settinginteger) values ('Ss
 
 insert into hm_settings (settingname, settingstring, settinginteger) values ('ImapMasterUser', '', 0);
 
-insert into hm_settings (settingname, settingstring, settinginteger) values ('ImapAuthAllowPlainText', '', 0);
-
 insert into hm_settings (settingname, settingstring, settinginteger) values ('EnableImapSASLPlain', '', 0);
 
 insert into hm_settings (settingname, settingstring, settinginteger) values ('EnableImapSASLInitialResponse', '', 0);

--- a/hmailserver/source/DBScripts/Upgrade5601to5700MSSQL.sql
+++ b/hmailserver/source/DBScripts/Upgrade5601to5700MSSQL.sql
@@ -1,7 +1,5 @@
 insert into hm_settings (settingname, settingstring, settinginteger) values ('ImapMasterUser', '', 0)
 
-insert into hm_settings (settingname, settingstring, settinginteger) values ('ImapAuthAllowPlainText', '', 0)
-
 insert into hm_settings (settingname, settingstring, settinginteger) values ('EnableImapSASLPlain', '', 0)
 
 insert into hm_settings (settingname, settingstring, settinginteger) values ('EnableImapSASLInitialResponse', '', 0)

--- a/hmailserver/source/DBScripts/Upgrade5601to5700MSSQLCE.sql
+++ b/hmailserver/source/DBScripts/Upgrade5601to5700MSSQLCE.sql
@@ -1,7 +1,5 @@
 insert into hm_settings (settingname, settingstring, settinginteger) values ('ImapMasterUser', '', 0)
 
-insert into hm_settings (settingname, settingstring, settinginteger) values ('ImapAuthAllowPlainText', '', 0)
-
 insert into hm_settings (settingname, settingstring, settinginteger) values ('EnableImapSASLPlain', '', 0)
 
 insert into hm_settings (settingname, settingstring, settinginteger) values ('EnableImapSASLInitialResponse', '', 0)

--- a/hmailserver/source/DBScripts/Upgrade5601to5700MySQL.sql
+++ b/hmailserver/source/DBScripts/Upgrade5601to5700MySQL.sql
@@ -1,7 +1,5 @@
 insert into hm_settings (settingname, settingstring, settinginteger) values ('ImapMasterUser', '', 0);
 
-insert into hm_settings (settingname, settingstring, settinginteger) values ('ImapAuthAllowPlainText', '', 0);
-
 insert into hm_settings (settingname, settingstring, settinginteger) values ('EnableImapSASLPlain', '', 0);
 
 insert into hm_settings (settingname, settingstring, settinginteger) values ('EnableImapSASLInitialResponse', '', 0);

--- a/hmailserver/source/DBScripts/Upgrade5601to5700PGSQL.sql
+++ b/hmailserver/source/DBScripts/Upgrade5601to5700PGSQL.sql
@@ -1,7 +1,5 @@
 insert into hm_settings (settingname, settingstring, settinginteger) values ('ImapMasterUser', '', 0);
 
-insert into hm_settings (settingname, settingstring, settinginteger) values ('ImapAuthAllowPlainText', '', 0);
-
 insert into hm_settings (settingname, settingstring, settinginteger) values ('EnableImapSASLPlain', '', 0);
 
 insert into hm_settings (settingname, settingstring, settinginteger) values ('EnableImapSASLInitialResponse', '', 0);

--- a/hmailserver/source/Server/COM/InterfaceSettings.cpp
+++ b/hmailserver/source/Server/COM/InterfaceSettings.cpp
@@ -2522,39 +2522,6 @@ STDMETHODIMP InterfaceSettings::put_IMAPMasterUser(BSTR newVal)
    }
 }
 
-STDMETHODIMP InterfaceSettings::put_IMAPAuthAllowPlainText(VARIANT_BOOL newVal)
-{
-   try
-   {
-      if (!config_)
-         return GetAccessDenied();
-
-      config_->GetIMAPConfiguration()->SetIMAPAuthAllowPlainText(newVal == VARIANT_TRUE);
-      return S_OK;
-   }
-   catch (...)
-   {
-      return COMError::GenerateGenericMessage();
-   }
-}
-
-
-STDMETHODIMP InterfaceSettings::get_IMAPAuthAllowPlainText(VARIANT_BOOL *pVal)
-{
-   try
-   {
-      if (!config_)
-         return GetAccessDenied();
-
-      *pVal = config_->GetIMAPConfiguration()->GetIMAPAuthAllowPlainText() ? VARIANT_TRUE : VARIANT_FALSE;
-      return S_OK;
-   }
-   catch (...)
-   {
-      return COMError::GenerateGenericMessage();
-   }
-}
-
 STDMETHODIMP InterfaceSettings::put_IMAPSASLPlainEnabled(VARIANT_BOOL newVal)
 {
    try
@@ -2570,7 +2537,6 @@ STDMETHODIMP InterfaceSettings::put_IMAPSASLPlainEnabled(VARIANT_BOOL newVal)
       return COMError::GenerateGenericMessage();
    }
 }
-
 
 STDMETHODIMP InterfaceSettings::get_IMAPSASLPlainEnabled(VARIANT_BOOL *pVal)
 {

--- a/hmailserver/source/Server/COM/InterfaceSettings.h
+++ b/hmailserver/source/Server/COM/InterfaceSettings.h
@@ -234,9 +234,6 @@ END_COM_MAP()
    STDMETHOD(get_IMAPMasterUser)(/*[out, retval]*/ BSTR *pVal);
    STDMETHOD(put_IMAPMasterUser)(/*[in]*/ BSTR newVal);
 
-   STDMETHOD(get_IMAPAuthAllowPlainText)(/*[out, retval]*/ VARIANT_BOOL *pVal);
-   STDMETHOD(put_IMAPAuthAllowPlainText)(/*[in]*/ VARIANT_BOOL newVal);
-
    STDMETHOD(get_IMAPSASLPlainEnabled)(/*[out, retval]*/ VARIANT_BOOL *pVal);
    STDMETHOD(put_IMAPSASLPlainEnabled)(/*[in]*/ VARIANT_BOOL newVal);
 

--- a/hmailserver/source/Server/Common/Application/Constants.h
+++ b/hmailserver/source/Server/Common/Application/Constants.h
@@ -5,7 +5,6 @@
 #define PROPERTY_MAXSMTPCONNECTIONS             _T("maxsmtpconnections")
 #define PROPERTY_MIRROREMAILADDRESS             _T("mirroremailaddress")
 #define PROPERTY_AUTHALLOWPLAINTEXT             _T("authallowplaintext")
-#define PROPERTY_IMAPAUTHALLOWPLAINTEXT         _T("ImapAuthAllowPlainText")
 #define PROPERTY_ALLOWMAILFROMNULL              _T("allowmailfromnull")
 #define PROPERTY_LOGDEVICE                      _T("logdevice")
 #define PROPERTY_LOGGING                        _T("logging")

--- a/hmailserver/source/Server/IMAP/IMAPConfiguration.cpp
+++ b/hmailserver/source/Server/IMAP/IMAPConfiguration.cpp
@@ -134,13 +134,6 @@ namespace HM
       return GetSettings_()->GetString(PROPERTY_IMAPPUBLICFOLDERNAME);
    }
 
-
-   void
-      IMAPConfiguration::SetIMAPAuthAllowPlainText(bool newVal)
-   {
-      GetSettings_()->SetBool(PROPERTY_IMAPAUTHALLOWPLAINTEXT, newVal);
-   }
-
    String
    IMAPConfiguration::GetIMAPMasterUser() const
    {
@@ -151,12 +144,6 @@ namespace HM
    IMAPConfiguration::SetIMAPMasterUser(const String &newVal)
    {
       GetSettings_()->SetString(PROPERTY_IMAPMASTERUSER, newVal);
-   }
-
-   bool
-   IMAPConfiguration::GetIMAPAuthAllowPlainText() const
-   {
-      return GetSettings_()->GetBool(PROPERTY_IMAPAUTHALLOWPLAINTEXT);
    }
 
    void

--- a/hmailserver/source/Server/IMAP/IMAPConfiguration.h
+++ b/hmailserver/source/Server/IMAP/IMAPConfiguration.h
@@ -32,9 +32,6 @@ namespace HM
 
       bool GetUseIMAPACL() const;
       void SetUseIMAPACL(bool bValue);
-      
-      bool GetIMAPAuthAllowPlainText() const;
-      void SetIMAPAuthAllowPlainText(bool bValue);
 
       bool GetUseIMAPSASLPlain() const;
       void SetUseIMAPSASLPlain(bool bValue);

--- a/hmailserver/source/Server/hMailServer/hMailServer.idl
+++ b/hmailserver/source/Server/hMailServer/hMailServer.idl
@@ -670,30 +670,26 @@ interface IInterfaceSettings : IDispatch{
    [propget, id(100), helpstring("IMAP Master user")] HRESULT IMAPMasterUser([out, retval] BSTR *pVal);
    [propput, id(100), helpstring("IMAP Master user")] HRESULT IMAPMasterUser([in] BSTR newVal);
 
-   [propget, id(101), helpstring("IMAP Master user")] HRESULT IMAPAuthAllowPlainText([out, retval] VARIANT_BOOL *pVal);
-   [propput, id(101), helpstring("IMAP Master user")] HRESULT IMAPAuthAllowPlainText([in] VARIANT_BOOL newVal);
+   [propget, id(101), helpstring("IMAP Enable SASL Plain")] HRESULT IMAPSASLPlainEnabled([out, retval] VARIANT_BOOL *pVal);
+   [propput, id(101), helpstring("IMAP Enable SASL Plain")] HRESULT IMAPSASLPlainEnabled([in] VARIANT_BOOL newVal);
 
-
-   [propget, id(102), helpstring("IMAP Enable SASL Plain")] HRESULT IMAPSASLPlainEnabled([out, retval] VARIANT_BOOL *pVal);
-   [propput, id(102), helpstring("IMAP Enable SASL Plain")] HRESULT IMAPSASLPlainEnabled([in] VARIANT_BOOL newVal);
-
-   [propget, id(103), helpstring("IMAP Enable SASL Plain Initial Response")] HRESULT IMAPSASLInitialResponseEnabled([out, retval] VARIANT_BOOL *pVal);
-   [propput, id(103), helpstring("IMAP Enable SASL Plain Initial Response")] HRESULT IMAPSASLInitialResponseEnabled([in] VARIANT_BOOL newVal);
+   [propget, id(102), helpstring("IMAP Enable SASL Plain Initial Response")] HRESULT IMAPSASLInitialResponseEnabled([out, retval] VARIANT_BOOL *pVal);
+   [propput, id(102), helpstring("IMAP Enable SASL Plain Initial Response")] HRESULT IMAPSASLInitialResponseEnabled([in] VARIANT_BOOL newVal);
    
-   [propget, id(104), helpstring("Enable TLS version 1.3")] HRESULT TlsVersion13Enabled([out, retval] VARIANT_BOOL *pVal);
-   [propput, id(104), helpstring("Enable TLS version 1.3")] HRESULT TlsVersion13Enabled([in] VARIANT_BOOL newVal);
+   [propget, id(103), helpstring("Enable TLS version 1.3")] HRESULT TlsVersion13Enabled([out, retval] VARIANT_BOOL *pVal);
+   [propput, id(103), helpstring("Enable TLS version 1.3")] HRESULT TlsVersion13Enabled([in] VARIANT_BOOL newVal);
 
-   [propget, id(105), helpstring("Prefer IPv6 over IPv4.")] HRESULT IPv6PreferredEnabled([out, retval] VARIANT_BOOL* pVal);
-   [propput, id(105), helpstring("Prefer IPv6 over IPv4.")] HRESULT IPv6PreferredEnabled([in] VARIANT_BOOL newVal);
+   [propget, id(104), helpstring("Prefer IPv6 over IPv4.")] HRESULT IPv6PreferredEnabled([out, retval] VARIANT_BOOL *pVal);
+   [propput, id(104), helpstring("Prefer IPv6 over IPv4.")] HRESULT IPv6PreferredEnabled([in] VARIANT_BOOL newVal);
 
-   [propget, id(106), helpstring("Prefer server cipher order.")] HRESULT TlsOptionPreferServerCiphersEnabled([out, retval] VARIANT_BOOL *pVal);
-   [propput, id(106), helpstring("Prefer server cipher order.")] HRESULT TlsOptionPreferServerCiphersEnabled([in] VARIANT_BOOL newVal);
+   [propget, id(105), helpstring("Prefer server cipher order.")] HRESULT TlsOptionPreferServerCiphersEnabled([out, retval] VARIANT_BOOL *pVal);
+   [propput, id(105), helpstring("Prefer server cipher order.")] HRESULT TlsOptionPreferServerCiphersEnabled([in] VARIANT_BOOL newVal);
 
-   [propget, id(107), helpstring("Prioritize ChaCha20 ciphers when client prefers them.")] HRESULT TlsOptionPrioritizeChaChaEnabled([out, retval] VARIANT_BOOL *pVal);
-   [propput, id(107), helpstring("Prioritize ChaCha20 ciphers when client prefers them.")] HRESULT TlsOptionPrioritizeChaChaEnabled([in] VARIANT_BOOL newVal);
+   [propget, id(106), helpstring("Prioritize ChaCha20 ciphers when client prefers them.")] HRESULT TlsOptionPrioritizeChaChaEnabled([out, retval] VARIANT_BOOL *pVal);
+   [propput, id(106), helpstring("Prioritize ChaCha20 ciphers when client prefers them.")] HRESULT TlsOptionPrioritizeChaChaEnabled([in] VARIANT_BOOL newVal);
 
-   [propget, id(108), helpstring("Rewrite envelope From address to the forwarding account address when forwarding.")] HRESULT RewriteEnvelopeFromWhenForwarding([out, retval] VARIANT_BOOL *pVal);
-   [propput, id(108), helpstring("Rewrite envelope From address to the forwarding account address when forwarding.")] HRESULT RewriteEnvelopeFromWhenForwarding([in] VARIANT_BOOL newVal);
+   [propget, id(107), helpstring("Rewrite envelope From address to the forwarding account address when forwarding.")] HRESULT RewriteEnvelopeFromWhenForwarding([out, retval] VARIANT_BOOL *pVal);
+   [propput, id(107), helpstring("Rewrite envelope From address to the forwarding account address when forwarding.")] HRESULT RewriteEnvelopeFromWhenForwarding([in] VARIANT_BOOL newVal);
 
 };
 


### PR DESCRIPTION
Remove all orphaned ImapAuthAllowPlainText settings from code/sql, this is never used and replaced with IMAPSASLPlainEnabled