### PR TITLE
Message SpamFlag, optionally disable reply/forward when spam marked

### DIFF
--- a/hmailserver/source/DBScripts/CreateTablesMSSQL.sql
+++ b/hmailserver/source/DBScripts/CreateTablesMSSQL.sql
@@ -190,7 +190,9 @@ create table hm_accounts (
 	accountvacationexpires tinyint not null,
 	accountvacationexpiredate datetime not null,
 	accountpersonfirstname nvarchar(60) not null,
-	accountpersonlastname nvarchar(60) not null
+	accountpersonlastname nvarchar(60) not null,
+	accountvacationabortspamflagged tinyint not null,
+	accountforwardabortspamflagged tinyint not null
 ) 
 
 ALTER TABLE hm_accounts ADD CONSTRAINT hm_accounts_pk PRIMARY KEY NONCLUSTERED (accountid) 
@@ -512,7 +514,8 @@ create table hm_rule_actions
 	actionscriptfunction nvarchar(255) not null,
 	actionheader nvarchar(80) not null,
 	actionvalue nvarchar(255) not null,
-   actionrouteid int not null
+	actionrouteid int not null,
+	actionabortspamflagged tinyint not null
 ) 
 
 ALTER TABLE hm_rule_actions ADD CONSTRAINT hm_rule_actions_pk PRIMARY KEY NONCLUSTERED (actionid) 
@@ -958,4 +961,4 @@ insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2,
 
 insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2, portconnectionsecurity, portsslcertificateid) values (5, 143, 0, NULL, 0, 0) 
 
-insert into hm_dbversion values (5705)
+insert into hm_dbversion values (5708)

--- a/hmailserver/source/DBScripts/CreateTablesMYSQL.sql
+++ b/hmailserver/source/DBScripts/CreateTablesMYSQL.sql
@@ -92,7 +92,9 @@ create table hm_accounts
 	accountvacationexpires tinyint unsigned not null,
 	accountvacationexpiredate datetime not null,
 	accountpersonfirstname varchar(60) not null,
-	accountpersonlastname varchar(60) not null
+	accountpersonlastname varchar(60) not null,
+	accountvacationabortspamflagged tinyint not null,
+	accountforwardabortspamflagged tinyint not null
 ) DEFAULT CHARSET=utf8;
 
 CREATE INDEX idx_hm_accounts ON hm_accounts (accountaddress);
@@ -155,7 +157,7 @@ create table hm_messages
 	messagesize bigint not null,
 	messagecurnooftries int not null,
 	messagenexttrytime datetime not null,
-	messageflags tinyint not null,
+	messageflags tinyint unsigned not null,
 	messagecreatetime datetime not null,
 	messagelocked tinyint not null,
    messageuid bigint not null
@@ -368,7 +370,8 @@ create table hm_rule_actions
 	actionscriptfunction varchar(255) not null,
 	actionheader varchar(80) not null,
 	actionvalue varchar(255) not null,
-    actionrouteid int not null
+    actionrouteid int not null,
+	actionabortspamflagged tinyint not null
 ) DEFAULT CHARSET=utf8;
 
 CREATE INDEX idx_rules_actions ON hm_rule_actions (actionruleid);
@@ -783,4 +786,4 @@ insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2,
 
 insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2, portconnectionsecurity, portsslcertificateid) values (5, 143, 0, NULL, 0, 0);
 
-insert into hm_dbversion values (5705);
+insert into hm_dbversion values (5708);

--- a/hmailserver/source/DBScripts/CreateTablesPGSQL.sql
+++ b/hmailserver/source/DBScripts/CreateTablesPGSQL.sql
@@ -101,10 +101,12 @@ create table hm_accounts
 	accountsignatureplaintext text not null,
 	accountsignaturehtml text not null,
 	accountlastlogontime timestamp not null,
-	accountvacationexpires smallint  not null,
+	accountvacationexpires smallint not null,
 	accountvacationexpiredate timestamp not null,
 	accountpersonfirstname varchar(60) not null,
-	accountpersonlastname varchar(60) not null	
+	accountpersonlastname varchar(60) not null,	
+	accountvacationabortspamflagged smallint not null,
+	accountforwardabortspamflagged smallint not null
 );
 
 
@@ -383,7 +385,8 @@ create table hm_rule_actions
 	actionscriptfunction varchar(255) not null,
 	actionheader varchar(80) not null,
 	actionvalue varchar(255) not null,
-    actionrouteid int not null
+    actionrouteid int not null,
+	actionabortspamflagged smallint not null
 );
 
 CREATE INDEX idx_rules_actions ON hm_rule_actions (actionruleid);
@@ -799,4 +802,4 @@ insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2,
 
 insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2, portconnectionsecurity, portsslcertificateid) values (5, 143, 0, NULL, 0, 0);
 
-insert into hm_dbversion values (5705);
+insert into hm_dbversion values (5708);

--- a/hmailserver/source/DBScripts/Upgrade5705to5708MSSQL.sql
+++ b/hmailserver/source/DBScripts/Upgrade5705to5708MSSQL.sql
@@ -1,0 +1,7 @@
+alter table hm_accounts add accountvacationabortspamflagged tinyint not null default 0
+
+alter table hm_accounts add accountforwardabortspamflagged tinyint not null default 0
+
+alter table hm_rule_actions add actionabortspamflagged tinyint not null default 0
+
+update hm_dbversion set value = 5708

--- a/hmailserver/source/DBScripts/Upgrade5705to5708MSSQLCE.sql
+++ b/hmailserver/source/DBScripts/Upgrade5705to5708MSSQLCE.sql
@@ -1,0 +1,7 @@
+alter table hm_accounts add accountvacationabortspamflagged tinyint not null default 0
+
+alter table hm_accounts add accountforwardabortspamflagged tinyint not null default 0
+
+alter table hm_rule_actions add actionabortspamflagged tinyint not null default 0
+
+update hm_dbversion set value = 5708

--- a/hmailserver/source/DBScripts/Upgrade5705to5708MySQL.sql
+++ b/hmailserver/source/DBScripts/Upgrade5705to5708MySQL.sql
@@ -1,0 +1,9 @@
+alter table hm_accounts add column accountvacationabortspamflagged tinyint not null default 0;
+
+alter table hm_accounts add column accountforwardabortspamflagged tinyint not null default 0;
+
+alter table hm_rule_actions add column actionabortspamflagged tinyint not null default 0;
+
+alter table hm_messages modify column messageflags tinyint unsigned not null;
+
+update hm_dbversion set value = 5708;

--- a/hmailserver/source/DBScripts/Upgrade5705to5708PGSQL.sql
+++ b/hmailserver/source/DBScripts/Upgrade5705to5708PGSQL.sql
@@ -1,0 +1,7 @@
+alter table hm_accounts add column accountvacationabortspamflagged smallint not null default 0;
+
+alter table hm_accounts add column accountforwardabortspamflagged smallint not null default 0;
+
+alter table hm_rule_actions add column actionabortspamflagged smallint not null default 0;
+
+update hm_dbversion set value = 5708;

--- a/hmailserver/source/Server/COM/InterfaceAccount.cpp
+++ b/hmailserver/source/Server/COM/InterfaceAccount.cpp
@@ -659,6 +659,38 @@ STDMETHODIMP InterfaceAccount::put_VacationMessageExpiresDate(BSTR newVal)
    }
 }
 
+STDMETHODIMP InterfaceAccount::get_VacationMessageAbortSpamFlagged(VARIANT_BOOL *pVal)
+{
+   try
+   {
+      if (!object_)
+         return GetAccessDenied();
+
+      *pVal = object_->GetVacationAbortSpamFlagged() ? VARIANT_TRUE : VARIANT_FALSE;
+      return S_OK;
+   }
+   catch (...)
+   {
+      return COMError::GenerateGenericMessage();
+   }
+}
+
+STDMETHODIMP InterfaceAccount::put_VacationMessageAbortSpamFlagged(VARIANT_BOOL newVal)
+{
+   try
+   {
+      if (!object_)
+         return GetAccessDenied();
+
+      object_->SetVacationAbortSpamFlagged(newVal == VARIANT_TRUE);
+      return S_OK;   
+   }
+   catch (...)
+   {
+      return COMError::GenerateGenericMessage();
+   }
+}
+
 STDMETHODIMP InterfaceAccount::get_FetchAccounts(IInterfaceFetchAccounts **pVal)
 {
    try
@@ -929,6 +961,38 @@ STDMETHODIMP InterfaceAccount::put_ForwardKeepOriginal(VARIANT_BOOL newVal)
 
       object_->SetForwardKeepOriginal(newVal == VARIANT_TRUE);
       return S_OK;
+   }
+   catch (...)
+   {
+      return COMError::GenerateGenericMessage();
+   }
+}
+
+STDMETHODIMP InterfaceAccount::get_ForwardAbortSpamFlagged(VARIANT_BOOL *pVal)
+{
+   try
+   {
+      if (!object_)
+         return GetAccessDenied();
+
+      *pVal = object_->GetForwardAbortSpamFlagged() ? VARIANT_TRUE : VARIANT_FALSE;
+      return S_OK;
+   }
+   catch (...)
+   {
+      return COMError::GenerateGenericMessage();
+   }
+}
+
+STDMETHODIMP InterfaceAccount::put_ForwardAbortSpamFlagged(VARIANT_BOOL newVal)
+{
+   try
+   {
+      if (!object_)
+         return GetAccessDenied();
+
+      object_->SetForwardAbortSpamFlagged(newVal == VARIANT_TRUE);
+      return S_OK;   
    }
    catch (...)
    {

--- a/hmailserver/source/Server/COM/InterfaceAccount.h
+++ b/hmailserver/source/Server/COM/InterfaceAccount.h
@@ -107,7 +107,8 @@ public:
    STDMETHOD(put_VacationMessageExpires)(/*[in]*/ VARIANT_BOOL newVal);
    STDMETHOD(get_VacationMessageExpiresDate)(/*[out, retval]*/ BSTR *pVal);
    STDMETHOD(put_VacationMessageExpiresDate)(/*[in]*/ BSTR newVal);
-
+   STDMETHOD(get_VacationMessageAbortSpamFlagged)(/*[out, retval]*/ VARIANT_BOOL *pVal);
+   STDMETHOD(put_VacationMessageAbortSpamFlagged)(/*[in]*/ VARIANT_BOOL newVal);
 
 
    STDMETHOD(get_AdminLevel)(/*[out, retval]*/ eAdminLevel *pVal);
@@ -125,6 +126,8 @@ public:
    STDMETHOD(put_ForwardAddress)(/*[in]*/ BSTR newVal);
    STDMETHOD(get_ForwardKeepOriginal)(/*[out, retval]*/ VARIANT_BOOL *pVal);
    STDMETHOD(put_ForwardKeepOriginal)(/*[in]*/ VARIANT_BOOL newVal);
+   STDMETHOD(get_ForwardAbortSpamFlagged)(/*[out, retval]*/ VARIANT_BOOL *pVal);
+   STDMETHOD(put_ForwardAbortSpamFlagged)(/*[in]*/ VARIANT_BOOL newVal);
 
    STDMETHOD(get_SignatureEnabled)(/*[out, retval]*/ VARIANT_BOOL *pVal);
    STDMETHOD(put_SignatureEnabled)(/*[in]*/ VARIANT_BOOL newVal);

--- a/hmailserver/source/Server/COM/InterfaceRuleAction.cpp
+++ b/hmailserver/source/Server/COM/InterfaceRuleAction.cpp
@@ -535,6 +535,38 @@ STDMETHODIMP InterfaceRuleAction::put_Value(BSTR newVal)
    }
 }
 
