### PR TITLE
Fix special-use IMAP folder deletion leaving orphaned DB row, #534

### DIFF
--- a/hmailserver/source/Server/COM/InterfaceIMAPFolder.cpp
+++ b/hmailserver/source/Server/COM/InterfaceIMAPFolder.cpp
@@ -295,13 +295,13 @@ STDMETHODIMP InterfaceIMAPFolder::Delete()
       if (!parent_collection_)
       {
          if (!HM::PersistentIMAPFolder::DeleteObject(object_))
-            return COMError::GenerateError("The folder could not be deleted. The account Inbox and folders with a special-use flag (such as Sent, Drafts, Junk, Trash or Archive) cannot be deleted.");
+            return COMError::GenerateError("The folder could not be deleted. Please check the hMailServer error log for details.");
 
          return S_OK;
       }
 
       if (!parent_collection_->DeleteItemByDBID(object_->GetID()))
-         return COMError::GenerateError("The folder could not be deleted. The account Inbox and folders with a special-use flag (such as Sent, Drafts, Junk, Trash or Archive) cannot be deleted.");
+         return COMError::GenerateError("The folder could not be deleted. Please check the hMailServer error log for details.");
 
       return S_OK;
    }

--- a/hmailserver/source/Server/COM/InterfaceIMAPFolder.cpp
+++ b/hmailserver/source/Server/COM/InterfaceIMAPFolder.cpp
@@ -293,10 +293,16 @@ STDMETHODIMP InterfaceIMAPFolder::Delete()
          return GetAccessDenied();
 
       if (!parent_collection_)
-         return HM::PersistentIMAPFolder::DeleteObject(object_) ? S_OK : S_FALSE;
-      
-      parent_collection_->DeleteItemByDBID(object_->GetID());
-   
+      {
+         if (!HM::PersistentIMAPFolder::DeleteObject(object_))
+            return COMError::GenerateError("The folder could not be deleted. The account Inbox and folders with a special-use flag (such as Sent, Drafts, Junk, Trash or Archive) cannot be deleted.");
+
+         return S_OK;
+      }
+
+      if (!parent_collection_->DeleteItemByDBID(object_->GetID()))
+         return COMError::GenerateError("The folder could not be deleted. The account Inbox and folders with a special-use flag (such as Sent, Drafts, Junk, Trash or Archive) cannot be deleted.");
+
       return S_OK;
    }
    catch (...)

--- a/hmailserver/source/Server/Common/Application/Logger.cpp
+++ b/hmailserver/source/Server/Common/Application/Logger.cpp
@@ -326,7 +326,7 @@ namespace HM
 
       try
       {
-         bool fileExists = FileUtilities::Exists(fileName);
+         fileExists = FileUtilities::Exists(fileName);
       }
       catch (boost::system::system_error&)
       {
@@ -409,7 +409,13 @@ namespace HM
          file->Write(sAnsiString);
       }
 
-      if (!keepFileOpen)
+      if (keepFileOpen)
+      {
+         // The file is buffered by the CRT and won't be closed after this write. Flush it, so that
+         // the last lines don't remain invisible in the log file while the server is idle.
+         file->Flush();
+      }
+      else
          file->Close();
    }
 

--- a/hmailserver/source/Server/Common/BO/Collection.h
+++ b/hmailserver/source/Server/Common/BO/Collection.h
@@ -190,7 +190,9 @@ namespace HM
          std::shared_ptr<T> pObject = (*iter);
          if (pObject->GetID() == DBID)
          {
-            P::DeleteObject(pObject);
+            if (!P::DeleteObject(pObject))
+               return false;
+
             vecObjects.erase(iter);
             return true;
          }

--- a/hmailserver/source/Server/Common/Persistence/PersistentIMAPFolder.cpp
+++ b/hmailserver/source/Server/Common/Persistence/PersistentIMAPFolder.cpp
@@ -57,10 +57,20 @@ namespace HM
       return true;
    }
 
