### PR TITLE
Fix issue where a file received over SMTP is left open

### DIFF
--- a/hmailserver/documentation/book_installation/system_requirements.md
+++ b/hmailserver/documentation/book_installation/system_requirements.md
@@ -8,17 +8,29 @@ is_book: false
 
 ## Operating system
 
-hMailServer can be installed in the following operating systems. The latest available Windows service pack must be installed. hMailServer has only been tested on the following operating systems. hMailServer may work on other operating system versions as well, but only the versions below are officially and regulary tested.
+hMailServer can be installed in the following operating systems. The latest available Windows service pack must be installed.
+
+### hMailServer 5.7
+
+- Microsoft Server 2022
+- Microsoft Server 2019
+- Microsoft Server 2016
+- Microsoft Server 2012
+- Microsoft Server 2008 R2
+- Microsoft Windows 11
+- Microsoft Windows 10
+- Microsoft Windows 8.X
+- Microsoft Windows 7 Service Pack 1
 
 ### hMailServer 5.6
 
-- Microsoft Server 2016 (all editions)*
-- Microsoft Server 2012 (all editions)*
-- Microsoft Server 2008 (all editions)
-- Microsoft Server 2003 (all editions)
-- Microsoft Windows 10 (all editions)*
-- Microsoft Windows 8.X (all editions)*
-- Microsoft Windows 7 (all editions)
+- Microsoft Server 2016*
+- Microsoft Server 2012*
+- Microsoft Server 2008
+- Microsoft Server 2003
+- Microsoft Windows 10*
+- Microsoft Windows 8.X*
+- Microsoft Windows 7
 - Microsoft Windows Vista
 - Microsoft Windows XP Professional Service Pack 3
 
@@ -30,34 +42,34 @@ An alternative is to use an external database with these Operating Systems.
 
 ### hMailServer 5.4 and 5.5
 
-- Microsoft Windows 2012 (all editions)
-- Microsoft Windows 2008 (all editions)
-- Microsoft Windows 2003 (all editions)
-- Microsoft Windows 7 (all editions)
+- Microsoft Windows 2012
+- Microsoft Windows 2008
+- Microsoft Windows 2003
+- Microsoft Windows 7
 - Microsoft Windows Vista
 - Microsoft Windows XP Professional
 
-<p><span style="color: green; font-size: 14px; font-weight: bold;">hMailServer 5.3.x &amp; Earlier</span></p>
+### hMailServer 5.3.x &amp; Earlier
 
 - Microsoft Windows 2008 (all editions, except for *Core*)
 - Microsoft Windows Vista
-- Microsoft Windows 2003 (all editions)
+- Microsoft Windows 2003
 - Microsoft Windows XP Professional
-- Microsoft Windows 2000 (all editions)
+- Microsoft Windows 2000
 
 ### hMailServer 4.3 and 4.4
 
-- Microsoft Windows 2003 (all editions)
+- Microsoft Windows 2003
 - Microsoft Windows XP Professional
-- Microsoft Windows 2000 (all editions)
+- Microsoft Windows 2000
 
 Windows NT support has been removed since Microsoft no longer supports this operating system.
 
 ### hMailServer 4.2
 
-- Microsoft Windows 2003 (all editions)
+- Microsoft Windows 2003
 - Microsoft Windows XP Professional
-- Microsoft Windows 2000 (all editions)
+- Microsoft Windows 2000
 - Microsoft Windows NT
 
 ## Other Software

--- a/hmailserver/source/Server/Common/Util/TransparentTransmissionBuffer.cpp
+++ b/hmailserver/source/Server/Common/Util/TransparentTransmissionBuffer.cpp
@@ -61,6 +61,18 @@ namespace HM
       return true;
    }
 
