### PR TITLE
Fix stale anti-spam documentation claims

### DIFF
--- a/hmailserver/documentation/book_configuration/reference_antispam.md
+++ b/hmailserver/documentation/book_configuration/reference_antispam.md
@@ -70,15 +70,11 @@ If the size of an email message exceeds this size, hMailServer will not scan it 
 
 ### Use SPF
 
-<div class="indented">Select to enable spam protection using SPF. SPF record for the sending domain will be checked. Only a hard fail will score.</div>
+<div class="indented">Select to enable spam protection using SPF. The SPF record for the sending domain will be checked. Only a hard fail will score.</div>
 
-<div class="indented">If the domain has no SPF record, or the SPF record of the domain ends in a +all (allow all) or ends in ~all (softfail, intended only for testing) then this test will always pass and will not score.</div>
+<div class="indented">A hard fail happens when the mechanism that matches the sending IP address is prefixed with '-' (deny) - most commonly a trailing '-all' (deny all others), but it can also be an earlier, more specific mechanism such as '-ip4:1.2.3.4/32'. If the domain has no SPF record, or the matching mechanism is unprefixed / '+' (pass), '~' (softfail, intended only for testing) or '?' (neutral), the test will pass and will not score.</div>
 
-<div class="indented"> </div>
-
-<div class="indented">SPF scoring ONLY occurs where a SPF record for a domain exists, and that SPF record ends in a '-all' (deny all others), and the sending IP does NOT match the allowed parts of the record.</div>
-
-<div class="indented"> </div>
+<div class="indented"> </div>
 
 <div class="indented">See <a href="http://www.openspf.org/">www.openspf.org</a> for more detail about SPF. You can set SPF records for your own domains as part  of the DNS records.</div>
 
@@ -94,6 +90,11 @@ If the size of an email message exceeds this size, hMailServer will not scan it 
 <div class="indented">
 <h3>Verify DKIM-Signature header</h3>
 <div class="indented">If you enable this option, hMailServer will look for a DKIM-Signature header in every incoming message. If a header is found, hMailServer will verify that the message content matches the signature. If it does not, the spam score of this test will be added to the total spam score for the message.</div>
+</div>
+
+<div class="indented">
+<h3>Check rDNS/PTR record</h3>
+<div class="indented">If you enable this option, hMailServer will look up the PTR (reverse DNS) record for the connecting IP address, and check that one of the addresses that hostname resolves back to matches the connecting IP address. If no matching PTR record is found, the spam score of this test will be added to the total spam score for the message. This option is disabled by default.</div>
 </div>
 
 ## SpamAssassin

--- a/hmailserver/documentation/book_configuration/reference_autoban.md
+++ b/hmailserver/documentation/book_configuration/reference_autoban.md
@@ -26,19 +26,19 @@ When a user is banned, an IP range matching the user is automatically created. I
 
 When a client is banned, an IP range matching his IP address will be created. This IP range will have the following name:
 
-<p style="margin-left: 40px;">Auto-ban: username (random)</p>
+<p style="margin-left: 40px;">Auto-ban: username</p>
 
-Where "username" will be replaced with the username he is trying to log on with, and "random" is replaced with a 9 character random string.  
+Where "username" is replaced with the username he is trying to log on with. If an IP range with that name already exists, hMailServer appends a number in parentheses, e.g. "Auto-ban: username (1)", trying up to 10 numbers. If all of those are taken too, hMailServer falls back to appending a 9-character random string, e.g. "Auto-ban: username (Zx7Hq2pLm)".  
 
   
 
-In hMailServer you can not have multiple IP ranges with the same name. This is the reason the random string is included.
+In hMailServer you can not have multiple IP ranges with the same name. This is the reason a suffix is appended when needed.
 
 ### Potential problems
 
 The Auto-ban functionality blocks IP addresses. If too many invalid logon attempts are made from the same IP address, the IP address will be banned. If you are using a webmail system, all connections to hMailServer from that webmail system will come from the same IP address. If too many invalid logon attempts are made on that webmail system, the IP address the webmail system is connecting from will be blocked.
 
