### PR TITLE
Remove stale Python 3 build requirement from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ Environment set up
    * An installed version of hMailServer 5.7 (configured with a database)
    * Visual Studio 2019 Community edition
    * InnoSetup 5.5.4a (non-unicode version)
-   * Perl 5 (https://strawberryperl.com/)
-   * Python 3 (https://www.python.org/)
+   * Perl 5 (https://strawberryperl.com/) - required by the OpenSSL and PostgreSQL library builds
    * CMake (https://cmake.org/download/) - unless Visual Studio's "C++ CMake tools for Windows" component is installed
    
 **NOTE**


### PR DESCRIPTION
The README lists Python 3 under **Required software**, but nothing in the repository uses it.

## Verification

- `python` appears exactly once in the repo: `README.md:34`.
- There are no `.py` files.
- No build script (`build\*.ps1`, `libraries\build-*.ps1`), project file, or InnoSetup script invokes a Python interpreter.
- The library builds the README walks through need Perl (OpenSSL's `Configure`, PostgreSQL's `build.pl`) and CMake (MariaDB Connector/C).
- Boost is staged with `b2` and `libraries/build-boost.ps1` builds only `thread`, `filesystem`, `regex`, `chrono`, `system` and `atomic`, so Boost.Python is never involved.

## Change

```diff
-   * Perl 5 (https://strawberryperl.com/)
-   * Python 3 (https://www.python.org/)
+   * Perl 5 (https://strawberryperl.com/) - required by the OpenSSL and PostgreSQL library builds
```

Documentation only; no code or build changes. The Perl annotation matches the style of the adjacent CMake entry, which already states what it is needed for.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UuYg7ZFmQboZRe9x5ndhEH)_