### PR TITLE
Remove unused id/updated front-matter fields from manual pages

### DIFF
--- a/hmailserver/documentation/README.md
+++ b/hmailserver/documentation/README.md
@@ -17,19 +17,16 @@ Every file starts with a YAML front matter block:
 
 ```
 ---
-id: 1
 title: "Page title"
 slug: page_slug
 parent: parent_slug   # or "null" for a top-level page
 index: 10             # sort order among siblings
 is_book: false         # true for a section heading with no page content of its own
-updated: 2021-08-15
 ---
 ```
 
 - `slug` must be unique across the whole tree and match the filename (minus `.md`).
 - `parent` refers to another page's `slug`, not a path.
-- `id` is carried over from the legacy CMS for traceability; new pages can pick any unused integer.
 
 ## Body
 

--- a/hmailserver/documentation/book_before_installation/_index.md
+++ b/hmailserver/documentation/book_before_installation/_index.md
@@ -1,11 +1,9 @@
 ---
-id: 158
 title: "Before installation"
 slug: book_before_installation
 parent: null
 index: 0
 is_book: true
-updated: 2006-01-21
 ---
 
 

--- a/hmailserver/documentation/book_before_installation/changelog.md
+++ b/hmailserver/documentation/book_before_installation/changelog.md
@@ -1,11 +1,9 @@
 ---
-id: 203
 title: "hMailServer Change log"
 slug: changelog
 parent: book_before_installation
 index: 60
 is_book: false
-updated: 2014-11-16
 ---
 
 ## Change log has moved

--- a/hmailserver/documentation/book_before_installation/information_author.md
+++ b/hmailserver/documentation/book_before_installation/information_author.md
@@ -1,11 +1,9 @@
 ---
-id: 93
 title: "Author information"
 slug: information_author
 parent: book_before_installation
 index: 40
 is_book: false
-updated: 2010-02-16
 ---
 
 The server technology and overall design of hMailServer is in the hands of [Martin Knafve](mailto:martin@hmailserver.com).

--- a/hmailserver/documentation/book_before_installation/information_copyright.md
+++ b/hmailserver/documentation/book_before_installation/information_copyright.md
@@ -1,11 +1,9 @@
 ---
-id: 450
 title: "Copyright information"
 slug: information_copyright
 parent: book_before_installation
 index: 0
 is_book: false
-updated: 2016-03-09
 ---
 
 ## Copyright

--- a/hmailserver/documentation/book_before_installation/whatis_hmailserver.md
+++ b/hmailserver/documentation/book_before_installation/whatis_hmailserver.md
@@ -1,11 +1,9 @@
 ---
-id: 70
 title: "What is hMailServer?"
 slug: whatis_hmailserver
 parent: book_before_installation
 index: 10
 is_book: false
-updated: 2015-11-15
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_before_installation/whatis_pop3imapsmtp.md
+++ b/hmailserver/documentation/book_before_installation/whatis_pop3imapsmtp.md
@@ -1,11 +1,9 @@
 ---
-id: 2
 title: "What are SMTP, POP3 and IMAP?"
 slug: whatis_pop3imapsmtp
 parent: book_before_installation
 index: 20
 is_book: false
-updated: 2006-01-18
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_configuration/_index.md
+++ b/hmailserver/documentation/book_configuration/_index.md
@@ -1,11 +1,9 @@
 ---
-id: 162
 title: "Configuration"
 slug: book_configuration
 parent: null
 index: 40
 is_book: true
-updated: 2006-01-21
 ---
 
 

--- a/hmailserver/documentation/book_configuration/reference_account.md
+++ b/hmailserver/documentation/book_configuration/reference_account.md
@@ -1,11 +1,9 @@
 ---
-id: 33
 title: "Account"
 slug: reference_account
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2022-09-12
 ---
 
 ## General

--- a/hmailserver/documentation/book_configuration/reference_advanced.md
+++ b/hmailserver/documentation/book_configuration/reference_advanced.md
@@ -1,11 +1,9 @@
 ---
-id: 245
 title: "Advanced"
 slug: reference_advanced
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2009-08-18
 ---
 
 ## General

--- a/hmailserver/documentation/book_configuration/reference_alias.md
+++ b/hmailserver/documentation/book_configuration/reference_alias.md
@@ -1,11 +1,9 @@
 ---
-id: 110
 title: "Alias"
 slug: reference_alias
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2009-07-03
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_configuration/reference_antispam.md
+++ b/hmailserver/documentation/book_configuration/reference_antispam.md
@@ -1,11 +1,9 @@
 ---
-id: 118
 title: "Anti spam"
 slug: reference_antispam
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2023-02-20
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_configuration/reference_antivirus.md
+++ b/hmailserver/documentation/book_configuration/reference_antivirus.md
@@ -1,11 +1,9 @@
 ---
-id: 117
 title: "Anti virus"
 slug: reference_antivirus
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2021-05-23
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_configuration/reference_autoban.md
+++ b/hmailserver/documentation/book_configuration/reference_autoban.md
@@ -1,11 +1,9 @@
 ---
-id: 429
 title: "Auto-ban"
 slug: reference_autoban
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2022-09-13
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_configuration/reference_backup.md
+++ b/hmailserver/documentation/book_configuration/reference_backup.md
@@ -1,11 +1,9 @@
 ---
-id: 131
 title: "Backup"
 slug: reference_backup
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2009-07-03
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_configuration/reference_distributionlist.md
+++ b/hmailserver/documentation/book_configuration/reference_distributionlist.md
@@ -1,11 +1,9 @@
 ---
-id: 116
 title: "Distribution list"
 slug: reference_distributionlist
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2016-04-17
 ---
 
 ## General

--- a/hmailserver/documentation/book_configuration/reference_dnsblacklist.md
+++ b/hmailserver/documentation/book_configuration/reference_dnsblacklist.md
@@ -1,11 +1,9 @@
 ---
-id: 121
 title: "DNS blacklist"
 slug: reference_dnsblacklist
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2010-03-13
 ---
 
 ## General

--- a/hmailserver/documentation/book_configuration/reference_domain.md
+++ b/hmailserver/documentation/book_configuration/reference_domain.md
@@ -1,11 +1,9 @@
 ---
-id: 34
 title: "Domain"
 slug: reference_domain
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2021-08-12
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_configuration/reference_external_account.md
+++ b/hmailserver/documentation/book_configuration/reference_external_account.md
@@ -1,11 +1,9 @@
 ---
-id: 88
 title: "External accounts"
 slug: reference_external_account
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2014-09-23
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_configuration/reference_greylisting.md
+++ b/hmailserver/documentation/book_configuration/reference_greylisting.md
@@ -1,11 +1,9 @@
 ---
-id: 186
 title: "Grey listing"
 slug: reference_greylisting
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2017-01-08
 ---
 
 ## General

--- a/hmailserver/documentation/book_configuration/reference_group.md
+++ b/hmailserver/documentation/book_configuration/reference_group.md
@@ -1,11 +1,9 @@
 ---
-id: 244
 title: "Group"
 slug: reference_group
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2017-11-04
 ---
 
 ## General

--- a/hmailserver/documentation/book_configuration/reference_incomingrelay.md
+++ b/hmailserver/documentation/book_configuration/reference_incomingrelay.md
@@ -1,11 +1,9 @@
 ---
-id: 428
 title: "Incoming relay"
 slug: reference_incomingrelay
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2016-07-20
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_configuration/reference_inifilesettings.md
+++ b/hmailserver/documentation/book_configuration/reference_inifilesettings.md
@@ -1,11 +1,9 @@
 ---
-id: 218
 title: "Ini-file settings"
 slug: reference_inifilesettings
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2016-12-20
 ---
 
 # Overview

--- a/hmailserver/documentation/book_configuration/reference_iprange.md
+++ b/hmailserver/documentation/book_configuration/reference_iprange.md
@@ -1,11 +1,9 @@
 ---
-id: 122
 title: "IP range"
 slug: reference_iprange
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2014-08-16
 ---
 
 ## General

--- a/hmailserver/documentation/book_configuration/reference_live.md
+++ b/hmailserver/documentation/book_configuration/reference_live.md
@@ -1,11 +1,9 @@
 ---
-id: 35
 title: "Live"
 slug: reference_live
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2005-11-22
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_configuration/reference_logging.md
+++ b/hmailserver/documentation/book_configuration/reference_logging.md
@@ -1,11 +1,9 @@
 ---
-id: 120
 title: "Logging"
 slug: reference_logging
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2010-12-25
 ---
 
 ## General

--- a/hmailserver/documentation/book_configuration/reference_mirror.md
+++ b/hmailserver/documentation/book_configuration/reference_mirror.md
@@ -1,11 +1,9 @@
 ---
-id: 219
 title: "Mirror"
 slug: reference_mirror
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2007-02-10
 ---
 
 # Overview

--- a/hmailserver/documentation/book_configuration/reference_mxquery.md
+++ b/hmailserver/documentation/book_configuration/reference_mxquery.md
@@ -1,11 +1,9 @@
 ---
-id: 250
 title: "MX query"
 slug: reference_mxquery
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2008-08-16
 ---
 
 ## MX query

--- a/hmailserver/documentation/book_configuration/reference_performance.md
+++ b/hmailserver/documentation/book_configuration/reference_performance.md
@@ -1,11 +1,9 @@
 ---
-id: 188
 title: "Performance"
 slug: reference_performance
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2009-09-17
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_configuration/reference_protocolimap.md
+++ b/hmailserver/documentation/book_configuration/reference_protocolimap.md
@@ -1,11 +1,9 @@
 ---
-id: 75
 title: "IMAP settings"
 slug: reference_protocolimap
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2009-07-20
 ---
 
 <h3><span class="Title">General</span></h3>

--- a/hmailserver/documentation/book_configuration/reference_protocolpop3.md
+++ b/hmailserver/documentation/book_configuration/reference_protocolpop3.md
@@ -1,11 +1,9 @@
 ---
-id: 74
 title: "POP3 settings"
 slug: reference_protocolpop3
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2008-07-04
 ---
 
 ### Connections

--- a/hmailserver/documentation/book_configuration/reference_protocols.md
+++ b/hmailserver/documentation/book_configuration/reference_protocols.md
@@ -1,11 +1,9 @@
 ---
