### PR TITLE
Add exception guard to Directories method

### DIFF
--- a/hmailserver/source/Server/COM/COMError.h
+++ b/hmailserver/source/Server/COM/COMError.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include "../Common/Application/ErrorManager.h"
+#include "../Common/Util/ScopedSETranslator.h"
+
 class COMError
 {
 public:
@@ -11,4 +14,32 @@ public:
 
    static HRESULT GenerateGenericMessage();
    static HRESULT GenerateError(HM::String sDescription);
+
+   // Runs func() inside a try/catch that installs a structured-exception
+   // translator (so access violations / null dereferences are caught too),
+   // logs the full exception detail to the hMailServer error log, and returns
+   // a generic COM HRESULT to the caller. The detailed message is deliberately
+   // kept out of the returned error to avoid leaking internal details to the
+   // (potentially untrusted) script caller. Reusable across COM getters/setters.
+   template <typename Func>
+   static HRESULT Guard(const char *source, Func func)
+   {
+      try
+      {
+         HM::ScopedSETranslator se_translator;
+         return func();
+      }
+      catch (std::exception const &e)
+      {
+         HM::ErrorManager::Instance()->ReportError(HM::ErrorManager::Medium, 4231, source,
+            "Unhandled exception in COM call.", e);
+         return GenerateGenericMessage();
+      }
+      catch (...)
+      {
+         HM::ErrorManager::Instance()->ReportError(HM::ErrorManager::Medium, 4231, source,
+            "Unknown exception in COM call.");
+         return GenerateGenericMessage();
+      }
+   }
 };

--- a/hmailserver/source/Server/COM/InterfaceSettings.cpp
+++ b/hmailserver/source/Server/COM/InterfaceSettings.cpp
@@ -1110,29 +1110,25 @@ STDMETHODIMP InterfaceSettings::get_Backup(IInterfaceBackupSettings **pVal)
 
 STDMETHODIMP InterfaceSettings::get_Directories(IInterfaceDirectories **pVal)
 {
-   try
+   return COMError::Guard("InterfaceSettings::get_Directories", [&]() -> HRESULT
    {
       if (!config_)
          return GetAccessDenied();
 
       if (!GetIsServerAdmin())
          return authentication_->GetAccessDenied();
-   
+
       CComObject<InterfaceDirectories>* pItem = new CComObject<InterfaceDirectories>();
-   
+
       ini_file_settings_->LoadSettings();
-   
+
       pItem->SetAuthentication(authentication_);
       pItem->LoadSettings(ini_file_settings_);
       pItem->AddRef();
       *pVal = pItem;
-   
+
       return S_OK;
-   }
-   catch (...)
-   {
-      return COMError::GenerateGenericMessage();
-   }
+   });
 }
 
 STDMETHODIMP InterfaceSettings::get_AntiSpam(IInterfaceAntiSpam **pVal)

--- a/hmailserver/source/Server/Common/Util/ScopedSETranslator.h
+++ b/hmailserver/source/Server/Common/Util/ScopedSETranslator.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2010 Martin Knafve / hMailServer.com.
+// http://www.hmailserver.com
+
+#pragma once
+
+#include <eh.h>
+#include <stdexcept>
+#include <cstdio>
+
+#include "ExceptionLogger.h"
+
+namespace HM
+{
+   // Converts a Windows structured exception (access violation, etc.) into a
+   // C++ exception on the current thread for the lifetime of the object, so it
+   // can be caught by a normal catch (std::exception) handler. The previous
+   // translator is restored on destruction.
+   //
+   // Requires the module to be compiled with /EHa (Async exception handling),
+   // which hMailServer already uses.
+   //
+   // Note: _set_se_translator is per-thread, so an instance only affects the
+   // thread that constructed it.
+   class ScopedSETranslator
+   {
+   public:
+      ScopedSETranslator() : previous_(_set_se_translator(Translate)) {}
+      ~ScopedSETranslator() { _set_se_translator(previous_); }
+
+      ScopedSETranslator(const ScopedSETranslator&) = delete;
+      ScopedSETranslator& operator=(const ScopedSETranslator&) = delete;
+
+   private:
+      static void Translate(unsigned int code, EXCEPTION_POINTERS *ep)
+      {
+         // Write a minidump (via hMailServer.minidump.exe) while the faulting
+         // stack is still intact, so the crash can be opened in a debugger
+         // afterwards. Guarded so a failure here can't mask the original fault.
+         if (ep)
+         {
+            try
+            {
+               ExceptionLogger::Log(code, ep);
+            }
+            catch (...)
+            {
+               // Don't let dump generation swallow the real exception.
+            }
+         }
+
+         char msg[128];
+         sprintf_s(msg, sizeof(msg), "Structured exception 0x%08X at address 0x%p",
+            code, ep ? ep->ExceptionRecord->ExceptionAddress : nullptr);
+         throw std::runtime_error(msg);
+      }
+
+      _se_translator_function previous_;
+   };
+}

--- a/hmailserver/source/Server/hMailServer/hMailServer.vcxproj
+++ b/hmailserver/source/Server/hMailServer/hMailServer.vcxproj
@@ -940,6 +940,7 @@ EXIT 0
     <ClInclude Include="..\Common\Util\ProcessLauncher.h" />
     <ClInclude Include="..\Common\Util\Registry.h" />
     <ClInclude Include="..\Common\Util\RegularExpression.h" />
+    <ClInclude Include="..\Common\Util\ScopedSETranslator.h" />
     <ClInclude Include="..\Common\Util\ServerInfo.h" />
     <ClInclude Include="..\Common\Util\ServerStatus.h" />
     <ClInclude Include="..\Common\Util\ServiceManager.h" />


### PR DESCRIPTION
If `get_Directories` crashes, the guard will catch it, log it and produce a mini dump.