+STDMETHODIMP InterfaceRuleAction::get_AbortSpamFlagged(VARIANT_BOOL *pVal)
+{
+   try
+   {
+      if (!object_)
+         return GetAccessDenied();
+
+      *pVal = object_->GetAbortSpamFlagged() ? VARIANT_TRUE : VARIANT_FALSE;
+      return S_OK;
+   }
+   catch (...)
+   {
+      return COMError::GenerateGenericMessage();
+   }
+}
+
+STDMETHODIMP InterfaceRuleAction::put_AbortSpamFlagged(VARIANT_BOOL newVal)
+{
+   try
+   {
+      if (!object_)
+         return GetAccessDenied();
+
+      object_->SetAbortSpamFlagged(newVal == VARIANT_TRUE);
+      return S_OK;
+   }
+   catch (...)
+   {
+      return COMError::GenerateGenericMessage();
+   }
+}
+
 STDMETHODIMP InterfaceRuleAction::Delete()
 {
    try

--- a/hmailserver/source/Server/COM/InterfaceRuleAction.h
+++ b/hmailserver/source/Server/COM/InterfaceRuleAction.h
@@ -93,6 +93,9 @@ public:
 
    STDMETHOD(get_Value)(BSTR* pVal);
    STDMETHOD(put_Value)(BSTR pVal);
+
+   STDMETHOD(get_AbortSpamFlagged)(/*[out, retval]*/ VARIANT_BOOL *pVal);
+   STDMETHOD(put_AbortSpamFlagged)(/*[in]*/ VARIANT_BOOL newVal);
 };
 
 OBJECT_ENTRY_AUTO(__uuidof(RuleAction), InterfaceRuleAction)

--- a/hmailserver/source/Server/Common/Application/Constants.h
+++ b/hmailserver/source/Server/Common/Application/Constants.h
@@ -136,4 +136,4 @@
 
 #define PROPERTY_TLSOPTIONS                     _T("TlsOptions")
 
-#define REQUIRED_DB_VERSION            5705
+#define REQUIRED_DB_VERSION            5708

--- a/hmailserver/source/Server/Common/BO/Account.cpp
+++ b/hmailserver/source/Server/Common/BO/Account.cpp
@@ -33,7 +33,9 @@ namespace HM
       password_encryption_(0),
       admin_level_(NormalUser),
       enable_signature_(false),
-      vacation_expires_(false)
+      vacation_expires_(false),
+      vacation_abort_spam_flagged_(false),
+      forward_abort_spam_flagged_(false)
    {
       Initialize();
    }
@@ -50,7 +52,9 @@ namespace HM
       password_encryption_(0),
       admin_level_(adminLevel),
       enable_signature_(false),
-      vacation_expires_(false)
+      vacation_expires_(false),
+      vacation_abort_spam_flagged_(false),
+      forward_abort_spam_flagged_(false)
    {
       Initialize();
    }
@@ -84,11 +88,13 @@ namespace HM
       vacation_subject_ = oldAccount.vacation_subject_;
       vacation_expires_ = oldAccount.vacation_expires_;
       vacation_expires_date_ = oldAccount.vacation_expires_date_;
+      vacation_abort_spam_flagged_ = oldAccount.vacation_abort_spam_flagged_;
       signature_plain_text_ = oldAccount.signature_plain_text_;
       signature_html_ = oldAccount.signature_html_;
       forward_address_ = oldAccount.forward_address_;
       forward_enabled_ = oldAccount.forward_enabled_;
       forward_keep_original_ = oldAccount.forward_keep_original_;
+      forward_abort_spam_flagged_ = oldAccount.forward_abort_spam_flagged_;
       active_ = oldAccount.active_;
       is_ad_ = oldAccount.is_ad_;
       vacation_message_is_on_ = oldAccount.vacation_message_is_on_;
@@ -292,11 +298,13 @@ namespace HM
       pNode->AppendAttr(_T("VacationSubject"), vacation_subject_);
       pNode->AppendAttr(_T("VacationExpires"), vacation_expires_ ? _T("1") : _T("0"));
       pNode->AppendAttr(_T("VacationExpireDate"), vacation_expires_date_);
+      pNode->AppendAttr(_T("VacationAbortSpamFlagged"), vacation_abort_spam_flagged_ ? _T("1") : _T("0"));
       pNode->AppendAttr(_T("AdminLevel"), StringParser::IntToString(admin_level_));
       
       pNode->AppendAttr(_T("ForwardEnabled"), forward_enabled_ ? _T("1") : _T("0"));
       pNode->AppendAttr(_T("ForwardAddress"), String(forward_address_));
       pNode->AppendAttr(_T("ForwardKeepOriginal"), forward_keep_original_ ? _T("1") : _T("0"));
+      pNode->AppendAttr(_T("ForwardAbortSpamFlagged"), forward_abort_spam_flagged_ ? _T("1") : _T("0"));
 
       pNode->AppendAttr(_T("EnableSignature"), enable_signature_ ? _T("1") : _T("0"));
       pNode->AppendAttr(_T("SignaturePlainText"), signature_plain_text_);
@@ -344,6 +352,7 @@ namespace HM
       vacation_subject_ = pAccountNode->GetAttrValue(_T("VacationSubject"));
       vacation_expires_ = (pAccountNode->GetAttrValue(_T("VacationExpires")) == _T("1"));
       vacation_expires_date_ = pAccountNode->GetAttrValue(_T("VacationExpireDate"));
+      vacation_abort_spam_flagged_ = (pAccountNode->GetAttrValue(_T("VacationAbortSpamFlagged")) == _T("1"));
 
       admin_level_ = (AdminLevel) _ttoi(pAccountNode->GetAttrValue(_T("AdminLevel")));
      
@@ -352,6 +361,7 @@ namespace HM
       forward_enabled_ = (pAccountNode->GetAttrValue(_T("ForwardEnabled")) == _T("1"));
       forward_address_ = pAccountNode->GetAttrValue(_T("ForwardAddress"));
       forward_keep_original_ = (pAccountNode->GetAttrValue(_T("ForwardKeepOriginal")) == _T("1"));
+      forward_abort_spam_flagged_ = (pAccountNode->GetAttrValue(_T("ForwardAbortSpamFlagged")) == _T("1"));
 
       signature_plain_text_ = pAccountNode->GetAttrValue(_T("SignaturePlainText"));
       signature_html_ = pAccountNode->GetAttrValue(_T("SignatureHTML"));

--- a/hmailserver/source/Server/Common/BO/Account.h
+++ b/hmailserver/source/Server/Common/BO/Account.h
@@ -71,6 +71,9 @@ namespace HM
       String GetVacationExpiresDate() const{return vacation_expires_date_; }
       void SetVacationExpiresDate(const String &sNewVal) {vacation_expires_date_ = sNewVal;}
 
+      bool GetVacationAbortSpamFlagged() const { return vacation_abort_spam_flagged_; }
+      void SetVacationAbortSpamFlagged(bool bNewVal) { vacation_abort_spam_flagged_ = bNewVal; }
+
 
       AdminLevel GetAdminLevel() const{return admin_level_;}
       void SetAdminLevel(AdminLevel iNewVal) {admin_level_ = iNewVal; }
@@ -97,6 +100,9 @@ namespace HM
       
       bool GetForwardKeepOriginal() const;
       void SetForwardKeepOriginal(bool bEnabled);
+
+      bool GetForwardAbortSpamFlagged() const { return forward_abort_spam_flagged_; }
+      void SetForwardAbortSpamFlagged(bool bNewVal) { forward_abort_spam_flagged_ = bNewVal; }
 
       bool GetEnableSignature() const;
       void SetEnableSignature(bool bEnabled);
@@ -138,6 +144,7 @@ namespace HM
       String vacation_subject_;
       bool vacation_expires_;
       String vacation_expires_date_;