-id: 243
 title: "Protocols"
 slug: reference_protocols
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2009-07-03
 ---
 
 ## Protocols

--- a/hmailserver/documentation/book_configuration/reference_protocolsmtp.md
+++ b/hmailserver/documentation/book_configuration/reference_protocolsmtp.md
@@ -1,11 +1,9 @@
 ---
-id: 65
 title: "SMTP settings"
 slug: reference_protocolsmtp
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2024-02-26
 ---
 
 ## General

--- a/hmailserver/documentation/book_configuration/reference_route.md
+++ b/hmailserver/documentation/book_configuration/reference_route.md
@@ -1,11 +1,9 @@
 ---
-id: 119
 title: "Route"
 slug: reference_route
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2024-03-04
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_configuration/reference_rule/_index.md
+++ b/hmailserver/documentation/book_configuration/reference_rule/_index.md
@@ -1,11 +1,9 @@
 ---
-id: 183
 title: "Rule"
 slug: reference_rule
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2013-05-07
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_configuration/reference_rule/details_rules_examples.md
+++ b/hmailserver/documentation/book_configuration/reference_rule/details_rules_examples.md
@@ -1,11 +1,9 @@
 ---
-id: 106
 title: "Rule examples"
 slug: details_rules_examples
 parent: reference_rule
 index: 0
 is_book: false
-updated: 2009-10-16
 ---
 
 ## Example 1, Delete email

--- a/hmailserver/documentation/book_configuration/reference_scripts/_index.md
+++ b/hmailserver/documentation/book_configuration/reference_scripts/_index.md
@@ -1,11 +1,9 @@
 ---
-id: 247
 title: "Scripts"
 slug: reference_scripts
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2016-08-14
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_configuration/reference_scripts/scripting_onSMTPdata.md
+++ b/hmailserver/documentation/book_configuration/reference_scripts/scripting_onSMTPdata.md
@@ -1,11 +1,9 @@
 ---
-id: 423
 title: "OnSMTPData"
 slug: scripting_onSMTPdata
 parent: reference_scripts
 index: 0
 is_book: false
-updated: 2019-05-08
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_configuration/reference_scripts/scripting_onacceptmessage.md
+++ b/hmailserver/documentation/book_configuration/reference_scripts/scripting_onacceptmessage.md
@@ -1,11 +1,9 @@
 ---
-id: 20
 title: "OnAcceptMessage"
 slug: scripting_onacceptmessage
 parent: reference_scripts
 index: 0
 is_book: false
-updated: 2017-08-05
 ---
 
 ## Signature

--- a/hmailserver/documentation/book_configuration/reference_scripts/scripting_onbackupcompleted.md
+++ b/hmailserver/documentation/book_configuration/reference_scripts/scripting_onbackupcompleted.md
@@ -1,11 +1,9 @@
 ---
-id: 113
 title: "OnBackupCompleted"
 slug: scripting_onbackupcompleted
 parent: reference_scripts
 index: 0
 is_book: false
-updated: 2009-10-16
 ---
 
 ## Signature

--- a/hmailserver/documentation/book_configuration/reference_scripts/scripting_onbackupfailed.md
+++ b/hmailserver/documentation/book_configuration/reference_scripts/scripting_onbackupfailed.md
@@ -1,11 +1,9 @@
 ---
-id: 114
 title: "OnBackupFailed"
 slug: scripting_onbackupfailed
 parent: reference_scripts
 index: 0
 is_book: false
-updated: 2009-10-16
 ---
 
 ## Signature

--- a/hmailserver/documentation/book_configuration/reference_scripts/scripting_onclientconnect.md
+++ b/hmailserver/documentation/book_configuration/reference_scripts/scripting_onclientconnect.md
@@ -1,11 +1,9 @@
 ---
-id: 21
 title: "OnClientConnect"
 slug: scripting_onclientconnect
 parent: reference_scripts
 index: 0
 is_book: false
-updated: 2017-08-05
 ---
 
 ## Signature

--- a/hmailserver/documentation/book_configuration/reference_scripts/scripting_ondelivermessage.md
+++ b/hmailserver/documentation/book_configuration/reference_scripts/scripting_ondelivermessage.md
@@ -1,11 +1,9 @@
 ---
-id: 22
 title: "OnDeliverMessage"
 slug: scripting_ondelivermessage
 parent: reference_scripts
 index: 0
 is_book: false
-updated: 2014-10-07
 ---
 
 ## Signature

--- a/hmailserver/documentation/book_configuration/reference_scripts/scripting_ondeliveryfailed.md
+++ b/hmailserver/documentation/book_configuration/reference_scripts/scripting_ondeliveryfailed.md
@@ -1,11 +1,9 @@
 ---
-id: 424
 title: "OnDeliveryFailed"
 slug: scripting_ondeliveryfailed
 parent: reference_scripts
 index: 0
 is_book: false
-updated: 2010-05-09
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_configuration/reference_scripts/scripting_ondeliverystart.md
+++ b/hmailserver/documentation/book_configuration/reference_scripts/scripting_ondeliverystart.md
@@ -1,11 +1,9 @@
 ---
-id: 224
 title: "OnDeliveryStart"
 slug: scripting_ondeliverystart
 parent: reference_scripts
 index: 0
 is_book: false
-updated: 2014-10-07
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_configuration/reference_scripts/scripting_onerror.md
+++ b/hmailserver/documentation/book_configuration/reference_scripts/scripting_onerror.md
@@ -1,11 +1,9 @@
 ---
-id: 422
 title: "OnError"
 slug: scripting_onerror
 parent: reference_scripts
 index: 0
 is_book: false
-updated: 2017-07-19
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_configuration/reference_scripts/scripting_onexternalaccountdownload.md
+++ b/hmailserver/documentation/book_configuration/reference_scripts/scripting_onexternalaccountdownload.md
@@ -1,11 +1,9 @@
 ---
-id: 439
 title: "OnExternalAccountDownload"
 slug: scripting_onexternalaccountdownload
 parent: reference_scripts
 index: 0
 is_book: false
-updated: 2015-07-02
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_configuration/reference_security.md
+++ b/hmailserver/documentation/book_configuration/reference_security.md
@@ -1,11 +1,9 @@
 ---
-id: 453
 title: "Security"
 slug: reference_security
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2014-10-11
 ---
 
 This document describes the settings listed under Advanced -> Security.

--- a/hmailserver/documentation/book_configuration/reference_servermessage.md
+++ b/hmailserver/documentation/book_configuration/reference_servermessage.md
@@ -1,11 +1,9 @@
 ---
-id: 187
 title: "Server message"
 slug: reference_servermessage
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2008-08-16
 ---
 
 ## General

--- a/hmailserver/documentation/book_configuration/reference_serversendout.md
+++ b/hmailserver/documentation/book_configuration/reference_serversendout.md
@@ -1,11 +1,9 @@
 ---
-id: 251
 title: "Server sendout"
 slug: reference_serversendout
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2008-08-16
 ---
 
 ## Server sendout

--- a/hmailserver/documentation/book_configuration/reference_settings.md
+++ b/hmailserver/documentation/book_configuration/reference_settings.md
@@ -1,11 +1,9 @@
 ---
-id: 242
 title: "Settings"
 slug: reference_settings
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2009-07-03
 ---
 
 ## Settings

--- a/hmailserver/documentation/book_configuration/reference_sslcertificates.md
+++ b/hmailserver/documentation/book_configuration/reference_sslcertificates.md
@@ -1,11 +1,9 @@
 ---
-id: 246
 title: "SSL certificate"
 slug: reference_sslcertificates
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2019-09-21
 ---
 
 <h2><span style="color: rgb(119, 119, 119); font-size: 18px;">Settings</span></h2>

--- a/hmailserver/documentation/book_configuration/reference_ssltls.md
+++ b/hmailserver/documentation/book_configuration/reference_ssltls.md
@@ -1,11 +1,9 @@
 ---
-id: 452
 title: "SSL/TLS"
 slug: reference_ssltls
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2015-10-06
 ---
 
 When hMailServer communicates with other clients and servers (called peers), it is possible to enable encryption of the TCP/IP connection. In hMailServer, this is called Connection security.

--- a/hmailserver/documentation/book_configuration/reference_status.md
+++ b/hmailserver/documentation/book_configuration/reference_status.md
@@ -1,11 +1,9 @@
 ---
-id: 36
 title: "Status"
 slug: reference_status
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2008-11-25
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_configuration/reference_surblserver.md
+++ b/hmailserver/documentation/book_configuration/reference_surblserver.md
@@ -1,11 +1,9 @@
 ---
-id: 185
 title: "SURBL servers"
 slug: reference_surblserver
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2006-08-31
 ---
 
 ## General

--- a/hmailserver/documentation/book_configuration/reference_tcpipport.md
+++ b/hmailserver/documentation/book_configuration/reference_tcpipport.md
@@ -1,11 +1,9 @@
 ---
-id: 248
 title: "TCP/IP Listening Port"
 slug: reference_tcpipport
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2018-06-06
 ---
 
 ## TCP/IP Ports (listening only)

--- a/hmailserver/documentation/book_configuration/reference_utilities.md
+++ b/hmailserver/documentation/book_configuration/reference_utilities.md
@@ -1,11 +1,9 @@
 ---
-id: 249
 title: "Utilities"
 slug: reference_utilities
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2008-08-16
 ---
 
 ## Utilities

--- a/hmailserver/documentation/book_configuration/reference_welcome.md
+++ b/hmailserver/documentation/book_configuration/reference_welcome.md
@@ -1,11 +1,9 @@
 ---
-id: 233
 title: "Welcome"
 slug: reference_welcome
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2009-07-03
 ---
 
 ## Welcome

--- a/hmailserver/documentation/book_configuration/reference_whitelisting.md
+++ b/hmailserver/documentation/book_configuration/reference_whitelisting.md
@@ -1,11 +1,9 @@
 ---
-id: 210
 title: "Whitelisting"
 slug: reference_whitelisting
 parent: book_configuration
 index: 0
 is_book: false
-updated: 2019-06-21
 ---
 
 # General

--- a/hmailserver/documentation/book_installation/_index.md
+++ b/hmailserver/documentation/book_installation/_index.md
@@ -1,11 +1,9 @@
 ---
-id: 159
 title: "Installation"
 slug: book_installation
 parent: null
 index: 10
 is_book: true