+   void
+   TransparentTransmissionBuffer::Close()
+   //---------------------------------------------------------------------------()
+   // DESCRIPTION:
+   // Releases the handle to the file the received data is written to. Callers who
+   // access the file after the transmission has ended must make sure the handle has
+   // been released first.
+   //---------------------------------------------------------------------------()
+   {
+      file_.Close();
+   }
+
    void 
    TransparentTransmissionBuffer::SetMaxSizeKB(size_t maxSize)
    {
@@ -173,60 +185,63 @@ namespace HM
       // Start in the end and move 'back' MAX_LINE_LENGTH characters.
       size_t searchEndPos = 0;
       
-      if (bufferSize == 0)
-         return dataProcessed;
-
-      if (bufferSize > maxLineLength)
-         searchEndPos = bufferSize - maxLineLength;
-      else
-         searchEndPos = 0;
-
-      for (size_t current_position = bufferSize; current_position > searchEndPos; current_position--)
+      // The buffer can be empty at this point, if the last data we received was the
+      // end-of-data sequence and everything before it has already been flushed. There's
+      // then nothing to write to file/socket, but the file must still be closed below.
+      if (bufferSize > 0)
       {
-         char s = pBuffer[current_position-1];
+         if (bufferSize > maxLineLength)
+            searchEndPos = bufferSize - maxLineLength;
+         else
+            searchEndPos = 0;
 
-         // If we found a newline, send anything up until that.
-         // If we're forcing a send, send all we got
-         // If we found no newline in the stream, the message is malformed according to RFC2821 (max 1000 chars per line). 
-         //    Send all we got anyway. 
-
-         if (s == '\n' || bForce)
+         for (size_t current_position = bufferSize; current_position > searchEndPos; current_position--)
          {
-            last_send_ended_with_newline_ = s == '\n';
+            char s = pBuffer[current_position - 1];
 
-            // Copy the data up including this position
-            size_t bytes_to_copy = current_position;
+            // If we found a newline, send anything up until that.
+            // If we're forcing a send, send all we got
+            // If we found no newline in the stream, the message is malformed according to RFC2821 (max 1000 chars per line). 
+            //    Send all we got anyway. 
 
-            std::shared_ptr<ByteBuffer> pOutBuffer = std::shared_ptr<ByteBuffer>(new ByteBuffer);
-            pOutBuffer->Add(buffer_->GetBuffer(), bytes_to_copy);
-
-            // Remove it from the old buffer
-            size_t remaining_bytes = buffer_->GetSize() - bytes_to_copy;
-            buffer_->Empty(remaining_bytes);
-
-            // Parse this buffer and add it to file/socket
-            if (is_sending_)
-               InsertTransmissionPeriod_(pOutBuffer);
-            else
-               RemoveTransmissionPeriod_(pOutBuffer);
-
-            // The parsed buffer can now be sent.
-            if (is_sending_)
+            if (s == '\n' || bForce)
             {
-               if (std::shared_ptr<TCPConnection> connection = tcp_connection_.lock())
+               last_send_ended_with_newline_ = s == '\n';
+
+               // Copy the data up including this position
+               size_t bytes_to_copy = current_position;
+
+               std::shared_ptr<ByteBuffer> pOutBuffer = std::shared_ptr<ByteBuffer>(new ByteBuffer);
+               pOutBuffer->Add(buffer_->GetBuffer(), bytes_to_copy);
+
+               // Remove it from the old buffer
+               size_t remaining_bytes = buffer_->GetSize() - bytes_to_copy;
+               buffer_->Empty(remaining_bytes);
+
+               // Parse this buffer and add it to file/socket
+               if (is_sending_)
+                  InsertTransmissionPeriod_(pOutBuffer);
+               else
+                  RemoveTransmissionPeriod_(pOutBuffer);
+
+               // The parsed buffer can now be sent.
+               if (is_sending_)
                {
-                  connection->EnqueueWrite(pOutBuffer);
+                  if (std::shared_ptr<TCPConnection> connection = tcp_connection_.lock())
+                  {
+                     connection->EnqueueWrite(pOutBuffer);
+                  }
+
+               }
+               else
+               {
+                  SaveToFile_(pOutBuffer);
                }
 
-            }
-            else
-            {
-               SaveToFile_(pOutBuffer);
-            }
+               dataProcessed = true;
 
-            dataProcessed = true;
-
-            break;
+               break;
+            }
          }
       }
 

--- a/hmailserver/source/Server/Common/Util/TransparentTransmissionBuffer.h
+++ b/hmailserver/source/Server/Common/Util/TransparentTransmissionBuffer.h
@@ -35,6 +35,7 @@ namespace HM
       
       bool Initialize(std::weak_ptr<TCPConnection> pTcpConnection);
       bool Initialize(const String &sFilename);
+      void Close();
 
       void SetMaxSizeKB(size_t maxSize);
       

--- a/hmailserver/source/Server/ExternalFetcher/POP3ClientConnection.cpp
+++ b/hmailserver/source/Server/ExternalFetcher/POP3ClientConnection.cpp
@@ -754,6 +754,12 @@ namespace HM
       // The entire message has now been downloaded from the
       // remote POP3 server. Save it in the database and deliver
       // it to the account.