+      bool vacation_abort_spam_flagged_;
       
       String signature_plain_text_;
       String signature_html_;
@@ -145,6 +152,7 @@ namespace HM
       AnsiString forward_address_;
       bool forward_enabled_;
       bool forward_keep_original_;
+      bool forward_abort_spam_flagged_;
       bool active_;
       bool is_ad_;
       bool vacation_message_is_on_;

--- a/hmailserver/source/Server/Common/BO/Message.cpp
+++ b/hmailserver/source/Server/Common/BO/Message.cpp
@@ -184,6 +184,17 @@ namespace HM
       SetFlag_(FlagVirusScan, bNewVal);
    }
 
+   bool 
+   Message::GetFlagSpam() const
+   {
+      return GetFlag_(FlagSpam);
+   }
+
+   void 
+   Message::SetFlagSpam(bool bNewVal)
+   {
+      SetFlag_(FlagSpam, bNewVal);
+   }
 
    bool 
    Message::XMLStore(XNode *pParentNode, int iOptions)

--- a/hmailserver/source/Server/Common/BO/Message.h
+++ b/hmailserver/source/Server/Common/BO/Message.h
@@ -27,7 +27,8 @@ namespace HM
          FlagAnswered = 8,
          FlagDraft = 16,
          FlagRecent = 32,
-         FlagVirusScan = 64
+         FlagVirusScan = 64,
+         FlagSpam = 128
       };
 
 	   Message(bool generateFileName);
@@ -79,7 +80,8 @@ namespace HM
       void SetFlagRecent(bool bNewVal);
       bool GetFlagVirusScan() const;
       void SetFlagVirusScan(bool bNewVal);
-
+      bool GetFlagSpam() const;
+      void SetFlagSpam(bool bNewVal);
 
       void SetNoOfRetries(unsigned short lNewVal) {no_of_retries_ = lNewVal; }
       unsigned short GetNoOfRetries() const { return no_of_retries_;}

--- a/hmailserver/source/Server/Common/BO/RuleAction.cpp
+++ b/hmailserver/source/Server/Common/BO/RuleAction.cpp
@@ -15,7 +15,8 @@ namespace HM
       type_(Unknown),
       rule_id_(0),
       sort_order_(0),
-      route_id_(0)
+      route_id_(0),
+      abort_spam_flagged_(false)
    {
    }
 
@@ -42,6 +43,7 @@ namespace HM
       pNode->AppendAttr(_T("Header"), header_name_);
       pNode->AppendAttr(_T("Value"), value_);
       pNode->AppendAttr(_T("RouteID"), StringParser::IntToString(route_id_));
+      pNode->AppendAttr(_T("AbortSpamFlagged"), abort_spam_flagged_ ? _T("1") : _T("0"));
 
       return true;
    }
@@ -62,6 +64,7 @@ namespace HM
       header_name_ = pNode->GetAttrValue(_T("Header"));
       value_ = pNode->GetAttrValue(_T("Value"));
       route_id_ = _ttoi(pNode->GetAttrValue(_T("RouteID")));
+      abort_spam_flagged_ = (pNode->GetAttrValue(_T("AbortSpamFlagged")) == _T("1"));
 
       return true;
    }

--- a/hmailserver/source/Server/Common/BO/RuleAction.h
+++ b/hmailserver/source/Server/Common/BO/RuleAction.h
@@ -62,6 +62,9 @@ namespace HM
       String GetScriptFunction() const {return script_function_; }
       void SetScriptFunction(const String &sNewVal) {script_function_ = sNewVal; }
 
+      bool GetAbortSpamFlagged() const { return abort_spam_flagged_; }
+      void SetAbortSpamFlagged(bool bNewVal) { abort_spam_flagged_ = bNewVal; }
+
       bool XMLStore(XNode *pRuleNode, int iOptions);
       bool XMLLoad(XNode *pNode, int iOptions);
       bool XMLLoadSubItems(XNode *pNode, int iOptions) {return true;};
@@ -92,5 +95,6 @@ namespace HM
       String filename_;
       String to_;
       String script_function_;
+      bool abort_spam_flagged_;
    };
 }

--- a/hmailserver/source/Server/Common/Persistence/PersistentAccount.cpp
+++ b/hmailserver/source/Server/Common/Persistence/PersistentAccount.cpp
@@ -161,6 +161,7 @@ namespace HM
       pAccount->SetVacationMessage(pRS->GetStringValue("accountvacationmessage"));
       pAccount->SetVacationSubject(pRS->GetStringValue("accountvacationsubject"));
       pAccount->SetVacationExpires(pRS->GetLongValue("accountvacationexpires") ? true : false);
+      pAccount->SetVacationAbortSpamFlagged(pRS->GetLongValue("accountvacationabortspamflagged") ? true : false);
 
       String sVacationExpiresDate = pRS->GetStringValue("accountvacationexpiredate");
       if (sVacationExpiresDate.Left(4) != _T("0000"))
@@ -169,6 +170,7 @@ namespace HM
       pAccount->SetForwardEnabled(pRS->GetLongValue("accountforwardenabled") ? true : false);
       pAccount->SetForwardAddress(pRS->GetStringValue("accountforwardaddress"));
       pAccount->SetForwardKeepOriginal(pRS->GetLongValue("accountforwardkeeporiginal") ? true : false);
+      pAccount->SetForwardAbortSpamFlagged(pRS->GetLongValue("accountforwardabortspamflagged") ? true : false);
 
       pAccount->SetPasswordEncryption(pRS->GetLongValue("accountpwencryption"));
 
@@ -273,6 +275,7 @@ namespace HM
       oStatement.AddColumn("accountvacationsubject", pAccount->GetVacationSubject());
       oStatement.AddColumn("accountvacationexpires", pAccount->GetVacationExpires());
       oStatement.AddColumn("accountvacationexpiredate", pAccount->GetVacationExpiresDate());
+      oStatement.AddColumn("accountvacationabortspamflagged", pAccount->GetVacationAbortSpamFlagged());
 
       oStatement.AddColumn("accountpwencryption", pAccount->GetPasswordEncryption());
       oStatement.AddColumn("accountadminlevel", pAccount->GetAdminLevel());
@@ -280,6 +283,7 @@ namespace HM
       oStatement.AddColumn("accountforwardenabled", pAccount->GetForwardEnabled());
       oStatement.AddColumn("accountforwardaddress", pAccount->GetForwardAddress());
       oStatement.AddColumn("accountforwardkeeporiginal", pAccount->GetForwardKeepOriginal());
+      oStatement.AddColumn("accountforwardabortspamflagged", pAccount->GetForwardAbortSpamFlagged());
 
       oStatement.AddColumn("accountenablesignature", pAccount->GetEnableSignature());
       oStatement.AddColumn("accountsignatureplaintext", pAccount->GetSignaturePlainText());

--- a/hmailserver/source/Server/Common/Persistence/PersistentRuleAction.cpp
+++ b/hmailserver/source/Server/Common/Persistence/PersistentRuleAction.cpp
@@ -56,6 +56,7 @@ namespace HM
       pRuleAction->SetHeaderName(pRS->GetStringValue("actionheader"));
       pRuleAction->SetValue(pRS->GetStringValue("actionvalue"));
       pRuleAction->SetRouteID(pRS->GetLongValue("actionrouteid"));
+      pRuleAction->SetAbortSpamFlagged(pRS->GetLongValue("actionabortspamflagged") ? true : false);
 
       return true;
    }
@@ -104,6 +105,7 @@ namespace HM
       oStatement.AddColumn("actionheader", pRuleAction->GetHeaderName());
       oStatement.AddColumn("actionvalue", pRuleAction->GetValue());
       oStatement.AddColumnInt64("actionrouteid", pRuleAction->GetRouteID());
+      oStatement.AddColumn("actionabortspamflagged", pRuleAction->GetAbortSpamFlagged());
 
       // Save and fetch ID
       __int64 iDBID = 0;

--- a/hmailserver/source/Server/ExternalFetcher/POP3ClientConnection.cpp
+++ b/hmailserver/source/Server/ExternalFetcher/POP3ClientConnection.cpp
@@ -835,17 +835,25 @@ namespace HM
       setSpamTestResults.insert(setResult.begin(), setResult.end());
       
       int iTotalSpamScore = SpamProtection::CalculateTotalSpamScore(setSpamTestResults);
+      int iSpamDeleteThreshold = Configuration::Instance()->GetAntiSpamConfiguration().GetSpamDeleteThreshold();
+      int iSpamMarkThreshold = Configuration::Instance()->GetAntiSpamConfiguration().GetSpamMarkThreshold();
 
-      if (iTotalSpamScore >= Configuration::Instance()->GetAntiSpamConfiguration().GetSpamDeleteThreshold())
+      if (iSpamDeleteThreshold > 0 && iTotalSpamScore >= iSpamDeleteThreshold)
       {
+         // Increase the spam-counter
+         ServerStatus::Instance()->OnSpamMessageDetected();
+
          FileUtilities::DeleteFile(fileName);
          return false;
       }
       