-updated: 2006-01-21
 ---
 
 

--- a/hmailserver/documentation/book_installation/book_quickstartguide/_index.md
+++ b/hmailserver/documentation/book_installation/book_quickstartguide/_index.md
@@ -1,11 +1,9 @@
 ---
-id: 160
 title: "Quick-Start guide"
 slug: book_quickstartguide
 parent: book_installation
 index: 20
 is_book: true
-updated: 2006-01-21
 ---
 
 

--- a/hmailserver/documentation/book_installation/book_quickstartguide/basic_configuration.md
+++ b/hmailserver/documentation/book_installation/book_quickstartguide/basic_configuration.md
@@ -1,11 +1,9 @@
 ---
-id: 67
 title: "Configuration tutorial"
 slug: basic_configuration
 parent: book_quickstartguide
 index: 10
 is_book: false
-updated: 2017-01-26
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_installation/book_quickstartguide/howto_install.md
+++ b/hmailserver/documentation/book_installation/book_quickstartguide/howto_install.md
@@ -1,11 +1,9 @@
 ---
-id: 3
 title: "Installation tutorial"
 slug: howto_install
 parent: book_quickstartguide
 index: 0
 is_book: false
-updated: 2017-01-26
 ---
 
 ## Installing hMailServer

--- a/hmailserver/documentation/book_installation/book_quickstartguide/howto_install_phpwebadmin.md
+++ b/hmailserver/documentation/book_installation/book_quickstartguide/howto_install_phpwebadmin.md
@@ -1,11 +1,9 @@
 ---
-id: 26
 title: "Installing PHPWebAdmin"
 slug: howto_install_phpwebadmin
 parent: book_quickstartguide
 index: 20
 is_book: false
-updated: 2021-09-13
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_installation/book_quickstartguide/howto_set_language.md
+++ b/hmailserver/documentation/book_installation/book_quickstartguide/howto_set_language.md
@@ -1,11 +1,9 @@
 ---
-id: 441
 title: "Display language"
 slug: howto_set_language
 parent: book_quickstartguide
 index: 9
 is_book: false
-updated: 2016-03-21
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_installation/book_upgrading/Upgrade_ToLatest.md
+++ b/hmailserver/documentation/book_installation/book_upgrading/Upgrade_ToLatest.md
@@ -1,11 +1,9 @@
 ---
-id: 455
 title: "Upgrading: 5.x to Latest Version"
 slug: Upgrade_ToLatest
 parent: book_upgrading
 index: 0
 is_book: false
-updated: 2015-11-15
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_installation/book_upgrading/_index.md
+++ b/hmailserver/documentation/book_installation/book_upgrading/_index.md
@@ -1,11 +1,9 @@
 ---
-id: 161
 title: "Upgrading"
 slug: book_upgrading
 parent: book_installation
 index: 40
 is_book: true
-updated: 2007-02-04
 ---
 
 

--- a/hmailserver/documentation/book_installation/book_upgrading/upgrade_3x_to_40.md
+++ b/hmailserver/documentation/book_installation/book_upgrading/upgrade_3x_to_40.md
@@ -1,11 +1,9 @@
 ---
-id: 71
 title: "Upgrading: 3.x to 4.0"
 slug: upgrade_3x_to_40
 parent: book_upgrading
 index: 10
 is_book: false
-updated: 2009-10-16
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_installation/book_upgrading/upgrade_4x_to_50.md
+++ b/hmailserver/documentation/book_installation/book_upgrading/upgrade_4x_to_50.md
@@ -1,11 +1,9 @@
 ---
-id: 258
 title: "Upgrading: 4.x to 5.0"
 slug: upgrade_4x_to_50
 parent: book_upgrading
 index: 20
 is_book: false
-updated: 2009-10-16
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_installation/book_upgrading/upgrade_50_to_51.md
+++ b/hmailserver/documentation/book_installation/book_upgrading/upgrade_50_to_51.md
@@ -1,11 +1,9 @@
 ---
-id: 431
 title: "Upgrading: 5.0 to 5.1"
 slug: upgrade_50_to_51
 parent: book_upgrading
 index: 30
 is_book: false
-updated: 2009-10-16
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_installation/book_upgrading/upgrade_51_to_52.md
+++ b/hmailserver/documentation/book_installation/book_upgrading/upgrade_51_to_52.md
@@ -1,11 +1,9 @@
 ---
-id: 435
 title: "Upgrading: 5.1 to 5.2"
 slug: upgrade_51_to_52
 parent: book_upgrading
 index: 40
 is_book: false
-updated: 2009-10-16
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_installation/book_upgrading/upgrade_52_to_53.md
+++ b/hmailserver/documentation/book_installation/book_upgrading/upgrade_52_to_53.md
@@ -1,11 +1,9 @@
 ---
-id: 442
 title: "Upgrading: 5.2 to 5.3"
 slug: upgrade_52_to_53
 parent: book_upgrading
 index: 50
 is_book: false
-updated: 2009-10-16
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_installation/book_upgrading/upgrade_downgrade.md
+++ b/hmailserver/documentation/book_installation/book_upgrading/upgrade_downgrade.md
@@ -1,11 +1,9 @@
 ---
-id: 440
 title: "Downgrading"
 slug: upgrade_downgrade
 parent: book_upgrading
 index: 100
 is_book: false
-updated: 2009-08-03
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_installation/book_upgrading/upgrading_recommendations.md
+++ b/hmailserver/documentation/book_installation/book_upgrading/upgrading_recommendations.md
@@ -1,11 +1,9 @@
 ---
-id: 181
 title: "Upgrading recommendations"
 slug: upgrading_recommendations
 parent: book_upgrading
 index: 0
 is_book: false
-updated: 2009-10-14
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_installation/choosing_database_engine.md
+++ b/hmailserver/documentation/book_installation/choosing_database_engine.md
@@ -1,11 +1,9 @@
 ---
-id: 239
 title: "Choosing database engine"
 slug: choosing_database_engine
 parent: book_installation
 index: 15
 is_book: false
-updated: 2015-03-16
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_installation/scenarios/_index.md
+++ b/hmailserver/documentation/book_installation/scenarios/_index.md
@@ -1,11 +1,9 @@
 ---
-id: 170
 title: "Installation scenarios"
 slug: scenarios
 parent: book_installation
 index: 30
 is_book: true
-updated: 2007-05-27
 ---
 
 - [Installing on a single server with dynamic IP address](?page=scenario_single_server_dynamic_ip)

--- a/hmailserver/documentation/book_installation/scenarios/scenario_single_server_dynamic_ip.md
+++ b/hmailserver/documentation/book_installation/scenarios/scenario_single_server_dynamic_ip.md
@@ -1,11 +1,9 @@
 ---
-id: 171
 title: "Single server, dynamic IP address"
 slug: scenario_single_server_dynamic_ip
 parent: scenarios
 index: 0
 is_book: false
-updated: 2009-03-21
 ---
 
 ## Scenario:

--- a/hmailserver/documentation/book_installation/scenarios/scenario_single_server_static_ip.md
+++ b/hmailserver/documentation/book_installation/scenarios/scenario_single_server_static_ip.md
@@ -1,11 +1,9 @@
 ---
-id: 172
 title: "Single server, static IP address"
 slug: scenario_single_server_static_ip
 parent: scenarios
 index: 0
 is_book: false
-updated: 2007-07-30
 ---
 
 ## Scenario:

--- a/hmailserver/documentation/book_installation/system_requirements.md
+++ b/hmailserver/documentation/book_installation/system_requirements.md
@@ -1,11 +1,9 @@
 ---
-id: 1
 title: "System requirements"
 slug: system_requirements
 parent: book_installation
 index: 10
 is_book: false
-updated: 2021-08-15
 ---
 
 ## Operating system

--- a/hmailserver/documentation/book_maintenance/_index.md
+++ b/hmailserver/documentation/book_maintenance/_index.md
@@ -1,11 +1,9 @@
 ---
-id: 163
 title: "Maintenance"
 slug: book_maintenance
 parent: null
 index: 50
 is_book: true
-updated: 2006-01-21
 ---
 
 

--- a/hmailserver/documentation/book_maintenance/backup_restore.md
+++ b/hmailserver/documentation/book_maintenance/backup_restore.md
@@ -1,11 +1,9 @@
 ---
-id: 68
 title: "Backup & Restore"
 slug: backup_restore
 parent: book_maintenance
 index: 10
 is_book: false
-updated: 2014-12-20
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_maintenance/maintenance_database.md
+++ b/hmailserver/documentation/book_maintenance/maintenance_database.md
@@ -1,11 +1,9 @@
 ---
-id: 433
 title: "Database maintenance"
 slug: maintenance_database
 parent: book_maintenance
 index: 0
 is_book: false
-updated: 2009-02-10
 ---
 
 ## Background

--- a/hmailserver/documentation/book_maintenance/maintenance_newserver.md
+++ b/hmailserver/documentation/book_maintenance/maintenance_newserver.md
@@ -1,11 +1,9 @@
 ---
-id: 231
 title: "Moving to a new server"
 slug: maintenance_newserver
 parent: book_maintenance
 index: 20
 is_book: false
-updated: 2019-09-21
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_maintenance/maintenance_scripts.md
+++ b/hmailserver/documentation/book_maintenance/maintenance_scripts.md
@@ -1,11 +1,9 @@
 ---
-id: 444
 title: "Maintenance scripts"
 slug: maintenance_scripts
 parent: book_maintenance
 index: 0
 is_book: false
-updated: 2009-11-04
 ---
 
 ## Maintenance scripts

--- a/hmailserver/documentation/book_other/FAQ/_index.md
+++ b/hmailserver/documentation/book_other/FAQ/_index.md
@@ -1,11 +1,9 @@
 ---
-id: 6
 title: "Frequently Asked Questions"
 slug: FAQ
 parent: book_other
 index: 0
 is_book: false
-updated: 2009-07-03
 ---
 
 ### Question 1 - What is hMailServer?

--- a/hmailserver/documentation/book_other/FAQ/faq_empty_dirs_in_datadir.md
+++ b/hmailserver/documentation/book_other/FAQ/faq_empty_dirs_in_datadir.md
@@ -1,11 +1,9 @@
 ---
-id: 169
 title: "Why are there empty directories in the data directory?"
 slug: faq_empty_dirs_in_datadir
 parent: FAQ
 index: 0
 is_book: false
