### PR TITLE
Propagate exit code from installer

### DIFF
--- a/hmailserver/installation/hMailServerInnoExtension.iss
+++ b/hmailserver/installation/hMailServerInnoExtension.iss
@@ -10,6 +10,9 @@ var
   rdoUseInternal : TRadioButton;
   rdoUseExternal : TRadioButton;
 
+  // Non-zero if the installation failed. Setup exits with this code.
+  g_iExitCode : Integer;
+
 // The NT-service specific parts of the scrit below is taken
 // from the innosetup extension knowledgebase.
 // Author: Silvio Iaccarino silvio.iaccarino(at)de.adp.com
@@ -612,12 +615,31 @@ begin
 end;
 
 
-// Aborts the installation with an error message. Setup then exits with a non-zero
-// exit code, so an unattended installation doesn't report success after a failure.
+procedure ExitProcess(uExitCode: UINT);
+  external 'ExitProcess@kernel32.dll stdcall';
+
+// Aborts the installation with an error message. Inno Setup ignores an exception
+// raised after the files have been installed, and would report success even though
+// the installation failed. The exception stops the remaining post-installation
+// tasks, and the exit code is set when setup shuts down. 4 is the exit code Inno
+// Setup itself uses for a fatal error during installation.
 procedure FailPostInstall(szMessage: String);
 begin
+   Log('hMailServer: ' + szMessage);
    SuppressibleMsgBox(szMessage, mbError, MB_OK, IDOK);
+
+   g_iExitCode := 4;
+
    RaiseException(szMessage);
+end;
+
+procedure DeinitializeSetup();
+begin
+   if (g_iExitCode <> 0) then
+   begin
+      DelTree(ExpandConstant('{tmp}'), True, True, True);
+      ExitProcess(g_iExitCode);
+   end;
 end;
 
 // Must be kept in sync with hMailServer.Shared.ExitCodes.

--- a/hmailserver/test/VMTestRunner.Console/Infrastructure/HyperV.cs
+++ b/hmailserver/test/VMTestRunner.Console/Infrastructure/HyperV.cs
@@ -202,6 +202,14 @@ namespace VMTestRunner.Console
          }
       }
 
+      // The exit code is read inside the guest - a Process object doesn't keep its
+      // ExitCode when it's serialized back to us.
+      private const string RunProgramScript =
+         "param($exe, $argList) " +
+         "if ($argList) { $process = Start-Process -FilePath $exe -ArgumentList $argList -Wait -PassThru } " +
+         "else { $process = Start-Process -FilePath $exe -Wait -PassThru } " +
+         "$process.ExitCode";
+
       /// <summary>
       /// Runs a program in the guest. throwOnFailure should only be used for programs
       /// which are known to return a meaningful exit code - 'net stop' for example
@@ -217,7 +225,7 @@ namespace VMTestRunner.Console
               .AddParameter("VMName", _vmName)
               .AddParameter("Credential", _credential)
               .AddParameter("ScriptBlock",
-                  ScriptBlock.Create("param($exe, $argList) if ($argList) { Start-Process -FilePath $exe -ArgumentList $argList -Wait -PassThru } else { Start-Process -FilePath $exe -Wait -PassThru }"))
+                  ScriptBlock.Create(RunProgramScript))
               .AddParameter("ArgumentList", new object[] { fullPath, param });
 
             var results = ps.Invoke();
@@ -235,12 +243,12 @@ namespace VMTestRunner.Console
 
       private int GetExitCode(Collection<PSObject> results)
       {
-         var exitCode = results.FirstOrDefault()?.Properties["ExitCode"]?.Value;
+         var exitCode = results.FirstOrDefault()?.BaseObject;
 
-         if (exitCode == null)
-            throw new Exception("RunProgramInGuest: The exit code of the process could not be determined.");
+         if (!(exitCode is int))
+            throw new Exception($"RunProgramInGuest: The exit code of the process could not be determined. Result: {exitCode ?? "(none)"}");
 
-         return Convert.ToInt32(exitCode);
+         return (int) exitCode;
       }
 
       public void CreateDirectory(string name)

--- a/hmailserver/test/VMTestRunner.Console/TestEnvironments.json
+++ b/hmailserver/test/VMTestRunner.Console/TestEnvironments.json
@@ -180,8 +180,8 @@
   },
   {
     "operatingSystem": "Windows 10",
-    "description": "MySQL 8.0.29: New installation - MariaDB client",
-    "vmName": "Windows10-MySQL8.0.29",
+    "description": "MySQL 26.7.0: New installation - MariaDB client",
+    "vmName": "Windows10-MySQL-26.7.0",
     "snapshotName": "Ready",
     "preInstallCommands": [
       {


### PR DESCRIPTION
If installer fails to run DBSetup, it should return a non-zero exit code