-      bool classifiedAsSpam = iTotalSpamScore >= Configuration::Instance()->GetAntiSpamConfiguration().GetSpamMarkThreshold();
-      
+      bool classifiedAsSpam = iSpamMarkThreshold > 0 && iTotalSpamScore >= iSpamMarkThreshold;
+
       if (classifiedAsSpam)
       {
+         // Set message SPAM Flag
+         current_message_->SetFlagSpam(classifiedAsSpam);
+
          std::shared_ptr<MessageData> messageData = SpamProtection::AddSpamScoreHeaders(current_message_, setSpamTestResults, classifiedAsSpam);
          
          // Increase the spam-counter

--- a/hmailserver/source/Server/SMTP/LocalDelivery.cpp
+++ b/hmailserver/source/Server/SMTP/LocalDelivery.cpp
@@ -345,9 +345,16 @@ namespace HM
       if (!PersistentAccount::GetIsVacationMessageOn(pAccount))
          return;
 
-      // Don't deliver vacation message to ourselvs.
+      // Don't deliver vacation message to ourselves.
       if (pAccount->GetAddress().CompareNoCase(pMessage->GetFromAddress()) == 0)
          return;
+
+      // Don't deliver vacation message when the message is classified as spam
+      if (pAccount->GetVacationAbortSpamFlagged() && pMessage->GetFlagSpam())
+      {
+         LOG_DEBUG("LocalDelivery::SendAutoReplyMessage_ aborted, message marked as spam");
+         return;
+      }
 
       // Save a new message with the vacation message in it.
       SMTPVacationMessageCreator::Instance()->CreateVacationMessage(pAccount, 

--- a/hmailserver/source/Server/SMTP/RuleApplier.cpp
+++ b/hmailserver/source/Server/SMTP/RuleApplier.cpp
@@ -20,7 +20,6 @@
 #include "../Common/Cache/CacheContainer.h"
 #include "../Common/Util/Time.h"
 #include "../Common/Util/RegularExpression.h"
-#include "../common/Util/MailerDaemonAddressDeterminer.h"
 
 #include "../Common/Persistence/PersistentMessage.h"
 
@@ -229,6 +228,17 @@ namespace HM
          return;
       }
 
+      std::shared_ptr<Message> pOriginalMessage = pMsgData->GetMessage();
+
+      if (!pOriginalMessage)
+         return;
+
+      if (pOriginalMessage->GetFlagSpam() && pAction->GetAbortSpamFlagged())
+      {
+         LOG_DEBUG("RuleApplier::ApplyAction_Forward aborted, message marked as spam");
+         return; // skip message flagged as spam
+      }
+
       std::shared_ptr<Message> pMsg = PersistentMessage::CopyToQueue(account, pMsgData->GetMessage());
 
       if (!pMsg)
@@ -401,7 +411,16 @@ namespace HM
 	      return;
       }
 
-      std::shared_ptr<Account> emptyAccount;
+      std::shared_ptr<Message> pOriginalMessage = pMsgData->GetMessage();
+
+      if (!pOriginalMessage)
+         return;
+
+      if (pOriginalMessage->GetFlagSpam() && pAction->GetAbortSpamFlagged())
+      {
+         LOG_DEBUG("RuleApplier::ApplyAction_Reply aborted, message marked as spam");
+         return; // skip message flagged as spam
+      }
 
       // Reply to the email
       std::shared_ptr<Message> pMsg = std::shared_ptr<Message>(new Message());

--- a/hmailserver/source/Server/SMTP/SMTPConnection.cpp
+++ b/hmailserver/source/Server/SMTP/SMTPConnection.cpp
@@ -826,12 +826,12 @@ namespace HM
       }
 
       int iTotalSpamScore = SpamProtection::CalculateTotalSpamScore(spam_test_results_);
+      int iSpamDeleteThreshold = Configuration::Instance()->GetAntiSpamConfiguration().GetSpamDeleteThreshold();
+      int iSpamMarkThreshold = Configuration::Instance()->GetAntiSpamConfiguration().GetSpamMarkThreshold();
 
-      int deleteThreshold = Configuration::Instance()->GetAntiSpamConfiguration().GetSpamDeleteThreshold();
-      int markThreshold = Configuration::Instance()->GetAntiSpamConfiguration().GetSpamMarkThreshold();
-
-      if (deleteThreshold > 0 && iTotalSpamScore >= deleteThreshold)
+      if (iSpamDeleteThreshold > 0 && iTotalSpamScore >= iSpamDeleteThreshold)
       {
+         // Increase the spam-counter
          ServerStatus::Instance()->OnSpamMessageDetected();
 
          // Generate a text string to send to the client.
@@ -848,7 +848,7 @@ namespace HM
 
          return false;
       }
-      else if (markThreshold > 0 && iTotalSpamScore >= markThreshold)
+      else if (iSpamMarkThreshold > 0 && iTotalSpamScore >= iSpamMarkThreshold)
       {
          // This message is spam, but we shouldn't delete it. Instead, we will add spam headers to it.
          return true;
@@ -1193,9 +1193,13 @@ namespace HM
       int iTotalSpamScore = SpamProtection::CalculateTotalSpamScore(spam_test_results_);
       int iSpamMarkThreshold = Configuration::Instance()->GetAntiSpamConfiguration().GetSpamMarkThreshold();
 
-      bool classifiedAsSpam = iTotalSpamScore >= iSpamMarkThreshold;
+      bool classifiedAsSpam = iSpamMarkThreshold > 0 && iTotalSpamScore >= iSpamMarkThreshold;
+      
+      if (classifiedAsSpam) 
+      {
+         // Set message SPAM Flag
+         current_message_->SetFlagSpam(classifiedAsSpam);
 
-      if (classifiedAsSpam) {
          pMsgData = SpamProtection::AddSpamScoreHeaders(current_message_, spam_test_results_, classifiedAsSpam);
 
          // Increase the spam-counter

--- a/hmailserver/source/Server/SMTP/SMTPForwarding.cpp
+++ b/hmailserver/source/Server/SMTP/SMTPForwarding.cpp
@@ -39,6 +39,13 @@ namespace HM
          return true;
       }
 
+      // Don't forward when the message is classified as spam
+      if (pRecipientAccount->GetForwardAbortSpamFlagged() && pOriginalMessage->GetFlagSpam())
+      {
+         LOG_DEBUG("SMTPForwarding::PerformForwarding aborted, message marked as spam");
+         return true;
+      }
+
       if (!pRecipientAccount->GetForwardAddress().CompareNoCase(pRecipientAccount->GetAddress()))
       {
          ErrorManager::Instance()->ReportError(ErrorManager::Medium, 4334, "SMTPDeliverer::_ApplyForwarding", "Could not forward message since target address as same as account address.");

--- a/hmailserver/source/Server/SMTP/SMTPVacationMessageCreator.cpp
+++ b/hmailserver/source/Server/SMTP/SMTPVacationMessageCreator.cpp
@@ -96,7 +96,6 @@ namespace HM
       pNewMsgData->LoadFromMessage(newFileName, pMsg);
       
       // Required headers
-      pNewMsgData->SetReturnPath(recipientAccount->GetAddress());
       pNewMsgData->GenerateMessageID();
       pNewMsgData->SetSentTime(Time::GetCurrentMimeDate());
       pNewMsgData->SetFieldValue("Content-Type", "text/plain; charset=\"utf-8\"");

--- a/hmailserver/source/Server/hMailServer/hMailServer.idl
+++ b/hmailserver/source/Server/hMailServer/hMailServer.idl
@@ -402,6 +402,8 @@ typedef
 	eMFRecent = 32,
 	[helpstring("Virus scan")] 
 	eMFVirusScan = 64,
+    [helpstring("Spam")]
+    eMFSpam = 128,
 } eMessageFlag;
 
 typedef
@@ -875,6 +877,11 @@ interface IInterfaceAccount : IDispatch
 	[propget, id(36), helpstring("Last name of the account holder.")] HRESULT PersonLastName([out, retval] BSTR *pVal);
 	[propput, id(36), helpstring("Last name of the account holder.")] HRESULT PersonLastName([in] BSTR newVal);
    [id(37), helpstring("Deletes the account from the database.")] HRESULT Delete();
+   
+    [propget, id(38), helpstring("Vacation message is set to be aborted on messages marked as spam.")] HRESULT VacationMessageAbortSpamFlagged([out, retval] VARIANT_BOOL *pVal);
+    [propput, id(38), helpstring("Vacation message is set to be aborted on messages marked as spam.")] HRESULT VacationMessageAbortSpamFlagged([in] VARIANT_BOOL newVal);
+    [propget, id(39), helpstring("Forwarding is set to be aborted on messages marked as spam.")] HRESULT ForwardAbortSpamFlagged([out, retval] VARIANT_BOOL *pVal);
+    [propput, id(39), helpstring("Forwarding is set to be aborted on messages marked as spam.")] HRESULT ForwardAbortSpamFlagged([in] VARIANT_BOOL newVal);
 };
 
 
@@ -1868,7 +1875,9 @@ interface IInterfaceRuleAction : IDispatch
    [propput, id(16), helpstring("Value")] HRESULT Value([in] BSTR newVal);   
    [id(17), helpstring("Deletes the object from the database.")] HRESULT Delete();
    [propget, id(18), helpstring("Route ID to deliver via")] HRESULT RouteID([out, retval] LONG* pVal);
-   [propput, id(18), helpstring("Route ID to deliver via")] HRESULT RouteID([in] LONG newVal);   
+   [propput, id(18), helpstring("Route ID to deliver via")] HRESULT RouteID([in] LONG newVal);
+   [propget, id(19), helpstring("Abort on messages marked as spam.")] HRESULT AbortSpamFlagged([out, retval] VARIANT_BOOL* pVal);
+   [propput, id(19), helpstring("Abort on messages marked as spam.")] HRESULT AbortSpamFlagged([in] VARIANT_BOOL newVal);
 };
 
 [

--- a/hmailserver/source/Tools/Administrator/Dialogs/formRuleAction.Designer.cs
+++ b/hmailserver/source/Tools/Administrator/Dialogs/formRuleAction.Designer.cs
@@ -61,6 +61,8 @@ namespace hMailServer.Administrator.Dialogs
          this.labelIPAddress = new System.Windows.Forms.Label();
          this.comboRouteName = new hMailServer.Administrator.Controls.ucComboBox();
          this.comboAction = new hMailServer.Administrator.Controls.ucComboBox();
+         this.checkForwardAbortSpamFlagged = new hMailServer.Administrator.Controls.ucCheckbox();
+         this.checkReplyAbortSpamFlagged = new hMailServer.Administrator.Controls.ucCheckbox();
          this.panelForward.SuspendLayout();
          this.panelIMAP.SuspendLayout();
          this.panelScriptFunction.SuspendLayout();
@@ -72,6 +74,7 @@ namespace hMailServer.Administrator.Dialogs
          // 
          // panelForward
          // 
+         this.panelForward.Controls.Add(this.checkForwardAbortSpamFlagged);
          this.panelForward.Controls.Add(this.textForwardTo);
          this.panelForward.Controls.Add(this.labelForwardTo);
          this.panelForward.Location = new System.Drawing.Point(7, 34);
@@ -126,6 +129,7 @@ namespace hMailServer.Administrator.Dialogs
          // 
          // panelReply
          // 
+         this.panelReply.Controls.Add(this.checkReplyAbortSpamFlagged);
          this.panelReply.Controls.Add(this.textActionBody);
          this.panelReply.Controls.Add(this.label1);
          this.panelReply.Controls.Add(this.textActionSubject);
@@ -136,13 +140,13 @@ namespace hMailServer.Administrator.Dialogs
          this.panelReply.Controls.Add(this.labelFromName);
          this.panelReply.Location = new System.Drawing.Point(287, 362);
          this.panelReply.Name = "panelReply";
-         this.panelReply.Size = new System.Drawing.Size(274, 258);
+         this.panelReply.Size = new System.Drawing.Size(274, 268);
          this.panelReply.TabIndex = 4;
          // 
          // label1
          // 
          this.label1.AutoSize = true;
-         this.label1.Location = new System.Drawing.Point(13, 138);
+         this.label1.Location = new System.Drawing.Point(10, 138);
          this.label1.Name = "label1";
          this.label1.Size = new System.Drawing.Size(31, 13);
          this.label1.TabIndex = 6;
@@ -203,6 +207,26 @@ namespace hMailServer.Administrator.Dialogs
          this.labelHeaderName.Size = new System.Drawing.Size(71, 13);
          this.labelHeaderName.TabIndex = 0;
          this.labelHeaderName.Text = "Header name";
+         // 
+         // checkForwardAbortSpamFlagged
+         // 
+         this.checkForwardAbortSpamFlagged.AutoSize = true;
+         this.checkForwardAbortSpamFlagged.Location = new System.Drawing.Point(13, 54);
+         this.checkForwardAbortSpamFlagged.Name = "checkForwardAbortSpamFlagged";
+         this.checkForwardAbortSpamFlagged.Size = new System.Drawing.Size(196, 17);
+         this.checkForwardAbortSpamFlagged.TabIndex = 2;
+         this.checkForwardAbortSpamFlagged.Text = "Abort on messages marked as spam";
+         this.checkForwardAbortSpamFlagged.UseVisualStyleBackColor = true;
+         // 
+         // checkReplyAbortSpamFlagged
+         // 
+         this.checkReplyAbortSpamFlagged.AutoSize = true;
+         this.checkReplyAbortSpamFlagged.Location = new System.Drawing.Point(13, 248);
+         this.checkReplyAbortSpamFlagged.Name = "checkReplyAbortSpamFlagged";
+         this.checkReplyAbortSpamFlagged.Size = new System.Drawing.Size(196, 17);
+         this.checkReplyAbortSpamFlagged.TabIndex = 8;
+         this.checkReplyAbortSpamFlagged.Text = "Abort on messages marked as spam";
+         this.checkReplyAbortSpamFlagged.UseVisualStyleBackColor = true;
          // 
          // groupBox1
          // 
@@ -271,7 +295,7 @@ namespace hMailServer.Administrator.Dialogs
          // 
          // textActionBody
          // 
-         this.textActionBody.Location = new System.Drawing.Point(16, 154);
+         this.textActionBody.Location = new System.Drawing.Point(13, 154);
          this.textActionBody.Multiline = true;
          this.textActionBody.Name = "textActionBody";
          this.textActionBody.Number = 0;
@@ -457,5 +481,7 @@ namespace hMailServer.Administrator.Dialogs
       private System.Windows.Forms.Panel panelBindToAddress;
       private hMailServer.Shared.ucText textBindToAddress;
       private System.Windows.Forms.Label labelIPAddress;
+      private hMailServer.Administrator.Controls.ucCheckbox checkForwardAbortSpamFlagged;
+      private hMailServer.Administrator.Controls.ucCheckbox checkReplyAbortSpamFlagged;
    }
 }