-updated: 2007-06-11
 ---
 
 ## Question: Why are there empty directories in the data directory?

--- a/hmailserver/documentation/book_other/FAQ/faq_hosting_information.md
+++ b/hmailserver/documentation/book_other/FAQ/faq_hosting_information.md
@@ -1,11 +1,9 @@
 ---
-id: 230
 title: "FAQ: Hosting information"
 slug: faq_hosting_information
 parent: FAQ
 index: 0
 is_book: false
-updated: 2007-12-13
 ---
 
 ## hMailServer hosting information

--- a/hmailserver/documentation/book_other/FAQ/faq_storing_attachments_on_disk.md
+++ b/hmailserver/documentation/book_other/FAQ/faq_storing_attachments_on_disk.md
@@ -1,11 +1,9 @@
 ---
-id: 111
 title: "Storing only attachments on disk"
 slug: faq_storing_attachments_on_disk
 parent: FAQ
 index: 0
 is_book: false
-updated: 2005-11-22
 ---
 
 ## Question: Why not store only attachments on disk?

--- a/hmailserver/documentation/book_other/FAQ/faq_storing_message_in_database.md
+++ b/hmailserver/documentation/book_other/FAQ/faq_storing_message_in_database.md
@@ -1,11 +1,9 @@
 ---
-id: 9
 title: "Storing the message in the database"
 slug: faq_storing_message_in_database
 parent: FAQ
 index: 0
 is_book: false
-updated: 2008-10-27
 ---
 
 ## Question: Why aren't entire e-mail messages stored in the database?

--- a/hmailserver/documentation/book_other/_index.md
+++ b/hmailserver/documentation/book_other/_index.md
@@ -1,11 +1,9 @@
 ---
-id: 164
 title: "Other"
 slug: book_other
 parent: null
 index: 60
 is_book: true
-updated: 2006-01-21
 ---
 
 

--- a/hmailserver/documentation/book_other/book_internals/_index.md
+++ b/hmailserver/documentation/book_other/book_internals/_index.md
@@ -1,11 +1,9 @@
 ---
-id: 221
 title: "Internals"
 slug: book_internals
 parent: book_other
 index: 100
 is_book: true
-updated: 2007-03-15
 ---
 
 

--- a/hmailserver/documentation/book_other/book_internals/internals_commandhandlers.md
+++ b/hmailserver/documentation/book_other/book_internals/internals_commandhandlers.md
@@ -1,11 +1,9 @@
 ---
-id: 222
 title: "Command handlers"
 slug: internals_commandhandlers
 parent: book_internals
 index: 0
 is_book: false
-updated: 2007-03-15
 ---
 
 # Overview

--- a/hmailserver/documentation/book_other/book_internals/internals_rfc.md
+++ b/hmailserver/documentation/book_other/book_internals/internals_rfc.md
@@ -1,11 +1,9 @@
 ---
-id: 434
 title: "RFC's"
 slug: internals_rfc
 parent: book_internals
 index: 0
 is_book: false
-updated: 2009-08-04
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_other/com_objects/_index.md
+++ b/hmailserver/documentation/book_other/com_objects/_index.md
@@ -1,11 +1,9 @@
 ---
-id: 53
 title: "COM API"
 slug: com_objects
 parent: book_other
 index: 0
 is_book: false
-updated: 2016-08-14
 ---
 
 # Overview

--- a/hmailserver/documentation/book_other/com_objects/com_api_structure.md
+++ b/hmailserver/documentation/book_other/com_objects/com_api_structure.md
@@ -1,11 +1,9 @@
 ---
-id: 228
 title: "COM API: API structure"
 slug: com_api_structure
 parent: com_objects
 index: 0
 is_book: false
-updated: 2007-05-19
 ---
 
 # Overview

--- a/hmailserver/documentation/book_other/com_objects/com_changelog.md
+++ b/hmailserver/documentation/book_other/com_objects/com_changelog.md
@@ -1,11 +1,9 @@
 ---
-id: 202
 title: "COM API ChangeLog"
 slug: com_changelog
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-05
 ---
 
 This document briefly lists the changes made to the COM API.

--- a/hmailserver/documentation/book_other/com_objects/com_distributionlistrecipient.md
+++ b/hmailserver/documentation/book_other/com_objects/com_distributionlistrecipient.md
@@ -1,11 +1,9 @@
 ---
-id: 153
 title: "Distribution List Recipient"
 slug: com_distributionlistrecipient
 parent: com_objects
 index: 0
 is_book: false
-updated: 2023-10-12
 ---
 
 The Recipient object represents an recipient of a hMailServer distribution list.

--- a/hmailserver/documentation/book_other/com_objects/com_example_account_change_password.md
+++ b/hmailserver/documentation/book_other/com_objects/com_example_account_change_password.md
@@ -1,11 +1,9 @@
 ---
-id: 209
 title: "API Example: Changing an account password"
 slug: com_example_account_change_password
 parent: com_objects
 index: 0
 is_book: false
-updated: 2007-05-11
 ---
 
 This example shows how to change the password for an account in your hMailServer installation. The script is written in VBA. To use it, follow these steps:

--- a/hmailserver/documentation/book_other/com_objects/com_example_account_create.md
+++ b/hmailserver/documentation/book_other/com_objects/com_example_account_create.md
@@ -1,11 +1,9 @@
 ---
-id: 207
 title: "API Example: Creating an account"
 slug: com_example_account_create
 parent: com_objects
 index: 0
 is_book: false
-updated: 2007-05-11
 ---
 
 This example shows how to add a new account to an existing domain in your hMailServer installation. The script is written in VBA. To use it, follow these steps:

--- a/hmailserver/documentation/book_other/com_objects/com_example_account_delete.md
+++ b/hmailserver/documentation/book_other/com_objects/com_example_account_delete.md
@@ -1,11 +1,9 @@
 ---
-id: 208
 title: "API Example: Deleting an account"
 slug: com_example_account_delete
 parent: com_objects
 index: 0
 is_book: false
-updated: 2007-05-11
 ---
 
 This example shows how to delete an account from your domain in your hMailServer installation. The script is written in VBA. To use it, follow these steps:

--- a/hmailserver/documentation/book_other/com_objects/com_example_copy_message_to_imap_folder.md
+++ b/hmailserver/documentation/book_other/com_objects/com_example_copy_message_to_imap_folder.md
@@ -1,11 +1,9 @@
 ---
-id: 226
 title: "API Example: Copying a message to a new IMAP folder"
 slug: com_example_copy_message_to_imap_folder
 parent: com_objects
 index: 0
 is_book: false
-updated: 2007-04-28
 ---
 
 # Overview

--- a/hmailserver/documentation/book_other/com_objects/com_example_domain_enable.md
+++ b/hmailserver/documentation/book_other/com_objects/com_example_domain_enable.md
@@ -1,11 +1,9 @@
 ---
-id: 227
 title: "API example: Enabling a domain"
 slug: com_example_domain_enable
 parent: com_objects
 index: 0
 is_book: false
-updated: 2007-05-11
 ---
 
 This example shows how to enable an existing domain in your hMailServer installation. The script is written in VBA.

--- a/hmailserver/documentation/book_other/com_objects/com_example_folder_list.md
+++ b/hmailserver/documentation/book_other/com_objects/com_example_folder_list.md
@@ -1,11 +1,9 @@
 ---
-id: 225
 title: "API example: List user folders"
 slug: com_example_folder_list
 parent: com_objects
 index: 0
 is_book: false
-updated: 2007-04-21
 ---
 
 This example shows how to list a users IMAP folders using the hMailServer COM API. The script will display a message box listing all the IMAP folders (including sub folders) belonging to the account test@example.com.

--- a/hmailserver/documentation/book_other/com_objects/com_example_message_send.md
+++ b/hmailserver/documentation/book_other/com_objects/com_example_message_send.md
@@ -1,11 +1,9 @@
 ---
-id: 60
 title: "API example: Sending a message"
 slug: com_example_message_send
 parent: com_objects
 index: 0
 is_book: false
-updated: 2017-10-02
 ---
 
 This example shows how to send an email using the hMailServer COM API.

--- a/hmailserver/documentation/book_other/com_objects/com_example_trigger_helloworld.md
+++ b/hmailserver/documentation/book_other/com_objects/com_example_trigger_helloworld.md
@@ -1,11 +1,9 @@
 ---
-id: 446
 title: "Trigger example: Hello World"
 slug: com_example_trigger_helloworld
 parent: com_objects
 index: 0
 is_book: false
-updated: 2009-12-02
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_other/com_objects/com_example_trigger_remove_headers.md
+++ b/hmailserver/documentation/book_other/com_objects/com_example_trigger_remove_headers.md
@@ -1,11 +1,9 @@
 ---
-id: 447
 title: "Trigger example: Remove headers"
 slug: com_example_trigger_remove_headers
 parent: com_objects
 index: 0
 is_book: false
-updated: 2009-12-02
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_other/com_objects/com_examples.md
+++ b/hmailserver/documentation/book_other/com_objects/com_examples.md
@@ -1,11 +1,9 @@
 ---
-id: 448
 title: "COM API: Examples"
 slug: com_examples
 parent: com_objects
 index: 0
 is_book: false
-updated: 2009-12-02
 ---
 
 ### Script examples

--- a/hmailserver/documentation/book_other/com_objects/com_object_account.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_account.md
@@ -1,11 +1,9 @@
 ---
-id: 346
 title: "Account object"
 slug: com_object_account
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_accounts.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_accounts.md
@@ -1,11 +1,9 @@
 ---
-id: 345
 title: "Accounts object"
 slug: com_object_accounts
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_alias.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_alias.md
@@ -1,11 +1,9 @@
 ---
-id: 352
 title: "Alias object"
 slug: com_object_alias
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_aliases.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_aliases.md
@@ -1,11 +1,9 @@
 ---
-id: 350
 title: "Aliases object"
 slug: com_object_aliases
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_antispam.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_antispam.md
@@ -1,11 +1,9 @@
 ---
-id: 398
 title: "AntiSpam object"
 slug: com_object_antispam
 parent: com_objects
 index: 0
 is_book: false
-updated: 2017-02-14
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_antivirus.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_antivirus.md
@@ -1,11 +1,9 @@
 ---
