### PR TITLE
Only add missing Message-ID for authenticated senders, #536

### DIFF
--- a/hmailserver/source/Server/SMTP/SMTPMessageHeaderCreator.cpp
+++ b/hmailserver/source/Server/SMTP/SMTPMessageHeaderCreator.cpp
@@ -69,8 +69,13 @@ namespace HM
 
       String sComputerName = Utilities::ComputerName();
 
-      // Add Message-ID header if it does not exist.
-      if (!original_headers_->FieldExists("Message-ID"))
+      // Add Message-ID header if it does not exist. Adding a missing Message-ID is a
+      // message submission task (RFC 6409), so it's only done for authenticated senders.
+      // When another server relays a message to us we act as a relay rather than as a
+      // submission server, and should only add trace fields. Inserting a Message-ID in
+      // that case would hide from spam filters and rules further down the line that the
+      // original message didn't have one.
+      if (is_authenticated_ && !original_headers_->FieldExists("Message-ID"))
       {
          String sTemp;
          sTemp.Format(_T("Message-ID: %s\r\n"), Utilities::GenerateMessageID().c_str());

--- a/hmailserver/test/RegressionTests/SMTP/Basics.cs
+++ b/hmailserver/test/RegressionTests/SMTP/Basics.cs
@@ -261,6 +261,39 @@ namespace RegressionTests.SMTP
       }
 
       [Test]
+      [Category("SMTP")]
+      [Description("Issue 536: A missing Message-ID should be added for authenticated senders, since we act as a submission server for them.")]
+      public void TestMessageIDAddedForAuthenticatedSender()
+      {
+         SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "test@example.test", "test");
+
+         // The simulator does not add a Message-ID of its own, so any Message-ID in the
+         // delivered message was added by the server.
+         string errorMessage;
+         var simulator = new SmtpClientSimulator();
+         simulator.Send(false, "test@example.test", "test", "test@example.test", "test@example.test",
+                        "Test subject", "Test body", out errorMessage);
+
+         var test = Pop3ClientSimulator.AssertGetFirstMessageText("test@example.test", "test");
+
+         Assert.IsTrue(test.Contains("Message-ID: <"));
+      }
+
+      [Test]
+      [Category("SMTP")]
+      [Description("Issue 536: A missing Message-ID should not be added to relayed messages, since that hides from spam filters that the original message had none.")]
+      public void TestMessageIDNotAddedForUnauthenticatedSender()
+      {
+         SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "test@example.test", "test");
+
+         SmtpClientSimulator.StaticSend("someone@example.com", "test@example.test", "Test subject", "Test body");
+
+         var test = Pop3ClientSimulator.AssertGetFirstMessageText("test@example.test", "test");
+
+         Assert.IsFalse(test.Contains("Message-ID"));
+      }
+
+      [Test]
       public void TestEHLOKeywords()
       {
          var application = SingletonProvider<TestSetup>.Instance.GetApp();


### PR DESCRIPTION
Adding a Message-ID when the submitted message lacks one is a message
submission task (RFC 6409). hMailServer did it for every message received
over SMTP, including mail relayed to us by other servers.

The header is prepended during the DATA flush, before the post-transmission
spam tests run, so SpamAssassin was always handed a message that had a
Message-ID. Rules that check for a missing one (MISSING_MID,
NO_HEADERS_MESSAGE) could therefore never trigger, and the same applied to
rules and scripts inspecting headers further down the line.

Restrict the insertion to authenticated senders, where we act as the
submission server. Relayed messages now only get trace fields, as they
should.

Co-Authored-By: Claude Opus 5