### PR TITLE
POP3: Return -ERR when inbox messages can't be fetched

### DIFF
--- a/hmailserver/source/Server/POP3/POP3Connection.cpp
+++ b/hmailserver/source/Server/POP3/POP3Connection.cpp
@@ -501,7 +501,7 @@ namespace HM
   
       if (!Application::Instance()->GetFolderManager()->GetInboxMessages((int) account_->GetID(), messages_))
       {
-         EnqueueWrite_("+ERR Server error: Failed to fetch messages in Inbox.");
+         EnqueueWrite_("-ERR Server error: Failed to fetch messages in Inbox.");
          return ResultNormalResponse;
       }
 

--- a/hmailserver/test/RegressionTests/POP3/Basics.cs
+++ b/hmailserver/test/RegressionTests/POP3/Basics.cs
@@ -247,6 +247,22 @@ namespace RegressionTests.POP3
       }
 
       [Test]
+      [Description("If the inbox messages can't be loaded, the failure should be reported using -ERR.")]
+      public void TestLogonWhenInboxMessagesCannotBeFetched()
+      {
+         var account = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "test@example.test", "test");
+
+         // Remove the INBOX folder, so that the server is unable to load the inbox messages during logon.
+         account.IMAPFolders.get_ItemByName("INBOX").Delete();
+
+         string errorMessage;
+
+         var sim = new Pop3ClientSimulator();
+         Assert.IsFalse(sim.ConnectAndLogon(account.Address, "test", out errorMessage));
+         Assert.IsTrue(errorMessage.StartsWith("-ERR"), errorMessage);
+      }
+
+      [Test]
       public void TestPOP3TransactionSafety()
       {
          var account = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "test@example.test", "test");


### PR DESCRIPTION
When FolderManager::GetInboxMessages failed during PASS, the server responded with "+ERR Server error: Failed to fetch messages in Inbox.". POP3 only defines "+OK" and "-ERR" as status indicators, so a "+" prefixed failure is read as success by clients, or leaves them waiting for a status indicator they never receive.

Report the failure with "-ERR" instead.

Added a regression test that deletes the account's INBOX folder, which makes the inbox message fetch fail during logon, and asserts that the logon is rejected with a "-ERR" response.

Fixes #590