--- a/hmailserver/source/Tools/Administrator/Dialogs/formRuleAction.cs
+++ b/hmailserver/source/Tools/Administrator/Dialogs/formRuleAction.cs
@@ -88,7 +88,12 @@ namespace hMailServer.Administrator.Dialogs
                textHeaderValue.Text = _ruleAction.Value;
             else if (_ruleAction.Type == eRuleActionType.eRABindToAddress)
                textBindToAddress.Text = _ruleAction.Value;
-     
+
+            if (_ruleAction.Type == eRuleActionType.eRAForwardEmail)
+               checkForwardAbortSpamFlagged.Checked = _ruleAction.AbortSpamFlagged;
+            else if (_ruleAction.Type == eRuleActionType.eRAReply)
+               checkReplyAbortSpamFlagged.Checked = _ruleAction.AbortSpamFlagged;
+
             comboAction.SelectedValue = _ruleAction.Type;
             comboRouteName.SelectedValue = _ruleAction.RouteID;
         }
@@ -117,6 +122,12 @@ namespace hMailServer.Administrator.Dialogs
                 case eRuleActionType.eRABindToAddress:
                     _ruleAction.Value = textBindToAddress.Text;
                     break;
+                case eRuleActionType.eRAForwardEmail:
+                   _ruleAction.AbortSpamFlagged = checkForwardAbortSpamFlagged.Checked;
+                   break;
+                case eRuleActionType.eRAReply:
+                   _ruleAction.AbortSpamFlagged = checkReplyAbortSpamFlagged.Checked;
+                   break;
             }
 
             _ruleAction.RouteID = (int)comboRouteName.SelectedValue;

--- a/hmailserver/source/Tools/Administrator/Main panes/ucAccount.Designer.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucAccount.Designer.cs
@@ -45,6 +45,7 @@ namespace hMailServer.Administrator
            this.labelPassword = new System.Windows.Forms.Label();
            this.labelAddress = new System.Windows.Forms.Label();
            this.tabPageAutoReply = new System.Windows.Forms.TabPage();
+           this.checkVacationMessageAbortSpamFlagged = new hMailServer.Administrator.Controls.ucCheckbox();
            this.dateVacationMessageExpiresDate = new hMailServer.Administrator.Controls.ucDateTimePicker();
            this.checkVacationMessageExpires = new hMailServer.Administrator.Controls.ucCheckbox();
            this.labelAutoReplyText = new System.Windows.Forms.Label();
@@ -53,6 +54,7 @@ namespace hMailServer.Administrator
            this.textVacationMessageSubject = new hMailServer.Shared.ucText();
            this.checkVacationMessageEnable = new hMailServer.Administrator.Controls.ucCheckbox();
            this.tabPageForwarding = new System.Windows.Forms.TabPage();
+           this.checkForwardAbortSpamFlagged = new hMailServer.Administrator.Controls.ucCheckbox();
            this.checkForwardKeepOriginal = new hMailServer.Administrator.Controls.ucCheckbox();
            this.textForwardAddress = new hMailServer.Administrator.Controls.ucEmailEdit();
            this.labelForwardAddress = new System.Windows.Forms.Label();
@@ -265,6 +267,7 @@ namespace hMailServer.Administrator
            // 
            // tabPageAutoReply
            // 
+           this.tabPageAutoReply.Controls.Add(this.checkVacationMessageAbortSpamFlagged);
            this.tabPageAutoReply.Controls.Add(this.dateVacationMessageExpiresDate);
            this.tabPageAutoReply.Controls.Add(this.checkVacationMessageExpires);
            this.tabPageAutoReply.Controls.Add(this.labelAutoReplyText);
@@ -280,9 +283,19 @@ namespace hMailServer.Administrator
            this.tabPageAutoReply.Text = "Auto-reply";
            this.tabPageAutoReply.UseVisualStyleBackColor = true;
            // 
+           // checkVacationMessageAbortSpamFlagged
+           // 
+           this.checkVacationMessageAbortSpamFlagged.AutoSize = true;
+           this.checkVacationMessageAbortSpamFlagged.Location = new System.Drawing.Point(26, 277);
+           this.checkVacationMessageAbortSpamFlagged.Name = "checkVacationMessageAbortSpamFlagged";
+           this.checkVacationMessageAbortSpamFlagged.Size = new System.Drawing.Size(196, 17);
+           this.checkVacationMessageAbortSpamFlagged.TabIndex = 21;
+           this.checkVacationMessageAbortSpamFlagged.Text = "Abort on messages marked as spam";
+           this.checkVacationMessageAbortSpamFlagged.UseVisualStyleBackColor = true;
+           // 
            // dateVacationMessageExpiresDate
            // 
-           this.dateVacationMessageExpiresDate.Location = new System.Drawing.Point(39, 245);
+           this.dateVacationMessageExpiresDate.Location = new System.Drawing.Point(41, 249);
            this.dateVacationMessageExpiresDate.Name = "dateVacationMessageExpiresDate";
            this.dateVacationMessageExpiresDate.Size = new System.Drawing.Size(200, 20);
            this.dateVacationMessageExpiresDate.TabIndex = 20;
@@ -291,7 +304,7 @@ namespace hMailServer.Administrator
            // checkVacationMessageExpires
            // 
            this.checkVacationMessageExpires.AutoSize = true;