-id: 362
 title: "AntiVirus object"
 slug: com_object_antivirus
 parent: com_objects
 index: 0
 is_book: false
-updated: 2017-02-14
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_application.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_application.md
@@ -1,11 +1,9 @@
 ---
-id: 366
 title: "Application object"
 slug: com_object_application
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_attachment.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_attachment.md
@@ -1,11 +1,9 @@
 ---
-id: 353
 title: "Attachment object"
 slug: com_object_attachment
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_attachments.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_attachments.md
@@ -1,11 +1,9 @@
 ---
-id: 354
 title: "Attachments object"
 slug: com_object_attachments
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_backup.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_backup.md
@@ -1,11 +1,9 @@
 ---
-id: 389
 title: "Backup object"
 slug: com_object_backup
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_backupmanager.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_backupmanager.md
@@ -1,11 +1,9 @@
 ---
-id: 387
 title: "BackupManager object"
 slug: com_object_backupmanager
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_backupsettings.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_backupsettings.md
@@ -1,11 +1,9 @@
 ---
-id: 388
 title: "BackupSettings object"
 slug: com_object_backupsettings
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_blockedattachment.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_blockedattachment.md
@@ -1,11 +1,9 @@
 ---
-id: 399
 title: "BlockedAttachment object"
 slug: com_object_blockedattachment
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_blockedattachments.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_blockedattachments.md
@@ -1,11 +1,9 @@
 ---
-id: 400
 title: "BlockedAttachments object"
 slug: com_object_blockedattachments
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_cache.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_cache.md
@@ -1,11 +1,9 @@
 ---
-id: 386
 title: "Cache object"
 slug: com_object_cache
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_client.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_client.md
@@ -1,11 +1,9 @@
 ---
-id: 372
 title: "Client object"
 slug: com_object_client
 parent: com_objects
 index: 0
 is_book: false
-updated: 2017-07-19
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_constants.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_constants.md
@@ -1,11 +1,9 @@
 ---
-id: 459
 title: "Constants"
 slug: com_object_constants
 parent: com_objects
 index: 0
 is_book: false
-updated: 2017-02-14
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_database.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_database.md
@@ -1,11 +1,9 @@
 ---
-id: 347
 title: "Database object"
 slug: com_object_database
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_deliveryqueue.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_deliveryqueue.md
@@ -1,11 +1,9 @@
 ---
-id: 391
 title: "DeliveryQueue object"
 slug: com_object_deliveryqueue
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_directories.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_directories.md
@@ -1,11 +1,9 @@
 ---
-id: 419
 title: "Directories object"
 slug: com_object_directories
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_distributionlist.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_distributionlist.md
@@ -1,11 +1,9 @@
 ---
-id: 357
 title: "DistributionList object"
 slug: com_object_distributionlist
 parent: com_objects
 index: 0
 is_book: false
-updated: 2023-10-16
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_distributionlistrecipient.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_distributionlistrecipient.md
@@ -1,11 +1,9 @@
 ---
-id: 359
 title: "Distribution List Recipient object"
 slug: com_object_distributionlistrecipient
 parent: com_objects
 index: 0
 is_book: false
-updated: 2023-10-12
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_distributionlistrecipients.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_distributionlistrecipients.md
@@ -1,11 +1,9 @@
 ---
-id: 358
 title: "DistributionListsRecipients object"
 slug: com_object_distributionlistrecipients
 parent: com_objects
 index: 0
 is_book: false
-updated: 2023-10-16
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_distributionlists.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_distributionlists.md
@@ -1,11 +1,9 @@
 ---
-id: 356
 title: "DistributionLists object"
 slug: com_object_distributionlists
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_dnsblacklist.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_dnsblacklist.md
@@ -1,11 +1,9 @@
 ---
-id: 365
 title: "DNSBlackList object"
 slug: com_object_dnsblacklist
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_dnsblacklists.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_dnsblacklists.md
@@ -1,11 +1,9 @@
 ---
-id: 364
 title: "DNSBlackLists object"
 slug: com_object_dnsblacklists
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_domain.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_domain.md
@@ -1,11 +1,9 @@
 ---
-id: 344
 title: "Domain object"
 slug: com_object_domain
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_domainalias.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_domainalias.md
@@ -1,11 +1,9 @@
 ---
-id: 377
 title: "DomainAlias object"
 slug: com_object_domainalias
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_domainaliases.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_domainaliases.md
@@ -1,11 +1,9 @@
 ---
-id: 376
 title: "DomainAliases object"
 slug: com_object_domainaliases
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_domains.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_domains.md
@@ -1,11 +1,9 @@
 ---
-id: 367
 title: "Domains object"
 slug: com_object_domains
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_eventlog.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_eventlog.md
@@ -1,11 +1,9 @@
 ---
-id: 395
 title: "EventLog object"
 slug: com_object_eventlog
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_fetchaccount.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_fetchaccount.md
@@ -1,11 +1,9 @@
 ---
-id: 373
 title: "FetchAccount object"
 slug: com_object_fetchaccount
 parent: com_objects
 index: 0
 is_book: false
-updated: 2016-09-29
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_fetchaccounts.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_fetchaccounts.md
@@ -1,11 +1,9 @@
 ---
-id: 374
 title: "FetchAccounts object"
 slug: com_object_fetchaccounts
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_globalobjects.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_globalobjects.md
@@ -1,11 +1,9 @@
 ---
-id: 390
 title: "GlobalObjects object"
 slug: com_object_globalobjects
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_greylistingwhiteaddress.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_greylistingwhiteaddress.md
@@ -1,11 +1,9 @@
 ---
-id: 404
 title: "GreyListingWhiteAddress object"
 slug: com_object_greylistingwhiteaddress
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_greylistingwhiteaddresses.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_greylistingwhiteaddresses.md
@@ -1,11 +1,9 @@
 ---
-id: 403
 title: "GreyListingWhiteAddresses object"
 slug: com_object_greylistingwhiteaddresses
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_group.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_group.md
@@ -1,11 +1,9 @@
 ---
-id: 414
 title: "Group object"
 slug: com_object_group
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_groupmember.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_groupmember.md
@@ -1,11 +1,9 @@
 ---
-id: 416
 title: "GroupMember object"
 slug: com_object_groupmember
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_groupmembers.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_groupmembers.md
@@ -1,11 +1,9 @@
 ---
-id: 415
 title: "GroupMembers object"
 slug: com_object_groupmembers
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_groups.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_groups.md
@@ -1,11 +1,9 @@
 ---
-id: 413
 title: "Groups object"
 slug: com_object_groups
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_imapfolder.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_imapfolder.md
@@ -1,11 +1,9 @@
 ---
-id: 393
 title: "IMAPFolder object"
 slug: com_object_imapfolder
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_imapfolderpermission.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_imapfolderpermission.md
@@ -1,11 +1,9 @@
 ---
-id: 417
 title: "IMAPFolderPermission object"
 slug: com_object_imapfolderpermission
 parent: com_objects
 index: 0
 is_book: false
-updated: 2017-02-14
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_imapfolderpermissions.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_imapfolderpermissions.md
@@ -1,11 +1,9 @@
 ---
-id: 418
 title: "IMAPFolderPermissions object"
 slug: com_object_imapfolderpermissions
 parent: com_objects
 index: 0
 is_book: false
-updated: 2017-02-14
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_imapfolders.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_imapfolders.md
@@ -1,11 +1,9 @@
 ---
-id: 394
 title: "IMAPFolders object"
 slug: com_object_imapfolders
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_incomingrelay.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_incomingrelay.md
@@ -1,11 +1,9 @@
 ---
-id: 458
 title: "Incoming Relay"
 slug: com_object_incomingrelay
 parent: com_objects
 index: 0
 is_book: false
-updated: 2017-02-14
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_incomingrelays.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_incomingrelays.md
@@ -1,11 +1,9 @@
 ---
-id: 457
 title: "Incoming Relays"
 slug: com_object_incomingrelays
 parent: com_objects
 index: 0
 is_book: false
-updated: 2017-02-14
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_language.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_language.md
@@ -1,11 +1,9 @@
 ---
-id: 392
 title: "Language object"
 slug: com_object_language
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_languages.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_languages.md
@@ -1,11 +1,9 @@
 ---
-id: 420
 title: "Languages object"
 slug: com_object_languages
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_links.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_links.md
@@ -1,11 +1,9 @@
 ---
-id: 421
 title: "Links object"
 slug: com_object_links
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_logging.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_logging.md
@@ -1,11 +1,9 @@
 ---
-id: 355
 title: "Logging object"
 slug: com_object_logging
 parent: com_objects
 index: 0
 is_book: false
-updated: 2017-02-14
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_message.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_message.md
@@ -1,11 +1,9 @@
 ---
-id: 348
 title: "Message object"
 slug: com_object_message
 parent: com_objects
 index: 0
 is_book: false
-updated: 2019-01-14
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_messageheader.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_messageheader.md
@@ -1,11 +1,9 @@
 ---
-id: 409
 title: "MessageHeader object"
 slug: com_object_messageheader
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_messageheaders.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_messageheaders.md
@@ -1,11 +1,9 @@
 ---
-id: 410
 title: "MessageHeaders object"
 slug: com_object_messageheaders
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_messages.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_messages.md
@@ -1,11 +1,9 @@
 ---
-id: 349
 title: "Messages object"
 slug: com_object_messages
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_recipient.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_recipient.md
@@ -1,11 +1,9 @@
 ---
-id: 385
 title: "Recipient object"
 slug: com_object_recipient
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_recipients.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_recipients.md
@@ -1,11 +1,9 @@
 ---
-id: 384
 title: "Recipients object"
 slug: com_object_recipients
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_result.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_result.md
@@ -1,11 +1,9 @@
 ---
-id: 371
 title: "Result object"
 slug: com_object_result
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_route.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_route.md
@@ -1,11 +1,9 @@
 ---
-id: 363
 title: "Route object"
 slug: com_object_route
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_routeaddress.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_routeaddress.md
@@ -1,11 +1,9 @@
 ---
-id: 369
 title: "RouteAddress object"
 slug: com_object_routeaddress
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_routeaddresses.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_routeaddresses.md
@@ -1,11 +1,9 @@
 ---
-id: 370
 title: "RouteAddresses object"
 slug: com_object_routeaddresses
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_routes.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_routes.md
@@ -1,11 +1,9 @@
 ---
