### PR TITLE
IMAP: Fire OnClientLogon from AUTHENTICATE PLAIN

### DIFF
--- a/hmailserver/source/Server/IMAP/IMAPCommandAuthenticate.cpp
+++ b/hmailserver/source/Server/IMAP/IMAPCommandAuthenticate.cpp
@@ -11,6 +11,12 @@
 #include "../common/BO/Account.h"
 #include "../common/BO/SecurityRange.h"
 
+#include "../common/Scripting/ClientInfo.h"
+#include "../Common/Scripting/ScriptServer.h"
+#include "../Common/Scripting/ScriptObjectContainer.h"
+
+#include "../Common/TCPIP/CipherInfo.h"
+
 #ifdef _DEBUG
 #define DEBUG_NEW new(_NORMAL_BLOCK, __FILE__, __LINE__)
 #define new DEBUG_NEW
@@ -126,6 +132,35 @@ namespace HM
 
 			return IMAPResult(IMAPResult::ResultOKSupressRead, "");
 		}
+
+      const bool isAuthenticated = pAccount != nullptr;
+
+      if (Configuration::Instance()->GetUseScriptServer())
+      {
+         std::shared_ptr<ScriptObjectContainer> pContainer = std::shared_ptr<ScriptObjectContainer>(new ScriptObjectContainer);
+         std::shared_ptr<ClientInfo> pClientInfo = std::shared_ptr<ClientInfo>(new ClientInfo);
+
+         // If a master user has been used to log on, the session is logged on as the
+         // authorization identity, so that's the user name we report to the script.
+         pClientInfo->SetUsername(authzid.GetLength() > 0 ? authzid : authcid);
+         pClientInfo->SetIPAddress(pConnection->GetRemoteEndpointAddress().ToString());
+         pClientInfo->SetPort(pConnection->GetLocalEndpointPort());
+         pClientInfo->SetSessionID(pConnection->GetSessionID());
+         pClientInfo->SetIsAuthenticated(isAuthenticated);
+         pClientInfo->SetIsEncryptedConnection(pConnection->IsSSLConnection());
+         if (pConnection->IsSSLConnection())
+         {
+            auto cipher_info = pConnection->GetCipherInfo();
+            pClientInfo->SetCipherVersion(cipher_info.GetVersion().c_str());
+            pClientInfo->SetCipherName(cipher_info.GetName().c_str());
+            pClientInfo->SetCipherBits(cipher_info.GetBits());
+         }
+
+         pContainer->AddObject("HMAILSERVER_CLIENT", pClientInfo, ScriptObject::OTClient);
+
+         String sEventCaller = "OnClientLogon(HMAILSERVER_CLIENT)";
+         ScriptServer::Instance()->FireEvent(ScriptServer::EventOnClientLogon, sEventCaller, pContainer);
+      }
 
 		if (!pAccount)
 		{

--- a/hmailserver/test/RegressionTests/API/Events.cs
+++ b/hmailserver/test/RegressionTests/API/Events.cs
@@ -775,6 +775,51 @@ namespace RegressionTests.API
       }
 
       [Test]
+      public void TestOnClientLogon_IMAP_Authenticate()
+      {
+         var domain = SingletonProvider<TestSetup>.Instance.AddTestDomain();
+         SingletonProvider<TestSetup>.Instance.AddAccount(domain, "test@example.test", "test");
+
+         var app = SingletonProvider<TestSetup>.Instance.GetApp();
+         var scripting = app.Settings.Scripting;
+
+         app.Settings.IMAPSASLPlainEnabled = true;
+
+         var script = "Sub OnClientLogon(oClient) " + Environment.NewLine +
+                      " EventLog.Write(\"OnClientLogin-IMAP-Authenticate\")" + Environment.NewLine +
+                      " EventLog.Write(\"IsAuthenticated: \" & oClient.Authenticated) " + Environment.NewLine +
+                      " EventLog.Write(\"Username: \" & oClient.Username) " + Environment.NewLine +
+                      "End Sub" + Environment.NewLine + Environment.NewLine;
+
+         File.WriteAllText(scripting.CurrentScriptFile, script);
+
+         scripting.Enabled = true;
+         scripting.Reload();
+
+         var eventLogFile = app.Settings.Logging.CurrentEventLog;
+         if (File.Exists(eventLogFile))
+            File.Delete(eventLogFile);
+
+         // Log on using AUTHENTICATE PLAIN to trigger the event.
+         var token =
+            Convert.ToBase64String(Encoding.ASCII.GetBytes("\0test@example.test\0test"));
+
+         var simulator = new ImapClientSimulator();
+         simulator.Connect();
+         var result = simulator.SendSingleCommand("A01 AUTHENTICATE PLAIN " + token);
+         Assert.IsTrue(result.Contains("A01 OK LOGIN completed"), result);
+         simulator.Disconnect();
+
+         // Check that the message exists
+         var message = TestSetup.ReadExistingTextFile(eventLogFile);
+
+         Assert.IsNotEmpty(message);
+         Assert.IsTrue(message.Contains("OnClientLogin-IMAP-Authenticate"));
+         Assert.IsTrue(message.Contains("IsAuthenticated: True"));
+         Assert.IsTrue(message.Contains("Username: test@example.test"));
+      }
+
+      [Test]
       public void TestOnClientLogon_SMTP()
       {
          var domain = SingletonProvider<TestSetup>.Instance.AddTestDomain();


### PR DESCRIPTION
Fixes #591

`IMAPCommandAuthenticate.cpp` never fired the `OnClientLogon` script event, so clients logging on with `AUTHENTICATE PLAIN` were invisible to the event handler — unlike IMAP `LOGIN` (`IMAPCommandLogin.cpp`), POP3 (`POP3Connection.cpp`) and SMTP (`SMTPConnection.cpp`), which all build a `ClientInfo` and fire `ScriptServer::EventOnClientLogon`.

## Changes

`hmailserver/source/Server/IMAP/IMAPCommandAuthenticate.cpp`

- Added the event block after the auto-ban/disconnect check and *before* the `!pAccount` bail-out, so — as in the other three implementations — the event fires for failed logons too, with `IsAuthenticated` reflecting the outcome.
- Populates the same fields IMAP `LOGIN` sets: username, IP address, local port, session ID, authenticated flag, encrypted-connection flag, and cipher version/name/bits. (No `HELO`; that is SMTP-only.)
- For a master-user logon (`authzid` present) the session is logged on *as* the authorization identity — `PasswordValidator::ValidatePassword` returns the masqueraded account — so the script is given `authzid` when set, `authcid` otherwise. If scripts should instead see the credential actually used to authenticate, that is a one-line change.

`hmailserver/test/RegressionTests/API/Events.cs`

- Added `TestOnClientLogon_IMAP_Authenticate` alongside the existing per-protocol tests. It enables `IMAPSASLPlainEnabled`, logs on with `A01 AUTHENTICATE PLAIN <base64>`, and asserts the event log shows the handler ran with `IsAuthenticated: True` and the expected user name.

## Testing

The regression suite is Windows/VS-only, so the change has not been compiled or run here. The added code mirrors the three existing implementations line for line; CI on this PR is the first actual build.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6wrQwotoBi4yWQsC2iMpT)_