### PR TITLE
Flush log files when they are kept open, #549

### DIFF
--- a/hmailserver/source/Server/Common/Application/Logger.cpp
+++ b/hmailserver/source/Server/Common/Application/Logger.cpp
@@ -326,7 +326,7 @@ namespace HM
 
       try
       {
-         bool fileExists = FileUtilities::Exists(fileName);
+         fileExists = FileUtilities::Exists(fileName);
       }
       catch (boost::system::system_error&)
       {
@@ -409,7 +409,13 @@ namespace HM
          file->Write(sAnsiString);
       }
 
-      if (!keepFileOpen)
+      if (keepFileOpen)
+      {
+         // The file is buffered by the CRT and won't be closed after this write. Flush it, so that
+         // the last lines don't remain invisible in the log file while the server is idle.
+         file->Flush();
+      }
+      else
          file->Close();
    }
 

--- a/hmailserver/source/Server/Common/Util/File.cpp
+++ b/hmailserver/source/Server/Common/Util/File.cpp
@@ -171,6 +171,15 @@ namespace HM
       return true;
    }
 
+   bool
+   File::Flush()
+   {
+      if (file_ == nullptr)
+         return false;
+
+      return fflush(file_) == 0;
+   }
+
    bool 
    File::ReadLine(AnsiString &sLine)
    {

--- a/hmailserver/source/Server/Common/Util/File.h
+++ b/hmailserver/source/Server/Common/Util/File.h
@@ -40,6 +40,8 @@ namespace HM
       bool Write(File &sourceFile);
       bool WriteBOF();
 
+      bool Flush();
+
       void Write_(void *buffer, int item_size, int item_count);
       int GetSize();
 


### PR DESCRIPTION
Log data is written through a CRT-buffered `FILE*`. With "Keep files open" enabled the file is never closed after a write, so on an idle server the last lines sit in the buffer instead of appearing in the log. Adds `File::Flush` and flushes after each write when the file is kept open.

Also fixes a shadowed `fileExists` local in `Logger::GetCurrentLogFile_` that made it always false — which reopened the file on every write despite "Keep files open", and wrote a BOM before every line of the backup and event logs.

Fixes #549

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyYuCCqSoNGMDUaYL1Efwo)_