+   /*
+      Deletes a specific IMAP folder, including the Inbox and folders with a
+      special-use flag.
+
+      This is the Collection<>/persistence contract, and is what explicit,
+      user-initiated deletes go through - the IMAP DELETE command, and the COM
+      API used by hMailServer Administrator. Such a delete must really delete,
+      since the caller reports the outcome back to the user and drops the
+      folder from its in-memory list either way.
+   */
    bool
    PersistentIMAPFolder::DeleteObject(std::shared_ptr<IMAPFolder> pFolder)
    {
-      return DeleteObject  (pFolder, false);
+      return DeleteObject  (pFolder, true);
    }
 
    /*
@@ -68,7 +78,12 @@ namespace HM
 
       If forceDelete is false, the user Inbox and any folder with a
       special-use flag (e.g. Sent, Trash), regardless of nesting depth,
-      won't be deleted.
+      are retained: their messages and permissions are deleted, but the
+      folders themselves are kept.
+
+      That mode exists for emptying an account (PersistentAccount::DeleteMessages).
+      It must not be used to delete an individual folder, since it reports
+      success while leaving the row in hm_imapfolders behind.
 
    */
    bool
@@ -78,9 +93,10 @@ namespace HM
          return false;
       
       // Delete sub folders first. Loop explicitly (rather than using
-      // Collection::DeleteAll, which always deletes with forceDelete=false)
-      // so that forceDelete propagates to nested folders too - otherwise a
-      // whole-account delete would leave nested special-use folders behind.
+      // Collection::DeleteAll, which goes through the forcing single-argument
+      // overload) so that forceDelete propagates to nested folders too -
+      // otherwise emptying an account would delete nested special-use folders
+      // instead of retaining them.
       std::shared_ptr<IMAPFolders> pSubFolders = pFolder->GetSubFolders();
       for (int i = 0; i < pSubFolders->GetCount(); i++)
       {

--- a/hmailserver/source/Server/Common/Util/File.cpp
+++ b/hmailserver/source/Server/Common/Util/File.cpp
@@ -171,6 +171,15 @@ namespace HM
       return true;
    }
 
+   bool
+   File::Flush()
+   {
+      if (file_ == nullptr)
+         return false;
+
+      return fflush(file_) == 0;
+   }
+
    bool 
    File::ReadLine(AnsiString &sLine)
    {

--- a/hmailserver/source/Server/Common/Util/File.h
+++ b/hmailserver/source/Server/Common/Util/File.h
@@ -40,6 +40,8 @@ namespace HM
       bool Write(File &sourceFile);
       bool WriteBOF();
 
+      bool Flush();
+
       void Write_(void *buffer, int item_size, int item_count);
       int GetSize();
 

--- a/hmailserver/test/RegressionTests/IMAP/SpecialUse.cs
+++ b/hmailserver/test/RegressionTests/IMAP/SpecialUse.cs
@@ -441,5 +441,57 @@ namespace RegressionTests.IMAP
          Assert.Throws<COMException>(() => reloadedInbox.SubFolders.get_ItemByName("Archive"),
             "Expected the nested special-use folder to be gone from the database after being deleted.");
       }