-           this.checkVacationMessageExpires.Location = new System.Drawing.Point(24, 222);
+           this.checkVacationMessageExpires.Location = new System.Drawing.Point(26, 226);
            this.checkVacationMessageExpires.Name = "checkVacationMessageExpires";
            this.checkVacationMessageExpires.Size = new System.Drawing.Size(119, 17);
            this.checkVacationMessageExpires.TabIndex = 19;
@@ -319,7 +332,7 @@ namespace hMailServer.Administrator
            // 
            // textVacationMessageText
            // 
-           this.textVacationMessageText.Location = new System.Drawing.Point(24, 96);
+           this.textVacationMessageText.Location = new System.Drawing.Point(26, 96);
            this.textVacationMessageText.MaxLength = 1000;
            this.textVacationMessageText.Multiline = true;
            this.textVacationMessageText.Name = "textVacationMessageText";
@@ -330,7 +343,7 @@ namespace hMailServer.Administrator
            // 
            // textVacationMessageSubject
            // 
-           this.textVacationMessageSubject.Location = new System.Drawing.Point(24, 48);
+           this.textVacationMessageSubject.Location = new System.Drawing.Point(26, 48);
            this.textVacationMessageSubject.Name = "textVacationMessageSubject";
            this.textVacationMessageSubject.Number = 0;
            this.textVacationMessageSubject.Numeric = false;
@@ -350,6 +363,7 @@ namespace hMailServer.Administrator
            // 
            // tabPageForwarding
            // 
+           this.tabPageForwarding.Controls.Add(this.checkForwardAbortSpamFlagged);
            this.tabPageForwarding.Controls.Add(this.checkForwardKeepOriginal);
            this.tabPageForwarding.Controls.Add(this.textForwardAddress);
            this.tabPageForwarding.Controls.Add(this.labelForwardAddress);
@@ -360,6 +374,16 @@ namespace hMailServer.Administrator
            this.tabPageForwarding.TabIndex = 2;
            this.tabPageForwarding.Text = "Forwarding";
            this.tabPageForwarding.UseVisualStyleBackColor = true;
+           // 
+           // checkForwardAbortSpamFlagged
+           // 
+           this.checkForwardAbortSpamFlagged.AutoSize = true;
+           this.checkForwardAbortSpamFlagged.Location = new System.Drawing.Point(26, 103);
+           this.checkForwardAbortSpamFlagged.Name = "checkForwardAbortSpamFlagged";
+           this.checkForwardAbortSpamFlagged.Size = new System.Drawing.Size(196, 17);
+           this.checkForwardAbortSpamFlagged.TabIndex = 19;
+           this.checkForwardAbortSpamFlagged.Text = "Abort on messages marked as spam";
+           this.checkForwardAbortSpamFlagged.UseVisualStyleBackColor = true;
            // 
            // checkForwardKeepOriginal
            // 
@@ -829,5 +853,7 @@ namespace hMailServer.Administrator
        private hMailServer.Administrator.Controls.ucPassword textPassword;
        private System.Windows.Forms.ColumnHeader columnHeader3;
        private System.Windows.Forms.Button buttonEditFolders;
+       private Controls.ucCheckbox checkVacationMessageAbortSpamFlagged;
+       private Controls.ucCheckbox checkForwardAbortSpamFlagged;
     }
 }

--- a/hmailserver/source/Tools/Administrator/Main panes/ucAccount.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucAccount.cs
@@ -69,9 +69,11 @@ namespace hMailServer.Administrator
             textVacationMessageText.Enabled = checkVacationMessageEnable.Checked;
             checkVacationMessageExpires.Enabled = checkVacationMessageEnable.Checked;
             dateVacationMessageExpiresDate.Enabled = checkVacationMessageEnable.Checked;
+            checkVacationMessageAbortSpamFlagged.Enabled = checkVacationMessageEnable.Checked;
 
             textForwardAddress.Enabled = checkForwardEnabled.Checked;
             checkForwardKeepOriginal.Enabled = checkForwardEnabled.Checked;
+            checkForwardAbortSpamFlagged.Enabled = checkForwardEnabled.Checked;
 
             textSignaturePlainText.Enabled = checkSignatureEnabled.Checked;
             textSignatureHTML.Enabled = checkSignatureEnabled.Checked;
@@ -116,6 +118,7 @@ namespace hMailServer.Administrator
             textVacationMessageText.Text = _representedAccount.VacationMessage;
             checkVacationMessageExpires.Checked = _representedAccount.VacationMessageExpires;
             dateVacationMessageExpiresDate.Value = Convert.ToDateTime(_representedAccount.VacationMessageExpiresDate);
+            checkVacationMessageAbortSpamFlagged.Checked = _representedAccount.VacationMessageAbortSpamFlagged;
 
             // If out-of-office is not currently enabled, change the date to today. This makes it easier
             // for users to configure their out-of-office.
@@ -129,6 +132,7 @@ namespace hMailServer.Administrator
             checkForwardEnabled.Checked = _representedAccount.ForwardEnabled;
             textForwardAddress.Text = _representedAccount.ForwardAddress;
             checkForwardKeepOriginal.Checked = _representedAccount.ForwardKeepOriginal;
+            checkForwardAbortSpamFlagged.Checked = _representedAccount.ForwardAbortSpamFlagged;
 
             checkSignatureEnabled.Checked = _representedAccount.SignatureEnabled;
             textSignaturePlainText.Text = _representedAccount.SignaturePlainText;
@@ -202,10 +206,12 @@ namespace hMailServer.Administrator
             _representedAccount.VacationMessage = textVacationMessageText.Text;
             _representedAccount.VacationMessageExpires = checkVacationMessageExpires.Checked;
             _representedAccount.VacationMessageExpiresDate = dateVacationMessageExpiresDate.FormattedValue;
+            _representedAccount.VacationMessageAbortSpamFlagged = checkVacationMessageAbortSpamFlagged.Checked;
 
             _representedAccount.ForwardEnabled = checkForwardEnabled.Checked;
             _representedAccount.ForwardAddress = textForwardAddress.Text;
             _representedAccount.ForwardKeepOriginal = checkForwardKeepOriginal.Checked;
+            _representedAccount.ForwardAbortSpamFlagged = checkForwardAbortSpamFlagged.Checked;
 
             _representedAccount.SignatureEnabled = checkSignatureEnabled.Checked;
             _representedAccount.SignaturePlainText = textSignaturePlainText.Text;

--- a/hmailserver/source/Tools/DBUpdater/formMain.cs
+++ b/hmailserver/source/Tools/DBUpdater/formMain.cs
@@ -167,6 +167,7 @@ namespace DBUpdater
          _upgradeScripts.Add(new UpgradeScript(5702, 5703));
          _upgradeScripts.Add(new UpgradeScript(5703, 5704));
          _upgradeScripts.Add(new UpgradeScript(5704, 5705));
+         _upgradeScripts.Add(new UpgradeScript(5705, 5708));
       }
 
       private void buttonClose_Click(object sender, EventArgs e)
@@ -280,6 +281,8 @@ namespace DBUpdater
                return "hMailServer 5.7 (5704)";
             case 5705:
                return "hMailServer 5.7 (5705)";
+            case 5708:
+               return "hMailServer 5.7 (5708)";
             default:
                return "Unknown version";
          }

--- a/hmailserver/source/WebAdmin/background_account_save.php
+++ b/hmailserver/source/WebAdmin/background_account_save.php
@@ -28,10 +28,12 @@
    $vacationmessage   =   hmailGetVar("vacationmessage","");
    $vacationmessageexpires   =   hmailGetVar("vacationmessageexpires","0");
    $vacationmessageexpiresdate   =   hmailGetVar("vacationmessageexpiresdate","2001-01-01");
+   $vacationmessageabortspamflagged = hmailGetVar("vacationmessageabortspamflagged","0");
    
    $forwardenabled  = hmailGetVar("forwardenabled","0");
    $forwardaddress   = hmailGetVar("forwardaddress","");
    $forwardkeeporiginal   =   hmailGetVar("forwardkeeporiginal","0");
+   $forwardabortspamflagged = hmailGetVar("forwardabortspamflagged","0");
    
    $adenabled   = hmailGetVar("adenabled","");
    $addomain    = hmailGetVar("addomain","0");
@@ -72,10 +74,12 @@
    $obAccount->VacationMessage     = $vacationmessage;
    $obAccount->VacationMessageExpires      = $vacationmessageexpires;
    $obAccount->VacationMessageExpiresDate  = $vacationmessageexpiresdate;
+   $obAccount->VacationMessageAbortSpamFlagged = $vacationmessageabortspamflagged == "1";
 
    $obAccount->ForwardEnabled		= $forwardenabled == "1";
    $obAccount->ForwardAddress		= $forwardaddress;
    $obAccount->ForwardKeepOriginal	= $forwardkeeporiginal == "1";
+   $obAccount->ForwardAbortSpamFlagged = $forwardabortspamflagged == "1";
 
    $obAccount->SignatureEnabled		= $SignatureEnabled == "1";
    $obAccount->SignatureHTML		   = $SignatureHTML;

--- a/hmailserver/source/WebAdmin/background_rule_save.php
+++ b/hmailserver/source/WebAdmin/background_rule_save.php
@@ -112,13 +112,22 @@
       $actionObj->Body = hmailGetVar("Body", "");
       $actionObj->HeaderName = hmailGetVar("HeaderName", "");
       