-To solve this problem, you can whitelist the webmail system. A workaround to this problem is to add a new IP range matching the shared IP address and give this IP range higher priority than any IP range added by the auto-ban functionality. The IP ranges added by auto-ban is given the priority 20, so if your own IP range has priority 25 it will take precedence.
+To solve this problem, you can whitelist the webmail system. A workaround to this problem is to add a new IP range matching the shared IP address and give this IP range higher priority than any IP range added by the auto-ban functionality. The IP ranges added by auto-ban is given the priority 100, so if your own IP range has priority 105 it will take precedence.
 
 ## Settings
 

--- a/hmailserver/documentation/book_other/com_objects/com_object_antispam.md
+++ b/hmailserver/documentation/book_other/com_objects/com_object_antispam.md
@@ -18,7 +18,7 @@ The AntiSpam object contains all server-wide settings related to anti-spam.
 
 <div class="api_method_name">DKIMVerify(string File)</div>
 
-<div class="api_description">Verifies the DKIM-Signature of the specified file. Returns true if neutral or pass.</div>
+<div class="api_description">Verifies the DKIM-Signature of the specified file. Returns an eDKIMResult value: 0 (Neutral), 1 (Pass), 2 (Temporary failure) or 3 (Permanent failure).</div>
 
 <div class="api_method_name">TestSpamAssassinConnection(string Hostname, long Port, string ResultText)</div>
 

--- a/hmailserver/documentation/book_other/details_antispam_methods.md
+++ b/hmailserver/documentation/book_other/details_antispam_methods.md
@@ -34,6 +34,10 @@ If DKIM verification is enabled, hMailServer will look for a DKIM-Signature head
 
 This test is expected to catch little spam, since spammers can simply skip including the DKIM-Signature header.
 
+### Check rDNS/PTR record
+
+If you enable this option, hMailServer will look up the PTR (reverse DNS) record for the IP address the message is delivered from, and check that hostname resolves back to that same IP address. Legitimate mail servers are normally set up with matching forward and reverse DNS records, while many spam sources are not. If no matching PTR record is found, the message is treated as spam.
+
 ### SpamAssassin
 
 [SpamAssassin](http://spamassassin.apache.org/) is a popular 3rd part y spam system. It does hundreds of checks on the email message to determine whether the email message is spam.


### PR DESCRIPTION
## Summary
- `reference_autoban.md`: auto-ban IP ranges are created with priority **100**, not 20 (`AccountLogon.cpp:120`, `SetPriority(100)`). Also corrected the IP range naming scheme: hMailServer tries the plain `Auto-ban: username` name first, then numbered suffixes `(1)`-`(10)`, and only falls back to a 9-character random suffix if all of those are taken (`AccountLogon::GetIPRangeName_`) - the doc previously implied the random suffix is always used.
- `com_object_antispam.md`: `DKIMVerify` is documented as returning `true` for neutral/pass, but it actually returns an `eDKIMResult` enum (`Neutral`/`Pass`/`TempFail`/`PermFail`), per `hMailServer.idl` and `InterfaceAntiSpam::DKIMVerify`.
- `reference_antispam.md`: the "SPF scoring ONLY occurs ... record ends in '-all'" claim is too narrow - per the RMSPF library's mechanism-prefix parsing (`RMSPF.cpp`), any `-`-prefixed mechanism that matches the sending IP causes a hard fail, including an earlier, more specific mechanism like `-ip4:1.2.3.4/32`, not just a trailing `-all`. Also added the "Check rDNS/PTR record" spam test to this page - it's implemented (`SpamTestPTR.cpp`), shown in WebAdmin, and documented in the COM object reference, but was missing from the general anti-spam settings and methods pages entirely.
- `details_antispam_methods.md`: added the same missing PTR-check description for consistency.

## Test plan
- Docs-only change; no build/test required.
- Verified each claim against source: `hmailserver/source/Server/Common/Util/AccountLogon.cpp` (priority + naming fallback logic), `hmailserver/source/Server/hMailServer/hMailServer.idl` + `hmailserver/source/Server/COM/InterfaceAntiSpam.cpp` (`DKIMVerify` return type), `hmailserver/source/Server/SMTP/SPF/RMSPF.cpp` (SPF mechanism-prefix parsing), `hmailserver/source/Server/Common/AntiSpam/SpamTestPTR.cpp` and `hmailserver/source/WebAdmin/hm_smtp_antispam.php` (PTR check).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuU1Li4rwvHUd4nRAJdwVT)_