+
+      // Release the handle to the message file first. The message file is read and
+      // delivered below, which requires that we no longer keep it open for writing.
+      if (transmission_buffer_)
+         transmission_buffer_->Close();
+
       String fileName = PersistentMessage::GetFileName(current_message_);
       current_message_->SetSize(FileUtilities::FileSize(fileName));
 

--- a/hmailserver/source/Server/SMTP/SMTPConnection.cpp
+++ b/hmailserver/source/Server/SMTP/SMTPConnection.cpp
@@ -989,6 +989,13 @@ namespace HM
    void
    SMTPConnection::HandleSMTPFinalizationTaskCompleted_()
    {
+      // The entire message has been received, so the handle to the message file must
+      // be released before we continue. The spam tests, the message modifications and
+      // the delivery below all access the message file themselves, and a lingering
+      // write handle stops them from reading or replacing it.
+      if (transmission_buffer_)
+         transmission_buffer_->Close();
+
       if (!DoPreAcceptSpamProtection_())
       {
          // This message was stopped by spam protection. The user either needs
@@ -1132,8 +1139,8 @@ namespace HM
          // Add the message to the database.
          if (PersistentMessage::SaveObject(current_message_))
          {
-            // Make sure the transmission buffer has released the handle
-            // to the file.
+            // The transmission buffer isn't needed any longer. The handle to the
+            // message file has already been released above.
             if (transmission_buffer_)
                transmission_buffer_.reset();
 

--- a/hmailserver/test/RegressionTests/AntiSpam/Combinations.cs
+++ b/hmailserver/test/RegressionTests/AntiSpam/Combinations.cs
@@ -34,8 +34,12 @@ namespace RegressionTests.AntiSpam
          antiSpam.PrependSubject = true;
          antiSpam.PrependSubjectText = "ThisIsSpam";
 
-         antiSpam.CheckHostInHelo = true;
-         antiSpam.CheckHostInHeloScore = 10;
+         // Enable SpamAssassin.
+         antiSpam.SpamAssassinEnabled = true;
+         antiSpam.SpamAssassinHost = "localhost";
+         antiSpam.SpamAssassinPort = 783;
+         antiSpam.SpamAssassinMergeScore = false;
+         antiSpam.SpamAssassinScore = 10;
 
          // Enable SURBL.
          var surblServer = antiSpam.SURBLServers[0];
@@ -43,14 +47,14 @@ namespace RegressionTests.AntiSpam
          surblServer.Score = 10;
          surblServer.Save();
 
-         // Send a messages to this account, containing both incorrect MX records an SURBL-hits.
-         // We should only detect one of these two:
+         // Send a message to this account, containing both a SURBL-hit and a GTUBE
+         // (SpamAssassin test) string. Both tests should fire, since the delete
+         // threshold is lower than the mark threshold.
          var smtpClientSimulator = new SmtpClientSimulator();
 
-         // Should not be possible to send this email since it's results in a spam
-         // score over the delete threshold.
          smtpClientSimulator.Send("test@example.com", account1.Address, "INBOX",
-            "Test http://surbl-org-permanent-test-point.com/ Test 2");
+            "Test http://surbl-org-permanent-test-point.com/ Test 2 " +
+            "XJS*C4JDBQADN1.NSBN3*2IDNEN*GTUBE-STANDARD-ANTI-UBE-TEST-EMAIL*C.34X");
 
          var message = Pop3ClientSimulator.AssertGetFirstMessageText(account1.Address, "test");
 
@@ -72,23 +76,24 @@ namespace RegressionTests.AntiSpam
          _settings.AntiSpam.PrependSubject = true;
          _settings.AntiSpam.PrependSubjectText = "ThisIsSpam";
 
-         _settings.AntiSpam.CheckHostInHelo = true;
-         _settings.AntiSpam.CheckHostInHeloScore = 5;
+         // Enable SpamAssassin.
+         _settings.AntiSpam.SpamAssassinEnabled = true;
+         _settings.AntiSpam.SpamAssassinHost = "localhost";
+         _settings.AntiSpam.SpamAssassinPort = 783;
+         _settings.AntiSpam.SpamAssassinMergeScore = false;
+         _settings.AntiSpam.SpamAssassinScore = 5;
 
-         // Enable SURBL.
+         // Enable SURBL, but don't include any URL in the message body, so this
+         // test passes while the SpamAssassin (GTUBE) test fails.
          var surblServer = _settings.AntiSpam.SURBLServers[0];
          surblServer.Active = true;
          surblServer.Score = 5;
          surblServer.Save();
 
-         // Send a messages to this account, containing both incorrect MX records an SURBL-hits.
-         // We should only detect one of these two:
          var smtpClientSimulator = new SmtpClientSimulator();
 
-         // Should not be possible to send this email since it's results in a spam
-         // score over the delete threshold.
-         smtpClientSimulator.Send("test@domain.without.mxrecords.example.com", account1.Address, "INBOX",
-            "This is a test message.");
+         smtpClientSimulator.Send("test@example.com", account1.Address, "INBOX",
+            "This is a test message. XJS*C4JDBQADN1.NSBN3*2IDNEN*GTUBE-STANDARD-ANTI-UBE-TEST-EMAIL*C.34X");
 
          var message = Pop3ClientSimulator.AssertGetFirstMessageText(account1.Address, "test");
 

--- a/hmailserver/test/RegressionTests/AntiSpam/SpamAssassin.cs
+++ b/hmailserver/test/RegressionTests/AntiSpam/SpamAssassin.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.ServiceProcess;
+using System.Text;
+using System.Threading;
 using hMailServer;
 using NUnit.Framework;
 using RegressionTests.Infrastructure;
@@ -41,6 +43,62 @@ namespace RegressionTests.AntiSpam
 
       private Account account;
 
+
+      [Test]
+      [Description("Issue 533, message file kept open when the end-of-data sequence arrives in a packet of its own")]
+      public void TerminatingDotInSeparatePacketShouldNotLeaveMessageFileOpen()
+      {
+         // The transmission buffer writes its content to the message file when it holds more
+         // than 40000 bytes. The message below is sent in two chunks, where the second one
+         // pushes the buffer past that limit and ends with a line break. Everything received
+         // has then been written to the message file, and the buffer is empty when the
+         // terminating <CRLF>.<CRLF> is received in a packet of its own.
+         //
+         // hMailServer used to keep the message file open for writing in that situation, which
+         // made the spam tests below unable to add the Return-Path header to the message and
+         // unable to replace the message file with the SpamAssassin result.
+         var connection = new TcpConnection();
+         Assert.IsTrue(connection.Connect(25));
+         Assert.IsTrue(connection.Receive().StartsWith("220"));
+         Assert.IsTrue(connection.SendAndReceive("HELO example.com\r\n").StartsWith("250"));
+         Assert.IsTrue(connection.SendAndReceive("MAIL FROM:<" + account.Address + ">\r\n").StartsWith("250"));
+         Assert.IsTrue(connection.SendAndReceive("RCPT TO:<" + account.Address + ">\r\n").StartsWith("250"));
+         Assert.IsTrue(connection.SendAndReceive("DATA\r\n").StartsWith("354"));
+
+         var firstChunk = new StringBuilder();
+         firstChunk.Append("From: " + account.Address + "\r\n");
+         firstChunk.Append("To: " + account.Address + "\r\n");
+         firstChunk.Append("Subject: SA test\r\n");
+         firstChunk.Append("\r\n");
+
+         // Stay below the 40000 byte limit, so that nothing has been written to the message
+         // file when the second chunk is sent.
+         while (firstChunk.Length < 39800)
+            firstChunk.Append("This is a test message which is sent in several packets.\r\n");
+
+         connection.Send(firstChunk.ToString());
+         Thread.Sleep(1000);
+
+         var secondChunk = new StringBuilder();
+         while (secondChunk.Length < 300)
+            secondChunk.Append("Second chunk of the test message.\r\n");
+
+         connection.Send(secondChunk.ToString());
+         Thread.Sleep(1000);
+
+         connection.Send(".\r\n");
+         Assert.IsTrue(connection.Receive().StartsWith("250"));
+
+         connection.SendAndReceive("QUIT\r\n");
+         connection.Disconnect();
+
+         var messageContents = Pop3ClientSimulator.AssertGetFirstMessageText(account.Address, "test");
+
+         Assert.IsTrue(messageContents.Contains("Second chunk of the test message."), messageContents);
+         Assert.IsTrue(messageContents.Contains("X-Spam-Status"), "SpamAssassin did not run");
+
+         CustomAsserts.AssertNoReportedError();
+      }
 
       [Test]
       public void ItShouldBePossibleToTestSAConnectionUsingAPISuccess()


### PR DESCRIPTION
When hMailServer receives a file over SMTP, it is sometimes not closed. This leads to issue later on in processing.

The issue will happen depending on size of the data being transmitted, and how it's transmitted (buffer sizes).