-id: 368
 title: "Routes object"
 slug: com_object_routes
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_rule.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_rule.md
@@ -1,11 +1,9 @@
 ---
-id: 379
 title: "Rule object"
 slug: com_object_rule
 parent: com_objects
 index: 0
 is_book: false
-updated: 2022-09-12
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_ruleaction.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_ruleaction.md
@@ -1,11 +1,9 @@
 ---
-id: 382
 title: "RuleAction object"
 slug: com_object_ruleaction
 parent: com_objects
 index: 0
 is_book: false
-updated: 2022-09-12
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_ruleactions.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_ruleactions.md
@@ -1,11 +1,9 @@
 ---
-id: 383
 title: "RuleActions object"
 slug: com_object_ruleactions
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_rulecriteria.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_rulecriteria.md
@@ -1,11 +1,9 @@
 ---
-id: 380
 title: "RuleCriteria object"
 slug: com_object_rulecriteria
 parent: com_objects
 index: 0
 is_book: false
-updated: 2022-09-12
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_rulecriterias.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_rulecriterias.md
@@ -1,11 +1,9 @@
 ---
-id: 381
 title: "RuleCriterias object"
 slug: com_object_rulecriterias
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_rules.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_rules.md
@@ -1,11 +1,9 @@
 ---
-id: 378
 title: "Rules object"
 slug: com_object_rules
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_scripting.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_scripting.md
@@ -1,11 +1,9 @@
 ---
-id: 375
 title: "Scripting object"
 slug: com_object_scripting
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_securityrange.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_securityrange.md
@@ -1,11 +1,9 @@
 ---
-id: 360
 title: "SecurityRange object"
 slug: com_object_securityrange
 parent: com_objects
 index: 0
 is_book: false
-updated: 2017-02-14
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_securityranges.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_securityranges.md
@@ -1,11 +1,9 @@
 ---
-id: 361
 title: "SecurityRanges object"
 slug: com_object_securityranges
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_servermessage.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_servermessage.md
@@ -1,11 +1,9 @@
 ---
-id: 402
 title: "ServerMessage object"
 slug: com_object_servermessage
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_servermessages.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_servermessages.md
@@ -1,11 +1,9 @@
 ---
-id: 401
 title: "ServerMessages object"
 slug: com_object_servermessages
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_settings.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_settings.md
@@ -1,11 +1,9 @@
 ---
-id: 343
 title: "Settings object"
 slug: com_object_settings
 parent: com_objects
 index: 0
 is_book: false
-updated: 2017-02-14
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_sslcertificate.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_sslcertificate.md
@@ -1,11 +1,9 @@
 ---
-id: 411
 title: "SSLCertificate object"
 slug: com_object_sslcertificate
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_sslcertificates.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_sslcertificates.md
@@ -1,11 +1,9 @@
 ---
-id: 412
 title: "SSLCertificates object"
 slug: com_object_sslcertificates
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_status.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_status.md
@@ -1,11 +1,9 @@
 ---
-id: 342
 title: "Status object"
 slug: com_object_status
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_surblserver.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_surblserver.md
@@ -1,11 +1,9 @@
 ---
-id: 397
 title: "SURBLServer object"
 slug: com_object_surblserver
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_surblservers.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_surblservers.md
@@ -1,11 +1,9 @@
 ---
-id: 396
 title: "SURBLServers object"
 slug: com_object_surblservers
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_tcpipport.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_tcpipport.md
@@ -1,11 +1,9 @@
 ---
-id: 406
 title: "TCPIPPort object"
 slug: com_object_tcpipport
 parent: com_objects
 index: 0
 is_book: false
-updated: 2022-02-03
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_tcpipports.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_tcpipports.md
@@ -1,11 +1,9 @@
 ---
-id: 405
 title: "TCPIPPorts object"
 slug: com_object_tcpipports
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_utilities.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_utilities.md
@@ -1,11 +1,9 @@
 ---
-id: 351
 title: "Utilities object"
 slug: com_object_utilities
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_whitelistaddress.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_whitelistaddress.md
@@ -1,11 +1,9 @@
 ---
-id: 408
 title: "WhiteListAddress object"
 slug: com_object_whitelistaddress
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/com_objects/com_object_whitelistaddresses.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_whitelistaddresses.md
@@ -1,11 +1,9 @@
 ---
-id: 407
 title: "WhiteListAddresses object"
 slug: com_object_whitelistaddresses
 parent: com_objects
 index: 0
 is_book: false
-updated: 2008-10-31
 ---
 
 ### Description

--- a/hmailserver/documentation/book_other/details_antispam_methods.md
+++ b/hmailserver/documentation/book_other/details_antispam_methods.md
@@ -1,11 +1,9 @@
 ---
-id: 252
 title: "Anti-spam methods"
 slug: details_antispam_methods
 parent: book_other
 index: 0
 is_book: false
-updated: 2016-04-02
 ---
 
 ## Anti spam methods

--- a/hmailserver/documentation/book_other/details_antivirus_external_example.md
+++ b/hmailserver/documentation/book_other/details_antivirus_external_example.md
@@ -1,11 +1,9 @@
 ---
-id: 240
 title: "External anti virus sample settings"
 slug: details_antivirus_external_example
 parent: book_other
 index: 0
 is_book: false
-updated: 2016-05-29
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_other/details_cache.md
+++ b/hmailserver/documentation/book_other/details_cache.md
@@ -1,11 +1,9 @@
 ---
-id: 85
 title: "Caching"
 slug: details_cache
 parent: book_other
 index: 0
 is_book: false
-updated: 2009-07-03
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_other/details_imap_sort.md
+++ b/hmailserver/documentation/book_other/details_imap_sort.md
@@ -1,11 +1,9 @@
 ---
-id: 112
 title: "IMAP Sort extension"
 slug: details_imap_sort
 parent: book_other
 index: 0
 is_book: false
-updated: 2009-07-03
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_other/details_ipv6.md
+++ b/hmailserver/documentation/book_other/details_ipv6.md
@@ -1,11 +1,9 @@
 ---
-id: 438
 title: "IPv6 support"
 slug: details_ipv6
 parent: book_other
 index: 0
 is_book: false
-updated: 2022-09-12
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_other/details_recipients.md
+++ b/hmailserver/documentation/book_other/details_recipients.md
@@ -1,11 +1,9 @@
 ---
-id: 449
 title: "Resolving recipients"
 slug: details_recipients
 parent: book_other
 index: 0
 is_book: false
-updated: 2009-12-23
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_other/folderstructure.md
+++ b/hmailserver/documentation/book_other/folderstructure.md
@@ -1,11 +1,9 @@
 ---
-id: 23
 title: "hMailServer folder structure"
 slug: folderstructure
 parent: book_other
 index: 0
 is_book: false
-updated: 2007-03-07
 ---
 
 <table width="100%" border="0">

--- a/hmailserver/documentation/book_other/howto_remote_management.md
+++ b/hmailserver/documentation/book_other/howto_remote_management.md
@@ -1,11 +1,9 @@
 ---
-id: 217
 title: "Remote management"
 slug: howto_remote_management
 parent: book_other
 index: 0
 is_book: false
-updated: 2009-07-03
 ---
 
 # Overview

--- a/hmailserver/documentation/book_other/howtos/_index.md
+++ b/hmailserver/documentation/book_other/howtos/_index.md
@@ -1,11 +1,9 @@
 ---
-id: 30
 title: "HOW TO:s"
 slug: howtos
 parent: book_other
 index: 0
 is_book: false
-updated: 2012-05-12
 ---
 
 **How do I...**

--- a/hmailserver/documentation/book_other/howtos/howto_act_as_mx_backup.md
+++ b/hmailserver/documentation/book_other/howtos/howto_act_as_mx_backup.md
@@ -1,11 +1,9 @@
 ---
-id: 24
 title: "Act as a MX backup"
 slug: howto_act_as_mx_backup
 parent: howtos
 index: 0
 is_book: false
-updated: 2018-01-20
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_other/howtos/howto_administer_remote.md
+++ b/hmailserver/documentation/book_other/howtos/howto_administer_remote.md
@@ -1,11 +1,9 @@
 ---
-id: 104
 title: "Administer hMailServer remotely"
 slug: howto_administer_remote
 parent: howtos
 index: 0
 is_book: false
-updated: 2016-10-04
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_other/howtos/howto_build.md
+++ b/hmailserver/documentation/book_other/howtos/howto_build.md
@@ -1,11 +1,9 @@
 ---
-id: 451
 title: "Compiling hMailServer from source"
 slug: howto_build
 parent: howtos
 index: 0
 is_book: false