+      $replyabortspamflagged = hmailGetVar("replyabortspamflagged", "0");
+      $forwardabortspamflagged = hmailGetVar("forwardabortspamflagged", "0");
+      
 	  switch ($type)
 	  {
-	    case eRASetHeaderValue:
+		case eRASetHeaderValue:
 			$actionObj->Value = hmailGetVar("Value", "");
 			break;
 		case eRABindToAddress:
 			$actionObj->Value = hmailGetVar("BindToAddress", "");
+			break;
+		case eRAForwardEmail:
+			$actionObj->AbortSpamFlagged = $forwardabortspamflagged == 1;
+			break;
+		case eRAReply:
+			$actionObj->AbortSpamFlagged = $replyabortspamflagged == 1;
 			break;
 	  }
       

--- a/hmailserver/source/WebAdmin/hm_account.php
+++ b/hmailserver/source/WebAdmin/hm_account.php
@@ -31,13 +31,14 @@ $PersonLastName = "";
 $vacationmessageon = 0;
 $vacationsubject = "";
 $vacationmessage = "";
-
 $vacationmessageexpires = 0;
 $vacationmessageexpiresdate = "";
+$vacationmessageabortspamflagged = 0;
 
 $forwardenabled = 0;
 $forwardaddress = "";
 $forwardkeeporiginal = 0;
+$forwardabortspamflagged = 0;
 
 $adenabled       = 0;
 $addomain        = "";
@@ -66,16 +67,15 @@ if ($action == "edit")
    $vacationmessageon = $obAccount->VacationMessageIsOn;
    $vacationsubject = $obAccount->VacationSubject;
    $vacationmessage = $obAccount->VacationMessage;
-
    $vacationmessageexpires     = $obAccount->VacationMessageExpires;
    $vacationmessageexpiresdate = $obAccount->VacationMessageExpiresDate;
    $vacationmessageexpiresdate = substr($vacationmessageexpiresdate, 0, 10);
-     
-   
+   $vacationmessageabortspamflagged = $obAccount->VacationMessageAbortSpamFlagged;
    
    $forwardenabled = $obAccount->ForwardEnabled;
    $forwardaddress = $obAccount->ForwardAddress;
    $forwardkeeporiginal = $obAccount->ForwardKeepOriginal;
+   $forwardabortspamflagged = $obAccount->ForwardAbortSpamFlagged;
    
    $adenabled       = $obAccount->IsAD;
    $addomain        = $obAccount->ADDomain;
@@ -224,7 +224,10 @@ $str_server = $obLanguage->String("Server");
          		
          			<input type="text" name="vacationmessageexpiresdate" value="<?php echo PreprocessOutput($vacationmessageexpiresdate)?>"> (YYYY-MM-DD)
                </td>		
-      		</tr>		
+      		</tr>
+            <?php     
+               PrintCheckboxRow("vacationmessageabortspamflagged", "Abort on messages marked as spam", $vacationmessageabortspamflagged);
+            ?>
       	</table>
       </div>
        
@@ -240,7 +243,7 @@ $str_server = $obLanguage->String("Server");
                PrintCheckboxRow("forwardenabled", "Enabled", $forwardenabled);
                PrintPropertyEditRow("forwardaddress", "Address", $forwardaddress);
                PrintCheckboxRow("forwardkeeporiginal", "Keep original message", $forwardkeeporiginal);
-               
+               PrintCheckboxRow("forwardabortspamflagged", "Abort on messages marked as spam", $forwardabortspamflagged);
             ?>
          </table>
       </div>       

--- a/hmailserver/source/WebAdmin/hm_rule_action.php
+++ b/hmailserver/source/WebAdmin/hm_rule_action.php
@@ -35,6 +35,7 @@ if ($action == "edit")
    $HeaderName = $ruleAction->HeaderName;
    $Value = $ruleAction->Value;
    $Type = $ruleAction->Type;
+   $AbortSpamFlagged = $ruleAction->AbortSpamFlagged;
 }
 else
 {
@@ -48,6 +49,7 @@ else
    $HeaderName = "";
    $Value = "";
    $Type = 0;
+   $AbortSpamFlagged = 0;
 }  
 ?>
 
@@ -154,6 +156,10 @@ function hideAllPanels()
                   <div id="panel-<?php echo eRAForwardEmail?>" style="display: none">
                      <?php EchoTranslation("To")?><br/>
                      <input type="text" name="To" value="<?php echo PreprocessOutput($To)?>">
+                     <p>
+                        <input type="checkbox" name="forwardabortspamflagged" value="1" id="forwardabortspamflagged" <?php if ($AbortSpamFlagged == 1) echo "checked"?>>
+                        <label for="forwardabortspamflagged"><?php EchoTranslation("Abort on messages marked as spam")?></label>
+                     </p>
                   </div>
                   
                   <div id="panel-<?php echo eRAReply?>" style="display: none">
@@ -168,7 +174,10 @@ function hideAllPanels()
                      <br/>
                      <?php EchoTranslation("Body")?><br/>
                      <textarea name="Body" cols="30" rows="5"><?php echo PreprocessOutput($Body)?></textarea>
-                     <br/>
+                     <p>
+                        <input type="checkbox" name="replyabortspamflagged" value="1" id="replyabortspamflagged" <?php if ($AbortSpamFlagged == 1) echo "checked"?>>
+                        <label for="replyabortspamflagged"><?php EchoTranslation("Abort on messages marked as spam")?></label>
+                     </p>
                   </div>   
 
                   <div id="panel-<?php echo eRAMoveToImapFolder?>" style="display: none">

--- a/hmailserver/test/RegressionTests/Infrastructure/AccountServices.cs
+++ b/hmailserver/test/RegressionTests/Infrastructure/AccountServices.cs
@@ -164,6 +164,54 @@ namespace RegressionTests.Infrastructure
 
       [Test]
       [Category("Accounts")]
+      [Description("Test account reply when spam flagged")]
+      public void TestAutoReplyAbortSpamFlagged()
+      {
+         // Create a test account
+         // Fetch the default domain
+         var account1 = SingletonProvider<TestSetup>.Instance.AddAccount(_domain,
+            TestSetup.UniqueString() + "@example.test",
+            "test");
+         var account2 = SingletonProvider<TestSetup>.Instance.AddAccount(_domain,
+            TestSetup.UniqueString() + "@example.test",
+            "test");
+
+         account2.VacationMessageIsOn = true;
+         account2.VacationMessage = "I'm on vacation";
+         account2.VacationSubject = "Out of office!";
+         account2.VacationMessageAbortSpamFlagged = true;
+         account2.Save();
+
+         // Set Thresholds
+         _settings.AntiSpam.SpamMarkThreshold = 5;
+         _settings.AntiSpam.SpamDeleteThreshold = 20;
+
+         // Enable SpamAssassin
+         _settings.AntiSpam.SpamAssassinEnabled = true;
+         _settings.AntiSpam.SpamAssassinHost = "localhost";
+         _settings.AntiSpam.SpamAssassinPort = 783;
+         _settings.AntiSpam.SpamAssassinMergeScore = false;
+         _settings.AntiSpam.SpamAssassinScore = 5;
+
+         // Send a messages this account.
+         var smtpClientSimulator = new SmtpClientSimulator();
+         smtpClientSimulator.Send(account1.Address, account2.Address, "Test message", "This is a test message with spam.\r\n XJS*C4JDBQADN1.NSBN3*2IDNEN*GTUBE-STANDARD-ANTI-UBE-TEST-EMAIL*C.34X.");
+
+         var pop3ClientSimulator = new Pop3ClientSimulator();
+
+         Pop3ClientSimulator.AssertMessageCount(account1.Address, "test", 0);
+
+         var defaultLogText = TestSetup.ReadExistingTextFile(LogHandler.GetDefaultLogFileName());
+         Assert.IsTrue(defaultLogText.Contains("LocalDelivery::SendAutoReplyMessage_ aborted, message marked as spam")); 
+         Pop3ClientSimulator.AssertMessageCount(account2.Address, "test", 1);
+
+         account2.VacationMessageAbortSpamFlagged = false;
+         account2.VacationMessageIsOn = false;
+         account2.Save();
+      }
+
+      [Test]
+      [Category("Accounts")]
       [Description("Ensure that auto-replies are sent even if account forwarding is on.")]
       public void TestAutoReplyCombinedWithForwarding()
       {
@@ -292,6 +340,49 @@ namespace RegressionTests.Infrastructure
          SingletonProvider<TestSetup>.Instance.GetApp().SubmitEMail();
 
          Pop3ClientSimulator.AssertMessageCount(account2.Address, "test", 2);
+      }
+
+      [Test]
+      [Category("Accounts")]
+      [Description("Test account forwarding when spam flagged")]
+      public void TestForwardingAbortSpamFlagged()
+      {
+         // Create a test account
+         // Fetch the default domain
+         var account1 = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "Forward1@example.test", "test");
+         var account2 = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "Forward2@example.test", "test");
+
+         // Set Thresholds
+         _settings.AntiSpam.SpamMarkThreshold = 5;
+         _settings.AntiSpam.SpamDeleteThreshold = 20;
+
+         // Enable SpamAssassin
+         _settings.AntiSpam.SpamAssassinEnabled = true;
+         _settings.AntiSpam.SpamAssassinHost = "localhost";
+         _settings.AntiSpam.SpamAssassinPort = 783;
+         _settings.AntiSpam.SpamAssassinMergeScore = false;
+         _settings.AntiSpam.SpamAssassinScore = 5;
+
+         // Set up account 1 to forward to account2.
+         account1.ForwardEnabled = true;
+         account1.ForwardAddress = "Forward2@example.test";
+         account1.ForwardKeepOriginal = true;
+         account1.ForwardAbortSpamFlagged = true;
+         account1.Save();
+
+         // Send 2 messages to this account.
+         var smtpClientSimulator = new SmtpClientSimulator();
+         for (int i = 0; i < 2; i++)
+            smtpClientSimulator.Send("Forward1@example.test", "Forward1@example.test", "Test message", "This is a test message with spam.\r\n XJS*C4JDBQADN1.NSBN3*2IDNEN*GTUBE-STANDARD-ANTI-UBE-TEST-EMAIL*C.34X.");
+
+         Pop3ClientSimulator.AssertMessageCount(account1.Address, "test", 2);
+
+         // Tell hMailServer to deliver now, so that the forward takes effect.
+         SingletonProvider<TestSetup>.Instance.GetApp().SubmitEMail();
+
+         var defaultLogText = TestSetup.ReadExistingTextFile(LogHandler.GetDefaultLogFileName());
+         Assert.IsTrue(defaultLogText.Contains("SMTPForwarding::PerformForwarding aborted, message marked as spam"));
+         Pop3ClientSimulator.AssertMessageCount(account2.Address, "test", 0);
       }
 
       [Test]