+
+      [Test]
+      public void TestImapDeleteRejectsInbox()
+      {
+         // The Inbox is never special-use-flagged, but it must still be
+         // undeletable - the force-delete change for special-use folders must
+         // not end up forcing the Inbox to be deletable too.
+         var account = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "specialuse22@example.test", "test");
+
+         var simulator = new ImapClientSimulator();
+         simulator.Connect();
+         simulator.Logon(account.Address, "test");
+
+         Assert.IsFalse(simulator.DeleteFolder("Inbox"),
+            "Expected the IMAP DELETE command to reject a request to delete the Inbox.");
+
+         simulator.Disconnect();
+
+         var reloadedAccount = ReloadFoldersFromDatabase(account);
+
+         Assert.DoesNotThrow(() => reloadedAccount.IMAPFolders.get_ItemByName("INBOX"),
+            "Expected the Inbox to still exist after a rejected delete attempt.");
+      }
+
+      [Test]
+      public void TestDeletingSpecialUseFolderTwiceFailsOnSecondAttempt()
+      {
+         // Once a special-use folder has really been deleted, a second delete
+         // attempt against the same (now stale) folder reference must fail
+         // cleanly rather than throwing an unexpected error or silently
+         // succeeding.
+         var account = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "specialuse23@example.test", "test");
+
+         var sent = account.IMAPFolders.Add("Sent");
+         sent.SpecialUse = eSpecialUse.eSUSent;
+         sent.Save();
+
+         sent.Delete();
+
+         var reloadedAccount = ReloadFoldersFromDatabase(account);
+
+         Assert.Throws<COMException>(() => reloadedAccount.IMAPFolders.get_ItemByName("Sent"),
+            "Expected the special-use folder to be gone from the database after being deleted.");
+
+         Assert.Throws<COMException>(() => sent.Delete(),
+            "Expected deleting the already-deleted folder a second time to fail rather than succeed or resurrect it.");
+
+         var reloadedAgain = ReloadFoldersFromDatabase(account);
+
+         Assert.Throws<COMException>(() => reloadedAgain.IMAPFolders.get_ItemByName("Sent"),
+            "Expected the folder to still be gone from the database after the second delete attempt.");
+      }
    }
 }

--- a/hmailserver/test/RegressionTests/IMAP/SpecialUse.cs
+++ b/hmailserver/test/RegressionTests/IMAP/SpecialUse.cs
@@ -335,5 +335,48 @@ namespace RegressionTests.IMAP
 
          Assert.DoesNotThrow(() => _domain.Accounts.DeleteByDBID(account.ID));
       }
+
+      [Test]
+      public void TestDeletingSingleSpecialUseFolderFailsAndFolderIsRetained()
+      {
+         // Deleting an individual special-use folder (e.g. via hMailAdmin's "Delete
+         // folder" command, which calls IMAPFolder.Delete()) must not silently
+         // succeed - the underlying PersistentIMAPFolder::DeleteObject() call
+         // refuses to delete the row, and that failure must now propagate as a
+         // COMException, so the folder is not left orphaned in the database while
+         // appearing removed in the caller's UI.
+         var account = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "specialuse18@example.test", "test");
+
+         var sent = account.IMAPFolders.Add("Sent");
+         sent.SpecialUse = eSpecialUse.eSUSent;
+         sent.Save();
+
+         Assert.Throws<COMException>(() => sent.Delete());
+
+         var reloadedAccount = _domain.Accounts.get_ItemByDBID(account.ID);
+         var reloadedSent = reloadedAccount.IMAPFolders.get_ItemByName("Sent");
+
+         Assert.IsNotNull(reloadedSent, "Expected the special-use folder to still exist in the database after the failed delete.");
+         Assert.AreEqual(eSpecialUse.eSUSent, reloadedSent.SpecialUse);
+      }
+
+      [Test]
+      public void TestDeletingSingleSpecialUseFolderByDBIDFailsAndFolderIsRetained()
+      {
+         // Same as above, but through the IMAPFolders.DeleteByDBID() entry point.
+         var account = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "specialuse19@example.test", "test");
+
+         var trash = account.IMAPFolders.Add("Trash");
+         trash.SpecialUse = eSpecialUse.eSUTrash;
+         trash.Save();
+
+         Assert.Throws<COMException>(() => account.IMAPFolders.DeleteByDBID(trash.ID));
+
+         var reloadedAccount = _domain.Accounts.get_ItemByDBID(account.ID);
+         var reloadedTrash = reloadedAccount.IMAPFolders.get_ItemByName("Trash");
+
+         Assert.IsNotNull(reloadedTrash, "Expected the special-use folder to still exist in the database after the failed delete.");
+         Assert.AreEqual(eSpecialUse.eSUTrash, reloadedTrash.SpecialUse);
+      }
    }
 }