-updated: 2014-07-02
 ---
 
 Information on how to build hMailServer can be found on [the GitHub project page](https://github.com/martinknafve/hmailserver/blob/master/README.md).

--- a/hmailserver/documentation/book_other/howtos/howto_change_administrator_password.md
+++ b/hmailserver/documentation/book_other/howtos/howto_change_administrator_password.md
@@ -1,11 +1,9 @@
 ---
-id: 206
 title: "HOWTO: Changing the administrator password"
 slug: howto_change_administrator_password
 parent: howtos
 index: 0
 is_book: false
-updated: 2009-04-17
 ---
 
 ## Background

--- a/hmailserver/documentation/book_other/howtos/howto_change_data_directory.md
+++ b/hmailserver/documentation/book_other/howtos/howto_change_data_directory.md
@@ -1,11 +1,9 @@
 ---
-id: 25
 title: "Change the data directory"
 slug: howto_change_data_directory
 parent: howtos
 index: 20
 is_book: false
-updated: 2015-07-08
 ---
 
 ## Background

--- a/hmailserver/documentation/book_other/howtos/howto_clear_delivery_queue.md
+++ b/hmailserver/documentation/book_other/howtos/howto_clear_delivery_queue.md
@@ -1,11 +1,9 @@
 ---
-id: 108
 title: "Clear the delivery queue"
 slug: howto_clear_delivery_queue
 parent: howtos
 index: 0
 is_book: false
-updated: 2005-11-22
 ---
 
 ## Background

--- a/hmailserver/documentation/book_other/howtos/howto_connect_to_mssql.md
+++ b/hmailserver/documentation/book_other/howtos/howto_connect_to_mssql.md
@@ -1,11 +1,9 @@
 ---
-id: 443
 title: "Connect to MSSQL"
 slug: howto_connect_to_mssql
 parent: howtos
 index: 0
 is_book: false
-updated: 2009-11-03
 ---
 
 This page describes how to connect to the hMailServer MSSQL database to execute statements.

--- a/hmailserver/documentation/book_other/howtos/howto_connect_to_mysql.md
+++ b/hmailserver/documentation/book_other/howtos/howto_connect_to_mysql.md
@@ -1,11 +1,9 @@
 ---
-id: 87
 title: "Connect to MySQL"
 slug: howto_connect_to_mysql
 parent: howtos
 index: 0
 is_book: false
-updated: 2005-11-22
 ---
 
 This page describes how to connect to the MySQL database to execute statements.

--- a/hmailserver/documentation/book_other/howtos/howto_dcom_permissions.md
+++ b/hmailserver/documentation/book_other/howtos/howto_dcom_permissions.md
@@ -1,11 +1,9 @@
 ---
-id: 107
 title: "DCOM permissions"
 slug: howto_dcom_permissions
 parent: howtos
 index: 0
 is_book: false
-updated: 2015-12-03
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_other/howtos/howto_determine_antivirus_external_returnvalue.md
+++ b/hmailserver/documentation/book_other/howtos/howto_determine_antivirus_external_returnvalue.md
@@ -1,11 +1,9 @@
 ---
-id: 79
 title: "External virus scanner - Return value"
 slug: howto_determine_antivirus_external_returnvalue
 parent: howtos
 index: 0
 is_book: false
-updated: 2009-10-16
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_other/howtos/howto_determine_mysql_password.md
+++ b/hmailserver/documentation/book_other/howtos/howto_determine_mysql_password.md
@@ -1,11 +1,9 @@
 ---
-id: 229
 title: "HOWTO: Determine hMailServer database password"
 slug: howto_determine_mysql_password
 parent: howtos
 index: 0
 is_book: false
-updated: 2009-11-02
 ---
 
 If you are using the built-in version that comes with hMailServer, you might not know your password. To determine the password, follow these steps:

--- a/hmailserver/documentation/book_other/howtos/howto_enable_smtp_authentication_in_client.md
+++ b/hmailserver/documentation/book_other/howtos/howto_enable_smtp_authentication_in_client.md
@@ -1,11 +1,9 @@
 ---
-id: 220
 title: "HOWTO: Enabling SMTP authentication in email client"
 slug: howto_enable_smtp_authentication_in_client
 parent: howtos
 index: 0
 is_book: false
-updated: 2007-02-19
 ---
 
 # Overview

--- a/hmailserver/documentation/book_other/howtos/howto_install_client.md
+++ b/hmailserver/documentation/book_other/howtos/howto_install_client.md
@@ -1,11 +1,9 @@
 ---
-id: 168
 title: "Installing hMailServer client tools"
 slug: howto_install_client
 parent: howtos
 index: 0
 is_book: false
-updated: 2006-04-23
 ---
 
 This page describes how to install the hMailServer client tools. If you want to manage your hMailServer installation remotely, you need to install the hMailServer client tools on the computer you want to manage your installation from.

--- a/hmailserver/documentation/book_other/howtos/howto_move_spam_to_IMAP_folder.md
+++ b/hmailserver/documentation/book_other/howtos/howto_move_spam_to_IMAP_folder.md
@@ -1,11 +1,9 @@
 ---
-id: 82
 title: "Move spam to IMAP folder"
 slug: howto_move_spam_to_IMAP_folder
 parent: howtos
 index: 0
 is_book: false
-updated: 2005-11-22
 ---
 
 These instructions assume you're using hMailServer version 4.0 or higher. They are applicable to mail marked as spam using ASSP, but should work equally well with any other spam filter. It is only necessary that the filter put a spam flag in the header, for example, simply by replacing steps 3 and 4 below with the appropriate Header and Value.

--- a/hmailserver/documentation/book_other/howtos/howto_recreate_message_list.md
+++ b/hmailserver/documentation/book_other/howtos/howto_recreate_message_list.md
@@ -1,11 +1,9 @@
 ---
-id: 81
 title: "Recreating messages lists in the database"
 slug: howto_recreate_message_list
 parent: howtos
 index: 0
 is_book: false
-updated: 2009-08-28
 ---
 
 ## Background

--- a/hmailserver/documentation/book_other/howtos/howto_repair_mysql.md
+++ b/hmailserver/documentation/book_other/howtos/howto_repair_mysql.md
@@ -1,11 +1,9 @@
 ---
-id: 78
 title: "Repair corrupt MySQL table"
 slug: howto_repair_mysql
 parent: howtos
 index: 0
 is_book: false
-updated: 2007-09-29
 ---
 
 MySQL tables can become corrupt for several reasons, such as hardware failure, operating system bugs, viruses and bugs in MySQL. hMailServer itself does not cause corrupt MySQL tables. hMailServer communicates with MySQL over TCP/IP using a standardized language. There's nothing in this language that can cause corrupt tables. 

--- a/hmailserver/documentation/book_other/howtos/howto_reset_mysql_password.md
+++ b/hmailserver/documentation/book_other/howtos/howto_reset_mysql_password.md
@@ -1,11 +1,9 @@
 ---
-id: 80
 title: "Reset the MySQL password"
 slug: howto_reset_mysql_password
 parent: howtos
 index: 0
 is_book: false
-updated: 2007-04-11
 ---
 
 ## Background

--- a/hmailserver/documentation/book_other/howtos/howto_route_through_isp.md
+++ b/hmailserver/documentation/book_other/howtos/howto_route_through_isp.md
@@ -1,11 +1,9 @@
 ---
-id: 27
 title: "Route all outgoing email through another server"
 slug: howto_route_through_isp
 parent: howtos
 index: 0
 is_book: false
-updated: 2009-02-20
 ---
 
 ## Background

--- a/hmailserver/documentation/book_other/howtos/howto_set_up_local.md
+++ b/hmailserver/documentation/book_other/howtos/howto_set_up_local.md
@@ -1,11 +1,9 @@
 ---
-id: 427
 title: "Set up local / stand-alone server"
 slug: howto_set_up_local
 parent: howtos
 index: 0
 is_book: false
-updated: 2009-03-15
 ---
 
 ## Background

--- a/hmailserver/documentation/book_other/howtos/howto_setup_dkim.md
+++ b/hmailserver/documentation/book_other/howtos/howto_setup_dkim.md
@@ -1,11 +1,9 @@
 ---
-id: 456
 title: "Setting up DKIM"
 slug: howto_setup_dkim
 parent: howtos
 index: 0
 is_book: false
-updated: 2016-08-28
 ---
 
 <div>This page describes how to set up DKIM with hMailServer.</div>

--- a/hmailserver/documentation/book_other/howtos/howto_setup_ipranges_for_home_network.md
+++ b/hmailserver/documentation/book_other/howtos/howto_setup_ipranges_for_home_network.md
@@ -1,11 +1,9 @@
 ---
-id: 28
 title: "Set up IP ranges for your home network"
 slug: howto_setup_ipranges_for_home_network
 parent: howtos
 index: 0
 is_book: false
-updated: 2009-07-02
 ---
 
 ## Background

--- a/hmailserver/documentation/book_other/howtos/howto_use_assp.md
+++ b/hmailserver/documentation/book_other/howtos/howto_use_assp.md
@@ -1,11 +1,9 @@
 ---
-id: 29
 title: "Use ASSP"
 slug: howto_use_assp
 parent: howtos
 index: 0
 is_book: false
-updated: 2005-11-22
 ---
 
 ## Background

--- a/hmailserver/documentation/book_other/information_feature_implementation.md
+++ b/hmailserver/documentation/book_other/information_feature_implementation.md
@@ -1,11 +1,9 @@
 ---
-id: 205
 title: "Feature implementation"
 slug: information_feature_implementation
 parent: book_other
 index: 0
 is_book: false
-updated: 2009-07-03
 ---
 
 ## Feature implementation

--- a/hmailserver/documentation/book_other/information_imap.md
+++ b/hmailserver/documentation/book_other/information_imap.md
@@ -1,11 +1,9 @@
 ---
-id: 92
 title: "IMAP information"
 slug: information_imap
 parent: book_other
 index: 0
 is_book: false
-updated: 2009-07-03
 ---
 
 IMAP stands for Internet Message Access Protocol. It is a protocol that an email client can use to download email from an email server. IMAP includes many more features than POP3. The IMAP protocol is designed to let users keep their email on the server. The IMAP protocol requires more disk space and CPU resources on the server than the POP3 protocol, since all email messages remain stored on the server after the email client downloads them. IMAP normally uses port 143.

--- a/hmailserver/documentation/book_other/information_recipients.md
+++ b/hmailserver/documentation/book_other/information_recipients.md
@@ -1,11 +1,9 @@
 ---
-id: 232
 title: "About message recipients"
 slug: information_recipients
 parent: book_other
 index: 0
 is_book: false
-updated: 2009-05-19
 ---
 
 ## Background

--- a/hmailserver/documentation/book_other/open_relay_tests.md
+++ b/hmailserver/documentation/book_other/open_relay_tests.md
@@ -1,11 +1,9 @@
 ---
-id: 32
 title: "Open relay tests"
 slug: open_relay_tests
 parent: book_other
 index: 0
 is_book: false
-updated: 2016-01-23
 ---
 
 As soon as you finish installing and configuring hMailServer, you should run some open relay tests. It ensures that your server will not be used for spamming.[](http://members.iinet.net.au/~remmie/relay/)

--- a/hmailserver/documentation/book_other/reference_dialoghelp_hmailserver_password.md
+++ b/hmailserver/documentation/book_other/reference_dialoghelp_hmailserver_password.md
@@ -1,11 +1,9 @@
 ---
-id: 454
 title: "hMailServer Password"
 slug: reference_dialoghelp_hmailserver_password
 parent: book_other
 index: 0
 is_book: false
-updated: 2014-10-20
 ---
 
 ### What is "hMailServer Password"?

--- a/hmailserver/documentation/book_other/security.md
+++ b/hmailserver/documentation/book_other/security.md
@@ -1,11 +1,9 @@
 ---
-id: 259
 title: "Security"
 slug: security
 parent: book_other
 index: 0
 is_book: false
-updated: 2008-10-06
 ---
 
 

--- a/hmailserver/documentation/book_other/userguide_dds.md
+++ b/hmailserver/documentation/book_other/userguide_dds.md
@@ -1,11 +1,9 @@
 ---
-id: 204
 title: "Data directory synchronizer"
 slug: userguide_dds
 parent: book_other
 index: 0
 is_book: false
-updated: 2010-04-02
 ---
 
 ## Background

--- a/hmailserver/documentation/book_troubleshooting/_index.md
+++ b/hmailserver/documentation/book_troubleshooting/_index.md
@@ -1,11 +1,9 @@
 ---
-id: 436
 title: "Troubleshooting"
 slug: book_troubleshooting
 parent: null
 index: 45
 is_book: true
-updated: 2009-07-03
 ---
 
 

--- a/hmailserver/documentation/book_troubleshooting/book_error_messages/_index.md
+++ b/hmailserver/documentation/book_troubleshooting/book_error_messages/_index.md
@@ -1,11 +1,9 @@
 ---
-id: 115
 title: "Error messages"
 slug: book_error_messages
 parent: book_troubleshooting
 index: 0
 is_book: true
-updated: 2009-07-03
 ---
 
 

--- a/hmailserver/documentation/book_troubleshooting/book_error_messages/reference_error_messages_database.md
+++ b/hmailserver/documentation/book_troubleshooting/book_error_messages/reference_error_messages_database.md
@@ -1,11 +1,9 @@
 ---
-id: 254
 title: "Database error messages"
 slug: reference_error_messages_database
 parent: book_error_messages
 index: 0
 is_book: false
-updated: 2008-09-25
 ---
 
 ### MySQL server has gone away

--- a/hmailserver/documentation/book_troubleshooting/book_error_messages/reference_error_messages_dns.md
+++ b/hmailserver/documentation/book_troubleshooting/book_error_messages/reference_error_messages_dns.md
@@ -1,11 +1,9 @@
 ---
-id: 255
 title: "DNS error messages"
 slug: reference_error_messages_dns
 parent: book_error_messages
 index: 0
 is_book: false
-updated: 2008-09-25
 ---
 
 ## DNS errors

--- a/hmailserver/documentation/book_troubleshooting/book_error_messages/reference_error_messages_hmailadmin.md
+++ b/hmailserver/documentation/book_troubleshooting/book_error_messages/reference_error_messages_hmailadmin.md
@@ -1,11 +1,9 @@
 ---
-id: 256
 title: "hMailServer Administrator error messages"
 slug: reference_error_messages_hmailadmin
 parent: book_error_messages
 index: 0
 is_book: false
-updated: 2017-02-14
 ---
 
 ## hMailServer Administrator errors

--- a/hmailserver/documentation/book_troubleshooting/book_error_messages/reference_error_messages_smtp.md
+++ b/hmailserver/documentation/book_troubleshooting/book_error_messages/reference_error_messages_smtp.md
@@ -1,11 +1,9 @@
 ---
-id: 253
 title: "SMTP error messages"
 slug: reference_error_messages_smtp
 parent: book_error_messages
 index: 0
 is_book: false
-updated: 2017-03-15
 ---
 
 ## SMTP error messages

--- a/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/_index.md
+++ b/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/_index.md
@@ -1,11 +1,9 @@
 ---
-id: 437
 title: "Troubleshooting tips"
 slug: book_troubleshooting_tips
 parent: book_troubleshooting
 index: 0
 is_book: true
-updated: 2009-07-03
 ---
 
 

--- a/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/_index.md
+++ b/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/_index.md
@@ -1,11 +1,9 @@
 ---
-id: 37
 title: "More troubleshooting tips..."
 slug: troubleshooting_tips
 parent: book_troubleshooting_tips
 index: 30
 is_book: false
-updated: 2012-07-25
 ---
 
 ## Troubleshooting

--- a/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_blocked_ports.md
+++ b/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_blocked_ports.md
@@ -1,11 +1,9 @@
 ---
-id: 38
 title: "Blocked ports"
 slug: ts_blocked_ports
 parent: troubleshooting_tips
 index: 0
 is_book: false
-updated: 2008-02-17
 ---
 
 ## Troubleshooting blocked ports

--- a/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_connect_password.md
+++ b/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_connect_password.md
@@ -1,11 +1,9 @@
 ---
-id: 39
 title: "Wrong password"
 slug: ts_connect_password
 parent: troubleshooting_tips
 index: 0
 is_book: false
-updated: 2009-07-17
 ---
 
 In your email client, you must specify your full email address as your username. If your email address is user@domain.com, you should specify user@domain.com as your username.

--- a/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_connect_to_database.md
+++ b/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_connect_to_database.md
@@ -1,11 +1,9 @@
 ---
-id: 40
 title: "Connect to the database"
 slug: ts_connect_to_database
 parent: troubleshooting_tips
 index: 0
 is_book: false
-updated: 2005-11-22
 ---
 
 Open the hMailServer Log directory in Windows Explorer. Open the file named ERROR_*.log in a text-editor

--- a/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_connect_using_client.md
+++ b/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_connect_using_client.md
@@ -1,11 +1,9 @@
 ---
-id: 41
 title: "Connect using client"
 slug: ts_connect_using_client
 parent: troubleshooting_tips
 index: 0
 is_book: false
-updated: 2010-06-18
 ---
 
 ## General suggestions

--- a/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_mx_problems.md
+++ b/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_mx_problems.md
@@ -1,11 +1,9 @@
 ---
-id: 42
 title: "MX problems"
 slug: ts_mx_problems
 parent: troubleshooting_tips
 index: 0
 is_book: false
-updated: 2010-05-03
 ---
 
 ## What is MX?

--- a/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_outlook_crashes.md
+++ b/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_outlook_crashes.md
@@ -1,11 +1,9 @@
 ---
-id: 43
 title: "Outlook crashes"
 slug: ts_outlook_crashes
 parent: troubleshooting_tips
 index: 0
 is_book: false
-updated: 2005-11-22
 ---
 
 The Outlook 2003 IMAP implementation behaves a bit differently from the IMAP implementation in other email clients. There are problems encountered with Outlook, that are not specific to hMailServer. They will occur regardless of which IMAP server you are using. 

--- a/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_send_messages_to_specific_server.md
+++ b/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_send_messages_to_specific_server.md
@@ -1,11 +1,9 @@
 ---
-id: 182
 title: "hMailServer fails to deliver messages to certain servers"
 slug: ts_send_messages_to_specific_server
 parent: troubleshooting_tips
 index: 0
 is_book: false
-updated: 2009-08-09
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_server_used_for_spam.md
+++ b/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_server_used_for_spam.md
@@ -1,11 +1,9 @@
 ---
-id: 46
 title: "Server used for spam"
 slug: ts_server_used_for_spam
 parent: troubleshooting_tips
 index: 0
 is_book: false
-updated: 2016-05-06
 ---
 
 ## Background

--- a/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_setup_phpwebadmin.md
+++ b/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_setup_phpwebadmin.md
@@ -1,11 +1,9 @@
 ---
-id: 223
 title: "PHPWebAdmin setup problems"
 slug: ts_setup_phpwebadmin
 parent: troubleshooting_tips
 index: 0
 is_book: false
-updated: 2013-02-11
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_start_server.md
+++ b/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_start_server.md
@@ -1,11 +1,9 @@
 ---
-id: 47
 title: "Starting the server"
 slug: ts_start_server
 parent: troubleshooting_tips
 index: 0
 is_book: false
-updated: 2005-11-22
 ---
 
 ## Terminal services

--- a/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_using_nondefault_smtp_port.md
+++ b/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/troubleshooting_tips/ts_using_nondefault_smtp_port.md
@@ -1,11 +1,9 @@
 ---
-id: 48
 title: "Non-default SMTP port"
 slug: ts_using_nondefault_smtp_port
 parent: troubleshooting_tips
 index: 0
 is_book: false
-updated: 2005-11-22
 ---
 
 Email sent between mail servers is always sent on port 25. This is not configurable and is the same for all mail servers. If you change the SMTP port to anything other than 25, other servers will not be able to send you email. Unless, you have set up some kind of portforwarding. 

--- a/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/ts_receive_messages_from_outside.md
+++ b/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/ts_receive_messages_from_outside.md
@@ -1,11 +1,9 @@
 ---
-id: 44
 title: "Receiving messages"
 slug: ts_receive_messages_from_outside
 parent: book_troubleshooting_tips
 index: 20
 is_book: false
-updated: 2010-01-30
 ---
 
 The most common problems that prevent you from receiving emails are:

--- a/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/ts_rules.md
+++ b/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/ts_rules.md
@@ -1,11 +1,9 @@
 ---
-id: 425
 title: "Rule troubleshooting"
 slug: ts_rules
 parent: book_troubleshooting_tips
 index: 0
 is_book: false
-updated: 2009-10-16
 ---
 
 ## Overview

--- a/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/ts_send_messages_outside.md
+++ b/hmailserver/documentation/book_troubleshooting/book_troubleshooting_tips/ts_send_messages_outside.md
@@ -1,11 +1,9 @@
 ---
-id: 45
 title: "Sending messages"
 slug: ts_send_messages_outside
 parent: book_troubleshooting_tips
 index: 10
 is_book: false
-updated: 2009-07-03
 ---
 
 ## Port 25 blocked for outbound traffic

--- a/hmailserver/documentation/details_rules.md
+++ b/hmailserver/documentation/details_rules.md
@@ -1,11 +1,9 @@
 ---
-id: 426
 title: "Rule details"
 slug: details_rules
 parent: reference_rule
 index: 0
 is_book: false
-updated: 2009-07-03
 ---
 
 ## Rule details


### PR DESCRIPTION
## Summary
- Removes the \`id\` and \`updated\` front-matter fields from all 250 manual pages plus the schema example in \`README.md\`.
- Neither field is read anywhere in the website's render pipeline (\`render.php\`, \`build-docs-html.php\`) - both were carried over from the legacy CMS export purely for migration-time traceability (\`id\` = old \`documentid\`, \`updated\` = old \`documentlatestchange\`).
- The website repo's \`build-docs-html.php\` no longer reads or emits these fields either, so this is a pure cleanup with no behavior change once picked up by the next docs rebuild.

## Test plan
- [ ] Confirm the next \`update-latest-docs.php\` run builds successfully against the trimmed front matter