--- a/hmailserver/test/RegressionTests/Rules/Rules.cs
+++ b/hmailserver/test/RegressionTests/Rules/Rules.cs
@@ -1460,6 +1460,60 @@ namespace RegressionTests.Rules
       }
 
       [Test]
+      [Description("Test forward rule when spam flagged.")]
+      public void TestForwardAbortSpamFlagged()
+      {
+         // Add an account
+         var account1 = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "ruletest1@example.test", "test");
+         var account2 = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "ruletest2@example.test", "test");
+
+         // Set up a rule to forward from account1 to 2 and 3.
+         var oRule = account1.Rules.Add();
+         oRule.Name = "Criteria test";
+         oRule.Active = true;
+
+         var oRuleCriteria = oRule.Criterias.Add();
+         oRuleCriteria.UsePredefined = true;
+         oRuleCriteria.PredefinedField = eRulePredefinedField.eFTMessageSize;
+         oRuleCriteria.MatchType = eRuleMatchType.eMTGreaterThan;
+         oRuleCriteria.MatchValue = "0";
+         oRuleCriteria.Save();
+
+         // Set up the actions to forward.
+         var oRuleAction = oRule.Actions.Add();
+         oRuleAction.Type = eRuleActionType.eRAForwardEmail;
+         oRuleAction.To = "ruletest2@test.com";
+         oRuleAction.AbortSpamFlagged = true;
+         oRuleAction.Save();
+
+         // Save the rule in the database
+         oRule.Save();
+
+         // Set Thresholds
+         _settings.AntiSpam.SpamMarkThreshold = 5;
+         _settings.AntiSpam.SpamDeleteThreshold = 20;
+
+         // Enable SpamAssassin
+         _settings.AntiSpam.SpamAssassinEnabled = true;
+         _settings.AntiSpam.SpamAssassinHost = "localhost";
+         _settings.AntiSpam.SpamAssassinPort = 783;
+         _settings.AntiSpam.SpamAssassinMergeScore = false;
+         _settings.AntiSpam.SpamAssassinScore = 5;
+
+         var smtpClientSimulator = new SmtpClientSimulator();
+
+         // Test to send the messge to account 1.
+         smtpClientSimulator.Send(account1.Address, account1.Address, "Test message", "This is a test message with spam.\r\n XJS*C4JDBQADN1.NSBN3*2IDNEN*GTUBE-STANDARD-ANTI-UBE-TEST-EMAIL*C.34X.");
+
+         ImapClientSimulator.AssertMessageCount(account1.Address, "test", "Inbox", 1);
+         CustomAsserts.AssertRecipientsInDeliveryQueue(0);
+
+         var defaultLogText = TestSetup.ReadExistingTextFile(LogHandler.GetDefaultLogFileName());
+         Assert.IsTrue(defaultLogText.Contains("RuleApplier::ApplyAction_Forward aborted, message marked as spam"));
+         ImapClientSimulator.AssertMessageCount(account2.Address, "test", "Inbox", 0);
+      }
+
+      [Test]
       [Description("Test to move to a public folder without permission.")]
       public void TestMoveToPublicFolderWithoutPermission()
       {
@@ -1688,6 +1742,66 @@ namespace RegressionTests.Rules
 
          foreach (var line in rawMessage.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None))
             Assert.LessOrEqual(line.Length, 76, $"QP line exceeds 76 chars: {line}");
+      }
+
+      [Test]
+      [Description("Test reply rule when spam flagged.")]
+      public void TestReplyAbortSpamFlagged()
+      {
+         // Add accounts
+         var account1 = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "ruletest1@example.test", "test");
+         var account2 = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "ruletest2@example.test", "test");
+
+         // Set up a rule to reply to any message sent to account2.
+         var oRule = account2.Rules.Add();
+         oRule.Name = "Criteria test";
+         oRule.Active = true;
+
+         var oRuleCriteria = oRule.Criterias.Add();
+         oRuleCriteria.UsePredefined = true;
+         oRuleCriteria.PredefinedField = eRulePredefinedField.eFTMessageSize;
+         oRuleCriteria.MatchType = eRuleMatchType.eMTGreaterThan;
+         oRuleCriteria.MatchValue = "0";
+         oRuleCriteria.Save();
+
+         // Set up the actions to forward.
+         var oRuleAction = oRule.Actions.Add();
+         oRuleAction.Type = eRuleActionType.eRAReply;
+         oRuleAction.FromAddress = account2.Address;
+         oRuleAction.FromName = "Rule Test 2";
+         oRuleAction.Subject = "Autoreply";
+         oRuleAction.AbortSpamFlagged = true;
+         oRuleAction.Save();
+
+         // Save the rule in the database
+         oRule.Save();
+
+         // Set Thresholds
+         _settings.AntiSpam.SpamMarkThreshold = 5;
+         _settings.AntiSpam.SpamDeleteThreshold = 20;
+
+         // Enable SpamAssassin
+         _settings.AntiSpam.SpamAssassinEnabled = true;
+         _settings.AntiSpam.SpamAssassinHost = "localhost";
+         _settings.AntiSpam.SpamAssassinPort = 783;
+         _settings.AntiSpam.SpamAssassinMergeScore = false;
+         _settings.AntiSpam.SpamAssassinScore = 5;
+
+         var smtpClientSimulator = new SmtpClientSimulator();
+
+         // Test to send the message to account 2.
+         smtpClientSimulator.Send(account1.Address, account2.Address, "Test message", "This is a test message with spam.\r\n XJS*C4JDBQADN1.NSBN3*2IDNEN*GTUBE-STANDARD-ANTI-UBE-TEST-EMAIL*C.34X.");
+         ImapClientSimulator.AssertMessageCount(account2.Address, "test", "Inbox", 1);
+
+         CustomAsserts.AssertRecipientsInDeliveryQueue(0);
+
+         var defaultLogText = TestSetup.ReadExistingTextFile(LogHandler.GetDefaultLogFileName());
+         Assert.IsTrue(defaultLogText.Contains("RuleApplier::ApplyAction_Reply aborted, message marked as spam"));
+         // Make sure a reply is not sent back to account 1.
+         ImapClientSimulator.AssertMessageCount(account1.Address, "test", "Inbox", 0);
+
+         oRuleAction.AbortSpamFlagged = false;
+         oRuleAction.Save();
       }
 
       private void AddExactMatchRule(Account account)

--- a/hmailserver/test/RegressionTests/Shared/TestSetup.cs
+++ b/hmailserver/test/RegressionTests/Shared/TestSetup.cs
@@ -81,6 +81,9 @@ namespace RegressionTests.Shared
             restartRequired = true;
          }
 
+         if (!string.IsNullOrEmpty(_settings.WelcomePOP3))
+            _settings.WelcomePOP3 = string.Empty;
+
          if (_settings.AutoBanOnLogonFailure)
             _settings.AutoBanOnLogonFailure = false;
 
@@ -142,8 +145,6 @@ namespace RegressionTests.Shared
             _settings.IMAPSASLPlainEnabled = false;
          if (_settings.IMAPSASLInitialResponseEnabled)
             _settings.IMAPSASLInitialResponseEnabled = false;
-         if (_settings.IMAPAuthAllowPlainText)
-            _settings.IMAPAuthAllowPlainText = false;
          if (!string.IsNullOrEmpty(_settings.IMAPMasterUser))
             _settings.IMAPMasterUser = string.Empty;
 
@@ -442,6 +443,9 @@ namespace RegressionTests.Shared
 
          if (antiSpam.UseSPF)
             antiSpam.UseSPF = false;
+
+         if (antiSpam.CheckPTR)
+            antiSpam.CheckPTR = false;
 
          if (antiSpam.MaximumMessageSize != 1024)
             antiSpam.MaximumMessageSize = 1024;


### PR DESCRIPTION
- Fix some spam scoring inconsistencies, for example the spam-counter was not updated in POP3ClientConnection.cpp when a message scored above the SpamDeleteThreshold
- Make sure both the SpamMarkThreshold and SpamDeleteThreshold are > 0 in both POP3ClientConnection.cpp as in SMTPConnection.cpp‎ (this was not in POP3ClientConnection.cpp before)
- By correcting the above, if either the SpamMarkThreshold and/or SpamDeleteThreshold are set to 0, their functionality is disabled

Add a internal (persistent) FlagSpam message flag as the options to mark spam below are optional and can be disabled
- Add X-hMailServer-Spam
- Add X-hMailServer-Reason
- Add to message subject

Use the internal FlagSpam message flag to (optionally) determine if a message should be forwarded, replied to if defined by either Rule or with a Account Forward/OOF when a message is considered/marked as being spam

WebAdmin, GUI changes and tests included

-----------------------------------

In RuleApplier.cpp the include MailerDaemonAddressDeterminer.h can be removed, there was also a orphaned std::shared_ptr<Account> emptyAccount; that wasn't used.
In SMTPVacationMessageCreator.cpp the SetReturnPath action can also be removed, as part of https://github.com/hmailserver/hmailserver/pull/514