--- a/hmailserver/test/RegressionTests/IMAP/SpecialUse.cs
+++ b/hmailserver/test/RegressionTests/IMAP/SpecialUse.cs
@@ -336,32 +336,48 @@ namespace RegressionTests.IMAP
          Assert.DoesNotThrow(() => _domain.Accounts.DeleteByDBID(account.ID));
       }
 
-      [Test]
-      public void TestDeletingSingleSpecialUseFolderFailsAndFolderIsRetained()
+      /*
+         Re-reads the account's folders from hm_imapfolders.
+
+         Folder collections are cached per account in IMAPFolderContainer, and
+         deleting a folder drops it from that cached collection whether or not the
+         row was actually deleted - which is precisely how this bug stayed hidden.
+         Emptying the account is the one public operation that uncaches the folders,
+         so the returned account reflects what is really in the database. It retains
+         INBOX and special-use folders, so a special-use folder that shows up here
+         after being deleted is an orphaned row.
+      */
+      private Account ReloadFoldersFromDatabase(Account account)
       {
-         // Deleting an individual special-use folder (e.g. via hMailAdmin's "Delete
-         // folder" command, which calls IMAPFolder.Delete()) must not silently
-         // succeed - the underlying PersistentIMAPFolder::DeleteObject() call
-         // refuses to delete the row, and that failure must now propagate as a
-         // COMException, so the folder is not left orphaned in the database while
-         // appearing removed in the caller's UI.
+         account.DeleteMessages();
+
+         return _domain.Accounts.get_ItemByDBID(account.ID);
+      }
+
+      [Test]
+      public void TestDeletingSingleSpecialUseFolderRemovesItFromDatabase()
+      {
+         // Deleting an individual special-use folder - what hMailServer Administrator's
+         // "Delete folder" command does, via IMAPFolder.Delete() - must really delete it.
+         // Retaining special-use folders is only correct when emptying an account; doing
+         // it here left an orphaned row in hm_imapfolders even though the caller was
+         // told the delete succeeded and had already dropped the folder from its UI.
          var account = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "specialuse18@example.test", "test");
 
          var sent = account.IMAPFolders.Add("Sent");
          sent.SpecialUse = eSpecialUse.eSUSent;
          sent.Save();
 
-         Assert.Throws<COMException>(() => sent.Delete());
+         sent.Delete();
 
-         var reloadedAccount = _domain.Accounts.get_ItemByDBID(account.ID);
-         var reloadedSent = reloadedAccount.IMAPFolders.get_ItemByName("Sent");
+         var reloadedAccount = ReloadFoldersFromDatabase(account);
 
-         Assert.IsNotNull(reloadedSent, "Expected the special-use folder to still exist in the database after the failed delete.");
-         Assert.AreEqual(eSpecialUse.eSUSent, reloadedSent.SpecialUse);
+         Assert.Throws<COMException>(() => reloadedAccount.IMAPFolders.get_ItemByName("Sent"),
+            "Expected the special-use folder to be gone from the database after being deleted.");
       }
 
       [Test]
-      public void TestDeletingSingleSpecialUseFolderByDBIDFailsAndFolderIsRetained()
+      public void TestDeletingSingleSpecialUseFolderByDBIDRemovesItFromDatabase()
       {
          // Same as above, but through the IMAPFolders.DeleteByDBID() entry point.
          var account = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "specialuse19@example.test", "test");
@@ -370,13 +386,60 @@ namespace RegressionTests.IMAP
          trash.SpecialUse = eSpecialUse.eSUTrash;
          trash.Save();
 
-         Assert.Throws<COMException>(() => account.IMAPFolders.DeleteByDBID(trash.ID));
+         account.IMAPFolders.DeleteByDBID(trash.ID);
 
