### PR TITLE
TLSOptions Config Fixes

### DIFF
--- a/hmailserver/source/Tools/Administrator/Main panes/ucSSLTLS.Designer.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucSSLTLS.Designer.cs
@@ -138,7 +138,7 @@ namespace hMailServer.Administrator
             this.labelOptions.Name = "labelOptions";
             this.labelOptions.Size = new System.Drawing.Size(43, 13);
             this.labelOptions.TabIndex = 25;
-            this.labelOptions.Text = "Options\r\n";
+            this.labelOptions.Text = "Options";
             //
             // checkTlsOptionPreferServerCiphersEnabled
             //
@@ -157,7 +157,7 @@ namespace hMailServer.Administrator
             this.checkTlsOptionPrioritizeChaChaEnabled.Name = "checkTlsOptionPrioritizeChaChaEnabled";
             this.checkTlsOptionPrioritizeChaChaEnabled.Size = new System.Drawing.Size(198, 17);
             this.checkTlsOptionPrioritizeChaChaEnabled.TabIndex = 27;
-            this.checkTlsOptionPrioritizeChaChaEnabled.Text = "Prioritize ChaCha20 for mobile clients";
+            this.checkTlsOptionPrioritizeChaChaEnabled.Text = "Prioritize ChaCha20-Poly1305 when client prefers it (requires TLS v1.2 or TLS v1.3)";
             this.checkTlsOptionPrioritizeChaChaEnabled.UseVisualStyleBackColor = true;
             //
             // ucSSLTLS

--- a/hmailserver/source/Tools/Administrator/Main panes/ucSSLTLS.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucSSLTLS.cs
@@ -46,7 +46,8 @@ namespace hMailServer.Administrator
            checkTlsVersion12.Checked = settings.TlsVersion12Enabled;
            checkTlsVersion13.Checked = settings.TlsVersion13Enabled;
            checkTlsOptionPreferServerCiphersEnabled.Checked = settings.TlsOptionPreferServerCiphersEnabled;
-           checkTlsOptionPrioritizeChaChaEnabled.Checked = settings.TlsOptionPrioritizeChaChaEnabled;
+           checkTlsOptionPrioritizeChaChaEnabled.Enabled = (settings.TlsVersion12Enabled || settings.TlsVersion13Enabled) && settings.TlsOptionPreferServerCiphersEnabled;
+           checkTlsOptionPrioritizeChaChaEnabled.Checked = settings.TlsOptionPrioritizeChaChaEnabled && (settings.TlsVersion12Enabled || settings.TlsVersion13Enabled) && settings.TlsOptionPreferServerCiphersEnabled;
 
            Marshal.ReleaseComObject(settings);
         }
@@ -67,7 +68,7 @@ namespace hMailServer.Administrator
            settings.TlsVersion12Enabled = checkTlsVersion12.Checked;
            settings.TlsVersion13Enabled = checkTlsVersion13.Checked;
            settings.TlsOptionPreferServerCiphersEnabled = checkTlsOptionPreferServerCiphersEnabled.Checked;
-           settings.TlsOptionPrioritizeChaChaEnabled = checkTlsOptionPrioritizeChaChaEnabled.Checked;
+           settings.TlsOptionPrioritizeChaChaEnabled = checkTlsOptionPrioritizeChaChaEnabled.Enabled && checkTlsOptionPrioritizeChaChaEnabled.Checked && (checkTlsVersion12.Checked || checkTlsVersion13.Checked) && checkTlsOptionPreferServerCiphersEnabled.Checked;
 
            Marshal.ReleaseComObject(settings);
 
@@ -88,6 +89,12 @@ namespace hMailServer.Administrator
         private void OnContentChanged()
         {
            Instances.MainForm.OnContentChanged();
+
+           checkTlsOptionPrioritizeChaChaEnabled.Enabled = (checkTlsVersion12.Checked || checkTlsVersion13.Checked) && checkTlsOptionPreferServerCiphersEnabled.Checked;
+           if (!checkTlsOptionPrioritizeChaChaEnabled.Enabled && checkTlsOptionPrioritizeChaChaEnabled.Checked)
+           {
+              checkTlsOptionPrioritizeChaChaEnabled.Checked = false;
+           }
         }
 
         private void OnContentChanged(object sender, EventArgs e)

--- a/hmailserver/source/WebAdmin/hm_ssltls.php
+++ b/hmailserver/source/WebAdmin/hm_ssltls.php
@@ -20,7 +20,7 @@ if($action == "save")
 	$obSettings->TlsVersion13Enabled = hmailGetVar("TlsVersion13Enabled", 0);
 
 	$obSettings->TlsOptionPreferServerCiphersEnabled = hmailGetVar("TlsOptionPreferServerCiphersEnabled", 0);
-	if (hmailGetVar("TlsVersion12Enabled", 0) > 0 || hmailGetVar("TlsVersion13Enabled", 0) > 0) {
+	if ((hmailGetVar("TlsVersion12Enabled", 0) > 0 || hmailGetVar("TlsVersion13Enabled", 0) > 0) && hmailGetVar("TlsOptionPreferServerCiphersEnabled", 0) > 0) {
 		$obSettings->TlsOptionPrioritizeChaChaEnabled = hmailGetVar("TlsOptionPrioritizeChaChaEnabled", 0);
 	}
 	else {
@@ -35,7 +35,7 @@ $TlsVersion11Enabled 		= $obSettings->TlsVersion11Enabled;
 $TlsVersion12Enabled 		= $obSettings->TlsVersion12Enabled;
 $TlsVersion13Enabled 		= $obSettings->TlsVersion13Enabled;
 $TlsOptionPreferServerCiphersEnabled		= $obSettings->TlsOptionPreferServerCiphersEnabled;
-$TlsOptionPrioritizeChaChaEnabled		= $obSettings->TlsOptionPrioritizeChaChaEnabled;
+$TlsOptionPrioritizeChaChaEnabled		= $obSettings->TlsOptionPrioritizeChaChaEnabled && ($obSettings->TlsVersion12Enabled || $obSettings->TlsVersion13Enabled) && $obSettings->TlsOptionPreferServerCiphersEnabled;
 ?>
 
 <h1><?php EchoTranslation("Security")?></h1>


### PR DESCRIPTION
The way i understand it, it should ONLY be possible to enable 'TlsOptionPrioritizeChaChaEnabled' when both 'TlsOptionPreferServerCiphersEnabled' AND TlsVersion12Enabled OR TlsVersion13Enabled are enabled, eg:

> When SSL_OP_CIPHER_SERVER_PREFERENCE is set, temporarily reprioritize ChaCha20-Poly1305 ciphers to the top of the server cipher list if a ChaCha20-Poly1305 cipher is at the top of the client cipher list. This helps those clients (e.g. mobile) use ChaCha20-Poly1305 if that cipher is anywhere in the server cipher list; but still allows other clients to use AES and other ciphers. Requires SSL_OP_CIPHER_SERVER_PREFERENCE.

ChaCha20-Poly1305 ciphers are only available in TLS 1.2 and 1.3