### PR TITLE
Add missing Message-ID for all submitted messages, #536

### DIFF
--- a/hmailserver/source/Server/SMTP/SMTPConnection.cpp
+++ b/hmailserver/source/Server/SMTP/SMTPConnection.cpp
@@ -77,6 +77,7 @@ namespace HM
       rejected_by_delayed_grey_listing_(false),
       current_state_(INITIAL),
       trace_headers_written_(true),
+      message_submission_(false),
       requestedAuthenticationType_(AUTH_NONE),
       max_message_size_kb_(0),
       cur_no_of_rcptto_(0),
@@ -740,6 +741,15 @@ namespace HM
          return;
       }
 
+      // We act as message submission server (RFC 6409) for this message if the client has
+      // authenticated, or if it sends as one of our own domains from an IP range where we
+      // don't require authentication to do so. With the default configuration, the latter
+      // only applies to clients running on the server itself, such as web sites and scripts
+      // submitting mail over localhost. For everyone else we're a relay, and should not
+      // modify the message beyond adding trace fields.
+      if (isAuthenticated_ || (localSender && !authenticationRequired))
+         message_submission_ = true;
+
       // Pre-transmission spam protection.
       if (type_ == SPPreTransmission)
       {
@@ -890,7 +900,7 @@ namespace HM
       {
          std::shared_ptr<MimeHeader> original_headers = Utilities::GetMimeHeader(transmission_buffer_->GetBuffer()->GetBuffer(), transmission_buffer_->GetBuffer()->GetSize());
 
-         SMTPMessageHeaderCreator header_creator(username_, GetIPAddressString(), isAuthenticated_, helo_host_, original_headers, current_message_);
+         SMTPMessageHeaderCreator header_creator(username_, GetIPAddressString(), isAuthenticated_, message_submission_, helo_host_, original_headers, current_message_);
          
          if (IsSSLConnection())
             header_creator.SetCipherInfo(GetCipherInfo());
@@ -1472,6 +1482,8 @@ namespace HM
       }
 
       rejected_by_delayed_grey_listing_ = false;
+
+      message_submission_ = false;
 
       sender_domain_.reset();
       sender_account_.reset();

--- a/hmailserver/source/Server/SMTP/SMTPConnection.h
+++ b/hmailserver/source/Server/SMTP/SMTPConnection.h
@@ -191,6 +191,10 @@ namespace HM
 
       bool trace_headers_written_;
 
+      // True if we act as message submission server for the current message, rather
+      // than as a relay. Set when a recipient has been accepted.
+      bool message_submission_;
+
       String username_;
       String password_;
 

--- a/hmailserver/source/Server/SMTP/SMTPMessageHeaderCreator.cpp
+++ b/hmailserver/source/Server/SMTP/SMTPMessageHeaderCreator.cpp
@@ -23,10 +23,11 @@
 
 namespace HM
 {
-   SMTPMessageHeaderCreator::SMTPMessageHeaderCreator(const String &username, const AnsiString &remote_ip_address, bool is_authenticated, String helo_host, std::shared_ptr<MimeHeader> original_headers, std::shared_ptr<Message> message) :
+   SMTPMessageHeaderCreator::SMTPMessageHeaderCreator(const String &username, const AnsiString &remote_ip_address, bool is_authenticated, bool is_message_submission, String helo_host, std::shared_ptr<MimeHeader> original_headers, std::shared_ptr<Message> message) :
       username_(username),
       remote_ip_address_(remote_ip_address),
       is_authenticated_(is_authenticated),
+      is_message_submission_(is_message_submission),
       original_headers_(original_headers),
       helo_host_(helo_host),
       is_tls_(false),
@@ -70,12 +71,14 @@ namespace HM
       String sComputerName = Utilities::ComputerName();
 
       // Add Message-ID header if it does not exist. Adding a missing Message-ID is a
-      // message submission task (RFC 6409), so it's only done for authenticated senders.
+      // message submission task (RFC 6409), so it's only done for messages we've accepted
+      // for submission - either from an authenticated user, or from a client which is
+      // allowed to send as one of our domains without authenticating.
       // When another server relays a message to us we act as a relay rather than as a
       // submission server, and should only add trace fields. Inserting a Message-ID in
       // that case would hide from spam filters and rules further down the line that the
       // original message didn't have one.
-      if (is_authenticated_ && !original_headers_->FieldExists("Message-ID"))
+      if (is_message_submission_ && !original_headers_->FieldExists("Message-ID"))
       {
          String sTemp;
          sTemp.Format(_T("Message-ID: %s\r\n"), Utilities::GenerateMessageID().c_str());

--- a/hmailserver/source/Server/SMTP/SMTPMessageHeaderCreator.h
+++ b/hmailserver/source/Server/SMTP/SMTPMessageHeaderCreator.h
@@ -15,7 +15,7 @@ namespace HM
    {
    public:
       
-      SMTPMessageHeaderCreator(const String &username, const AnsiString &remote_ip_address, bool is_authenticated, String helo_host, std::shared_ptr<MimeHeader> original_headers, std::shared_ptr<Message> message);
+      SMTPMessageHeaderCreator(const String &username, const AnsiString &remote_ip_address, bool is_authenticated, bool is_message_submission, String helo_host, std::shared_ptr<MimeHeader> original_headers, std::shared_ptr<Message> message);
 
       AnsiString Create();
 
@@ -34,6 +34,7 @@ namespace HM
       CipherInfo cipher_info_;
       bool is_tls_;
       bool is_authenticated_;
+      bool is_message_submission_;
       
    };
 }

--- a/hmailserver/test/RegressionTests/SMTP/Basics.cs
+++ b/hmailserver/test/RegressionTests/SMTP/Basics.cs
@@ -281,11 +281,33 @@ namespace RegressionTests.SMTP
 
       [Test]
       [Category("SMTP")]
+      [Description("Issue 536: A missing Message-ID should be added for unauthenticated senders which are allowed to send as one of our domains, since we act as a submission server for them as well.")]
+      public void TestMessageIDAddedForLocalSenderNotRequiredToAuthenticate()
+      {
+         // The "My computer" IP range allows the local computer to send as one of our
+         // domains without authenticating. Web sites and scripts submitting mail over
+         // localhost rely on this.
+         var range =
+            SingletonProvider<TestSetup>.Instance.GetApp().Settings.SecurityRanges.get_ItemByName("My computer");
+         Assert.IsFalse(range.RequireSMTPAuthLocalToLocal);
+
+         SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "test@example.test", "test");
+
+         SmtpClientSimulator.StaticSend("test@example.test", "test@example.test", "Test subject", "Test body");
+
+         var test = Pop3ClientSimulator.AssertGetFirstMessageText("test@example.test", "test");
+
+         Assert.IsTrue(test.Contains("Message-ID: <"));
+      }
+
+      [Test]
+      [Category("SMTP")]
       [Description("Issue 536: A missing Message-ID should not be added to relayed messages, since that hides from spam filters that the original message had none.")]
-      public void TestMessageIDNotAddedForUnauthenticatedSender()
+      public void TestMessageIDNotAddedForRelayedMessage()
       {
          SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "test@example.test", "test");
 
+         // The sender is not one of our domains, so we're relaying rather than submitting.
          SmtpClientSimulator.StaticSend("someone@example.com", "test@example.test", "Test subject", "Test body");
 
          var test = Pop3ClientSimulator.AssertGetFirstMessageText("test@example.test", "test");


### PR DESCRIPTION
Follow-up to #542, which regressed mail submitted by unauthenticated local clients.

Adding a missing Message-ID is a submission task (RFC 6409), but authentication isn't the only way a client is accepted for submission: by default the "My computer" range lets clients on the server send as one of our domains without authenticating. Web sites and scripts submitting over localhost rely on that, and most of them (System.Net.Mail, Send-MailMessage, the COM API) write no Message-ID themselves, so their mail now goes out without one — triggering MISSING_MID and hurting deliverability.

Instead of hard-coding loopback, this reuses the submission/relay decision already made when a recipient is accepted:

```cpp
if (isAuthenticated_ || (localSender && !authenticationRequired))
   message_submission_ = true;
```

which is then passed to `SMTPMessageHeaderCreator` in place of the authentication flag. Relayed mail from other servers still gets trace fields only, so a missing Message-ID stays visible to spam filters, and LAN ranges opened for relaying are covered without hard-coding an address range.

Tests: added a case for the regression, and renamed `TestMessageIDNotAddedForUnauthenticatedSender` to `TestMessageIDNotAddedForRelayedMessage` — its assertion is unchanged and still passes.

Not compiled or run here (Linux environment, no MSVC build or live instance).