### PR TITLE
Avoid endless read loop on peer-closed stream

### DIFF
--- a/hmailserver/source/Server/Common/TCPIP/TCPConnection.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/TCPConnection.cpp
@@ -493,8 +493,8 @@ namespace HM
    {
       UpdateAutoLogoutTimer();
 
-      // Ignore end of file or end of stream error when binary transfer, there may still be data in the receive buffer we can read.
-      if ((error && !receive_binary_) || (error && error != boost::asio::error::eof && receive_binary_))
+      // Ignore end of file or end of stream error when binary transfer and we received some bytes, there may still be data in the receive buffer we can read.
+      if ((error && !receive_binary_) || (error && ((error != boost::asio::error::eof) || (bytes_transferred == 0)) && receive_binary_))
       {
          if (connection_state_ != StateConnected)
          {


### PR DESCRIPTION
My hMailServer used to enter endless CPU loops, ending up consuming all CPU on my server. I tracked it down to the TCP socket reading loop, which was constantly receiving 0 bytes while EOF condition was reported and yet reading was reissued.
The proposed fix addresses the issue for me. My understanding is that when EOF is reached and no more bytes are returned, then the socket has been closed by the peer and there is no point trying to fetch more bytes from it.