### PR TITLE
Fix Rule details page's parent in the manual

### DIFF
--- a/hmailserver/documentation/details_rules.md
+++ b/hmailserver/documentation/details_rules.md
@@ -2,7 +2,7 @@
 id: 426
 title: "Rule details"
 slug: details_rules
-parent: null
+parent: reference_rule
 index: 0
 is_book: false
 updated: 2009-07-03


### PR DESCRIPTION
## Summary
- \`details_rules\` ("Rule details") was set to \`parent: null\` (root-level) during the website migration in #560, as a workaround for a dangling parent reference (id 18) in the old CMS export.
- Its sibling \`details_rules_examples\` ("Rule examples") is correctly parented under \`reference_rule\` ("Rule") - confirming that's where "Rule details" belongs too, not at the top level.
- Same fix already applied to the archived manual versions (v5.2-v5.6) that had the same issue, in the website repo.

## Test plan
- [ ] Confirm the table of contents nests "Rule details" under "Rule" alongside "Rule examples" after the next docs rebuild