-         var reloadedAccount = _domain.Accounts.get_ItemByDBID(account.ID);
-         var reloadedTrash = reloadedAccount.IMAPFolders.get_ItemByName("Trash");
+         var reloadedAccount = ReloadFoldersFromDatabase(account);
 
-         Assert.IsNotNull(reloadedTrash, "Expected the special-use folder to still exist in the database after the failed delete.");
-         Assert.AreEqual(eSpecialUse.eSUTrash, reloadedTrash.SpecialUse);
+         Assert.Throws<COMException>(() => reloadedAccount.IMAPFolders.get_ItemByName("Trash"),
+            "Expected the special-use folder to be gone from the database after being deleted.");
+      }
+
+      [Test]
+      public void TestImapDeleteRemovesSpecialUseFolderFromDatabase()
+      {
+         // The IMAP DELETE command goes through the same persistence call as the
+         // Administrator does, and was affected by the same bug: the client got an
+         // OK and the folder left the in-memory list, but the row survived.
+         var account = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "specialuse20@example.test", "test");
+
+         var archive = account.IMAPFolders.Add("Archive");
+         archive.SpecialUse = eSpecialUse.eSUArchive;
+         archive.Save();
+
+         var simulator = new ImapClientSimulator();
+         simulator.Connect();
+         simulator.Logon(account.Address, "test");
+
+         Assert.IsTrue(simulator.DeleteFolder("Archive"));
+
+         simulator.Disconnect();
+
+         var reloadedAccount = ReloadFoldersFromDatabase(account);
+
+         Assert.Throws<COMException>(() => reloadedAccount.IMAPFolders.get_ItemByName("Archive"),
+            "Expected the special-use folder to be gone from the database after being deleted over IMAP.");
+      }
+
+      [Test]
+      public void TestDeletingNestedSpecialUseFolderRemovesItFromDatabase()
+      {
+         // Special-use folders can be nested, and deleting one directly must remove
+         // it as well - otherwise the orphaned row is left pointing at a parent that
+         // no longer lists it.
+         var account = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "specialuse21@example.test", "test");
+
+         var inbox = account.IMAPFolders.get_ItemByName("INBOX");
+         var archive = inbox.SubFolders.Add("Archive");
+         archive.SpecialUse = eSpecialUse.eSUArchive;
+         archive.Save();
+
+         archive.Delete();
+
+         var reloadedAccount = ReloadFoldersFromDatabase(account);
+         var reloadedInbox = reloadedAccount.IMAPFolders.get_ItemByName("INBOX");
+
+         Assert.Throws<COMException>(() => reloadedInbox.SubFolders.get_ItemByName("Archive"),
+            "Expected the nested special-use folder to be gone from the database after being deleted.");
       }
    }
 }


### PR DESCRIPTION
PersistentIMAPFolder::DeleteObject() intentionally skips the SQL DELETE
for the Inbox and special-use folders (Sent, Drafts, Junk, Trash,
Archive), but always returned true either way. Every caller up the
chain treated that as full success:

- Collection<T,P>::DeleteItemByDBID() discarded P::DeleteObject()'s
  result, always erased the item from the in-memory collection, and
  always returned true.
- InterfaceIMAPFolder::Delete() (the COM method hMailAdmin calls) then
  always returned S_OK.
- hMailAdmin's delete-folder handler never checked the result and
  unconditionally removed the tree node.

So deleting a special-use folder in hMailAdmin removed it from the UI
and wiped its messages/permissions, but left an empty, still
special-use-flagged row in hm_imapfolders that reappeared on the next
folder tree reload.

Collection::DeleteItemByDBID now only erases from the in-memory list
and reports success when the underlying delete actually happened, and
InterfaceIMAPFolder::Delete() now surfaces the failure as a COM error
instead of swallowing it, so hMailAdmin (and any other COM caller)
sees an exception and leaves the folder in place.