### PR TITLE
Don't add session links to commits and pull requests

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "attribution": {
+    "sessionUrl": false
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,7 @@ hmailserver/source/Server/hMailServer.Minidump/x64/*
 **/.vs/*
 
 /.claude/settings.*
+# Shared project settings are checked in. Personal overrides (settings.local.json)
+# are still ignored by the rule above.
+!/.claude/settings.json
 /hmailserver/.claude/settings.*


### PR DESCRIPTION
Claude Code adds a `Claude-Session: https://claude.ai/code/session_...` trailer to commit messages and pull request descriptions in web and Remote Control sessions. The link isn't accessible to anyone reading the repository history, so it's noise. #542 picked one up, for example.

Setting `attribution.sessionUrl` to `false` turns it off:

```json
{
  "attribution": {
    "sessionUrl": false
  }
}
```

`Co-Authored-By` attribution is unaffected — that's controlled separately by `attribution.commit` and `attribution.pr`, both left at their defaults.

### Note on .gitignore

`.gitignore` has so far kept every Claude settings file out of the repository (`/.claude/settings.*`, added in #539), so this needs an exception to have any effect. I've narrowed the rule to allow the shared `settings.json` while personal overrides in `settings.local.json` stay ignored. If keeping all Claude settings untracked was deliberate, this part is the piece to reject — the setting would then have to be applied per-user instead, via `/config attribution.sessionUrl=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011Lpcmcf4Nkojjdy2wvRYZG)_