### PR TITLE
Feature/housekeeping

### DIFF
--- a/hmailserver/source/Server/Common/AntiSpam/DKIM/Canonicalization.cpp
+++ b/hmailserver/source/Server/Common/AntiSpam/DKIM/Canonicalization.cpp
@@ -163,7 +163,7 @@ namespace HM
       if (!signatureField.first.IsEmpty())
       {
          // Don't pick the value from the actual header, use the header we're verifying instead
-         // If there are more than one DKIM-signature fields in the header, this will be important.
+         // If there are more than one DKIM-Signature fields in the header, this will be important.
          AnsiString  relaxedHeaderName = CanonicalizeHeaderName(signatureField.first);
          AnsiString relaxedFieldValue = CanonicalizeHeaderValue(signatureField.second);
 
@@ -320,7 +320,7 @@ namespace HM
       if (!signatureField.first.IsEmpty())
       {
          // Don't pick the value from the actual header, use the header we're verifying instead
-         // If there are more than one DKIM-signature fields in the header, this will be important.
+         // If there are more than one DKIM-Signature fields in the header, this will be important.
          AnsiString headerName = signatureField.first;
 
          AnsiString headerLine = headerName + ": " + GetDKIMWithoutSignature_(signatureField.second);

--- a/hmailserver/source/Server/Common/AntiSpam/DKIM/DKIM.cpp
+++ b/hmailserver/source/Server/Common/AntiSpam/DKIM/DKIM.cpp
@@ -144,7 +144,7 @@ namespace HM
 
       String headerValue = BuildSignatureHeader_(tagA, tagDomain, tagSelector, tagC, tagQ, fieldList, bodyHash, "");
       
-      canonicalizedHeader += headerCanonicalization->CanonicalizeHeaderLine("dkim-signature", headerValue);
+      canonicalizedHeader += headerCanonicalization->CanonicalizeHeaderLine("DKIM-Signature", headerValue);
 
       AnsiString privateKeyContent = FileUtilities::ReadCompleteTextFile(String(privateKey));
 
@@ -159,7 +159,7 @@ namespace HM
 
       // output to file.
       std::vector<std::pair<AnsiString, AnsiString> > fieldsToWrite;
-      fieldsToWrite.push_back(std::make_pair("dkim-signature", headerValue));
+      fieldsToWrite.push_back(std::make_pair("DKIM-Signature", headerValue));
 
       TraceHeaderWriter writer;
       bool result = writer.Write(fileName, message, fieldsToWrite);

--- a/hmailserver/source/Server/Common/AntiSpam/DKIM/DKIM.cpp
+++ b/hmailserver/source/Server/Common/AntiSpam/DKIM/DKIM.cpp
@@ -110,7 +110,7 @@ namespace HM
 
       if (FileUtilities::FileSize(fileName) > MaxFileSize)
       {
-         LOG_DEBUG("Message was not signed using DKIM since the size of the message exceeded the max DKIM size of 10MB.");
+         LOG_DEBUG("Message was not signed using DKIM since the size of the message exceeded the max DKIM size of 50MB.");
          return true;
       }
 

--- a/hmailserver/source/Server/Common/AntiSpam/DKIM/DKIM.h
+++ b/hmailserver/source/Server/Common/AntiSpam/DKIM/DKIM.h
@@ -31,7 +31,7 @@ namespace HM
 
       enum Settings
       {
-         // Limit signing of huge messages, to prevent memory/perforamnce issues.
+         // Limit signing of huge messages, to prevent memory/performance issues.
          MaxFileSize = 1024 * 1024 * 50
       };
 

--- a/hmailserver/source/Server/Common/Mime/Mime.cpp
+++ b/hmailserver/source/Server/Common/Mime/Mime.cpp
@@ -764,7 +764,7 @@ namespace HM
    {
       static int s_nPartNumber = 0;
       char buf[80];
-      if (!pszBoundary)				// generate a new boundary delimeter
+      if (!pszBoundary)				// generate a new boundary delimiter
       {
          unsigned __int64 value = (unsigned __int64)::time(NULL) ^ (unsigned __int64)this;
          ::srand((unsigned int) value);

--- a/hmailserver/source/Server/Common/Mime/MimeCode.cpp
+++ b/hmailserver/source/Server/Common/Mime/MimeCode.cpp
@@ -739,7 +739,7 @@ namespace HM
 
 	   const char* pszInput = (const char*) input_;
       size_t nInputSize = input_size_;
-	   int nNonAsciiChars, nDelimeter = GetDelimeter();
+	   int nNonAsciiChars, nDelimiter = GetDelimiter();
 	   int nLineLen = 0;
 	   
       AnsiString strUnit;
@@ -747,7 +747,7 @@ namespace HM
 	   // divide the field into syntactic units to encode
 	   for (;;)
 	   {
-		   size_t nUnitSize = FindSymbol(pszInput, nInputSize, nDelimeter, nNonAsciiChars);
+		   size_t nUnitSize = FindSymbol(pszInput, nInputSize, nDelimiter, nNonAsciiChars);
 		   if (!nNonAsciiChars || strCharset.empty())
          {
 			   strUnit.assign(pszInput, nUnitSize);
@@ -761,7 +761,7 @@ namespace HM
             coder.GetOutput(strUnit);
 		   }
 		   if (nUnitSize < nInputSize)
-			   strUnit += pszInput[nUnitSize];		// add the following delimeter (space or special char)
+			   strUnit += pszInput[nUnitSize];		// add the following delimiter (space or special char)
 
 		   // copy the encoded string to target buffer and perform folding if needed
 		   if (!MimeEnvironment::AutoFolding())
@@ -872,7 +872,7 @@ namespace HM
 	   }
    }
 
-   int FieldCodeBase::FindSymbol(const char* pszData, size_t nSize, int& nDelimeter, int& nNonAscChars) const
+   int FieldCodeBase::FindSymbol(const char* pszData, size_t nSize, int& nDelimiter, int& nNonAscChars) const
    {
 	   nNonAscChars = 0;
 	   const char* pszDataStart = pszData;
@@ -885,9 +885,9 @@ namespace HM
 			   nNonAscChars++;
 		   else
 		   {
-			   if (ch == (char) nDelimeter)
+			   if (ch == (char)nDelimiter)
 			   {
-				   nDelimeter = 0;		// stop at any delimeters (space or specials)
+				   nDelimiter = 0;		// stop at any delimeters (space or specials)
 				   break;
 			   }
 
@@ -898,7 +898,7 @@ namespace HM
             The notation of RFC 822 is used, with the exception that white space
             characters MUST NOT appear between components of an 'encoded-word'.
             */
-            if (!nDelimeter && CMimeChar::IsSpecial(ch))
+            if (!nDelimiter && CMimeChar::IsSpecial(ch))
 			   {
                if (pszData > pszDataStart)
                {
@@ -906,22 +906,22 @@ namespace HM
                   if (CMimeChar::IsSpace(previousChar))
                   {
                      pszData--;
-                     nDelimeter = ' ';
+                     nDelimiter = ' ';
                   }
                }
                
-               if (nDelimeter == 0 )
+               if (nDelimiter == 0 )
                {
 				      switch (ch)
 				      {
 				      case '"':
-					      nDelimeter = '"';	// quoted-string, delimeter is '"'
+					      nDelimiter = '"';	// quoted-string, delimiter is '"'
 					      break;
 				      case '(':
-					      nDelimeter = ')';	// comment, delimeter is ')'
+					      nDelimiter = ')';	// comment, delimetir is ')'
 					      break;
 				      case '<':
-					      nDelimeter = '>';	// address, delimeter is '>'
+					      nDelimiter = '>';	// address, delimetir is '>'
 					      break;
 				      }
                }

--- a/hmailserver/source/Server/Common/Mime/MimeCode.cpp
+++ b/hmailserver/source/Server/Common/Mime/MimeCode.cpp
@@ -887,7 +887,7 @@ namespace HM
 		   {
 			   if (ch == (char)nDelimiter)
 			   {
-				   nDelimiter = 0;		// stop at any delimeters (space or specials)
+				   nDelimiter = 0;		// stop at any delimiters (space or specials)
 				   break;
 			   }
 

--- a/hmailserver/source/Server/Common/Mime/MimeCode.h
+++ b/hmailserver/source/Server/Common/Mime/MimeCode.h
@@ -38,8 +38,8 @@ using namespace std;
 #endif
 
 // maximum length of an encoded line (RFC 2045)
-#define MAX_MIME_LINE_LEN	76
-#define MAX_ENCODEDWORD_LEN	75
+constexpr int MAX_MIME_LINE_LEN = 76;
+constexpr int MAX_ENCODEDWORD_LEN = 75;
 
 //////////////////////////////////////////////////////////////////////
 // MimeEnvironment - global environment to manage encoding/decoding
@@ -286,14 +286,14 @@ namespace HM
 	   string charset_;
 
 	   virtual bool IsFoldingChar(char ch) const { return false; }
-	   virtual int GetDelimeter() const { return 0; }
-      int FindSymbol(const char* pszData, size_t nSize, int& nDelimeter, int& nNonAscChars) const;
+	   virtual int GetDelimiter() const { return 0; }
+      int FindSymbol(const char* pszData, size_t nSize, int& nDelimiter, int& nNonAscChars) const;
 	   void UnfoldField(string& strField) const;
 	   int SelectEncoding(size_t nLength, int nNonAsciiChars) const
 	   {
-         size_t nQEncodeSize = nLength + nNonAsciiChars * 2;
+         size_t nQEncodeSize = nLength + ((size_t)nNonAsciiChars) * 2;
          size_t nBEncodeSize = (nLength + 2) / 3 * 4;
-		   return (nQEncodeSize <= nBEncodeSize || ((size_t) nNonAsciiChars)*5 <= nLength) ? 'Q' : 'B';
+		   return (nQEncodeSize <= nBEncodeSize || ((size_t)nNonAsciiChars)*5 <= nLength) ? 'Q' : 'B';
 	   }
 
    protected:
@@ -309,7 +309,7 @@ namespace HM
 	   DECLARE_FIELDCODER(FieldCodeText)
 
    protected:
-	   virtual int GetDelimeter() const { return 0xff; }
+	   virtual int GetDelimiter() const { return 0xff; }
    };
 
    //////////////////////////////////////////////////////////////////////

--- a/hmailserver/source/Server/Common/Scripting/ScriptServer.cpp
+++ b/hmailserver/source/Server/Common/Scripting/ScriptServer.cpp
@@ -34,7 +34,7 @@ namespace HM
       has_on_client_logon_(false),
       has_on_client_validate_password_(false),
       has_on_recipient_unknown_(false),
-      has_on_too_many_invalid_comands_(false)
+      has_on_too_many_invalid_commands_(false)
    {
       
    }
@@ -106,7 +106,7 @@ namespace HM
          has_on_client_logon_ = DoesFunctionExist_("OnClientLogon");
          has_on_client_validate_password_ = DoesFunctionExist_("OnClientValidatePassword");
          has_on_recipient_unknown_ = DoesFunctionExist_("OnRecipientUnknown");
-         has_on_too_many_invalid_comands_ = DoesFunctionExist_("OnTooManyInvalidCommands");
+         has_on_too_many_invalid_commands_ = DoesFunctionExist_("OnTooManyInvalidCommands");
       }
       catch (...)
       {
@@ -280,7 +280,7 @@ namespace HM
          event_name = _T("OnRecipientUnknown");
          break;
       case EventOnTooManyInvalidCommands:
-         if (!has_on_too_many_invalid_comands_)
+         if (!has_on_too_many_invalid_commands_)
             return;
          event_name = _T("OnTooManyInvalidCommands");
          break;

--- a/hmailserver/source/Server/Common/Scripting/ScriptServer.h
+++ b/hmailserver/source/Server/Common/Scripting/ScriptServer.h
@@ -73,7 +73,7 @@ namespace HM
       bool has_on_client_logon_;
       bool has_on_client_validate_password_;
       bool has_on_recipient_unknown_;
-      bool has_on_too_many_invalid_comands_;
+      bool has_on_too_many_invalid_commands_;
 
       String script_contents_;
       String script_extension_;

--- a/hmailserver/source/Server/hMailServer/hMailServer.idl
+++ b/hmailserver/source/Server/hMailServer/hMailServer.idl
@@ -2254,7 +2254,7 @@ interface IInterfaceAntiSpam : IDispatch
    [propget, id(30), helpstring("Maximum message size to run anti-spam on.")] HRESULT MaximumMessageSize([out, retval] long *pVal);
    [propput, id(30), helpstring("Maximum message size to run anti-spam on.")] HRESULT MaximumMessageSize([in] long newVal);
 
-   [id(31), helpstring("Verifies the DKIM-signature of the specified file. Returns true if neutral or pass.")] HRESULT DKIMVerify([in] BSTR File, [out, retval] eDKIMResult *pResult);
+   [id(31), helpstring("Verifies the DKIM-Signature of the specified file. Returns true if neutral or pass.")] HRESULT DKIMVerify([in] BSTR File, [out, retval] eDKIMResult *pResult);
    
    [propget, id(32), helpstring("Enable DKIM header verification.")] HRESULT DKIMVerificationEnabled([out, retval] VARIANT_BOOL  *pVal);
    [propput, id(32), helpstring("Enable DKIM header verification.")] HRESULT DKIMVerificationEnabled([in] VARIANT_BOOL newVal);


### PR DESCRIPTION
- Correct various typos
- Copilot suggested macro to constexpr conversion
- Do not write DKIM header name in all lowercase