### PR TITLE
Fix stale DKIM and IMAP delimiter documentation claims

### DIFF
--- a/hmailserver/documentation/book_configuration/reference_domain.md
+++ b/hmailserver/documentation/book_configuration/reference_domain.md
@@ -93,8 +93,8 @@ It is possible to use the macros %User.FirstName% and %User.LastName% in signa
 <p>DKIM, Domain Keys Identified Mail, is a method to sign the content of messages. The recipient can verify that the message is sent from a server authenticated to send from the sender's domain, and that the message content has not been modified in transit.</p>
 <p>Before hMailServer delivers a message to another server, it will look at the sender address of the message. If the sender address matches a local domain, the DKIM signing options from that domain will be used. If DKIM signing has been enabled, the message will be signed.</p>
 <p>Whether or not the original sender has used SMTP authentication when delivering the message to hMailServer has no effect on the DKIM signing process.</p>
-<p>hMailServer only DKIM-signs email messages delivered to other servers. If a user on a hMailServer installation sends a message to another user on the same server, the message will not be signed.</p>
-<p>hMailServer only signs messages smaller than an internally-defined limit. Currently that limit is set to 10MB in the program code. The limit is not runtime-configurable.</p>
+<p>hMailServer signs a message with DKIM before deciding whether it will be delivered locally or to another server, so messages between two accounts on the same server are signed as well.</p>
+<p>hMailServer only signs messages smaller than an internally-defined limit. Currently that limit is set to 50MB in the program code. The limit is not runtime-configurable.</p>
 <h3>Private key file</h3>
 <div class="indented">The private key to use when signing messages with DKIM. This must be a file existing on the local file system, readable by hMailServer, and the file must not have a password set.</div>
 <h3>Selector</h3>

--- a/hmailserver/documentation/book_other/information_imap.md
+++ b/hmailserver/documentation/book_other/information_imap.md
@@ -26,4 +26,4 @@ hMailServer supports the IMAP SORT extension. This extension can dramatically im
 
 ## Folder separators
 
-hMailServer uses . (dot) as folder separator. This means that you cannot have dot in an IMAP folder name.
+By default, hMailServer uses . (dot) as the folder separator. This can be changed to a different character under Settings -> Protocols -> IMAP -> Advanced. Whichever character is selected as the separator cannot also be used in an IMAP folder name.


### PR DESCRIPTION
## Summary
- DKIM: `reference_domain.md` claimed hMailServer does not sign messages delivered locally between two accounts on the same server. In `SMTPDeliverer.cpp`, DKIM signing happens before the message is split into local vs. external delivery paths, so local-to-local mail is signed too. Also corrected the documented max signable message size from 10MB to 50MB, matching `DKIM.h`'s `MaxFileSize`.
- IMAP: `information_imap.md`'s "Folder separators" section claimed `.` (dot) is a fixed, hardcoded folder separator. It is actually a configurable setting (`IMAPHierarchyDelimiter` COM property, changeable under Settings -> Protocols -> IMAP -> Advanced), which `reference_protocolimap.md` already documented correctly — the two pages contradicted each other.

## Test plan
- Docs-only change; no build/test required.
- Verified claims against source: `hmailserver/source/Server/SMTP/SMTPDeliverer.cpp` (DKIM signing precedes local/external split), `hmailserver/source/Server/Common/AntiSpam/DKIM/DKIM.h` (`MaxFileSize = 50MB`), `hmailserver/source/Server/hMailServer/hMailServer.idl` and `IMAPConfiguration.cpp` (`IMAPHierarchyDelimiter` is a persisted, configurable setting).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuU1Li4rwvHUd4nRAJdwVT)_