### PR TITLE
Synchronize messages in public folders in the data directory synchronizer

### DIFF
--- a/hmailserver/source/Server/Common/Persistence/PersistentMessage.cpp
+++ b/hmailserver/source/Server/Common/Persistence/PersistentMessage.cpp
@@ -1205,12 +1205,12 @@ namespace HM
       String filePath = fullPath.Mid(dataDirectory.GetLength() + 1);
 
       // Is the file in the public folder?
-      String publicFolderName = IMAPConfiguration::GetPublicFolderDiskName();
+      String publicFolderPrefix = IMAPConfiguration::GetPublicFolderDiskName() + FileUtilities::PathSeparator;
 
-      if (filePath.StartsWith(publicFolderName))
+      if (filePath.StartsWith(publicFolderPrefix))
       {
          // Trim it away.
-         filePath = filePath.Mid(publicFolderName.GetLength() + 1);
+         filePath = filePath.Mid(publicFolderPrefix.GetLength());
 
          int guidSlashPos = filePath.Find(FileUtilities::PathSeparator);
          if (guidSlashPos <= 0)
@@ -1220,7 +1220,7 @@ namespace HM
          if (guidSlashPos != 2)
             return false;
 
-         String lastLevelName = filePath.Mid(guidSlashPos);
+         String lastLevelName = filePath.Mid(0, guidSlashPos);
 
          filePath = filePath.Mid(guidSlashPos+1);
 

--- a/hmailserver/source/Server/Common/Util/MailImporter.cpp
+++ b/hmailserver/source/Server/Common/Util/MailImporter.cpp
@@ -78,6 +78,14 @@ namespace HM
          }
       }
 
+      // The message isn't referenced in the database. If it's stored in the public folder, we
+      // have no way of telling which public IMAP folder it belongs to - the folder isn't part
+      // of the path on disk. Rather than guessing, we leave the file alone.
+      String publicFolderPath = FileUtilities::Combine(dataDirectory, IMAPConfiguration::GetPublicFolderDiskName());
+
+      if (originalFullPath.StartsWith(publicFolderPath + FileUtilities::PathSeparator))
+         return false;
+
       String newFullPath = originalFullPath;
 
       // Construct a partial file name.

--- a/hmailserver/source/Tools/DataDirectorySynchronizer/Globals.cs
+++ b/hmailserver/source/Tools/DataDirectorySynchronizer/Globals.cs
@@ -19,12 +19,14 @@ namespace DataDirectorySynchronizer
 
       public static ModeType Mode { get; set; }
       public static List<string> SelectedDomains { get; set; }
+      public static bool SynchronizePublicFolders { get; set; }
 
       private static hMailServer.Application _application;
 
       static Globals()
       {
          SelectedDomains = new List<string>();
+         SynchronizePublicFolders = true;
       }
 
       public static void SetApp(hMailServer.Application application)

--- a/hmailserver/source/Tools/DataDirectorySynchronizer/Pages/ucProgress.cs
+++ b/hmailserver/source/Tools/DataDirectorySynchronizer/Pages/ucProgress.cs
@@ -66,6 +66,11 @@ namespace DataDirectorySynchronizer.Pages
             // Process all domains
             IterateDomainFolders(dirInfo);
 
+            // Process the public folders. They are not stored below any of the
+            // domain folders, so they need to be handled separately.
+            if (Globals.SynchronizePublicFolders)
+               IteratePublicFolder(dirInfo);
+
             timer.Enabled = false;
 
             application.Reinitialize();
@@ -111,6 +116,29 @@ namespace DataDirectorySynchronizer.Pages
             }
 
             AddProcessedFile(fullName, imported);
+         }
+      }
+
+      private void IteratePublicFolder(DirectoryInfo dirRoot)
+      {
+         DirectoryInfo publicFolder =
+            new DirectoryInfo(Path.Combine(dirRoot.FullName, _application.Settings.PublicFolderDiskName));
+
+         if (!publicFolder.Exists)
+            return;
+
+         try
+         {
+            // Messages in public folders aren't owned by an account, which is why
+            // no account is given here.
+            ProcessFilesInFolder(publicFolder, 0);
+
+            foreach (DirectoryInfo publicSubFolder in publicFolder.GetDirectories())
+               ProcessFilesInFolder(publicSubFolder, 0);
+         }
+         catch (Exception)
+         {
+            AddProcessedFile(publicFolder.FullName, false);
          }
       }
 

--- a/hmailserver/source/Tools/DataDirectorySynchronizer/Pages/ucSelectDomain.Designer.cs
+++ b/hmailserver/source/Tools/DataDirectorySynchronizer/Pages/ucSelectDomain.Designer.cs
@@ -33,6 +33,7 @@
          this.columnDomainName = new System.Windows.Forms.ColumnHeader();
          this.buttonSelectAll = new System.Windows.Forms.Button();
          this.buttonSelectNone = new System.Windows.Forms.Button();
+         this.checkPublicFolders = new System.Windows.Forms.CheckBox();
          this.SuspendLayout();
          // 
          // labelSelectDomain
@@ -40,9 +41,9 @@
          this.labelSelectDomain.AutoSize = true;
          this.labelSelectDomain.Location = new System.Drawing.Point(25, 16);
          this.labelSelectDomain.Name = "labelSelectDomain";
-         this.labelSelectDomain.Size = new System.Drawing.Size(212, 13);
+         this.labelSelectDomain.Size = new System.Drawing.Size(268, 13);
          this.labelSelectDomain.TabIndex = 5;
-         this.labelSelectDomain.Text = "Select the domain you want to synchronize.";
+         this.labelSelectDomain.Text = "Select the domains and folders you want to synchronize.";
          // 
          // listViewDomains
          // 
@@ -87,10 +88,22 @@
          this.buttonSelectNone.UseVisualStyleBackColor = true;
          this.buttonSelectNone.Click += new System.EventHandler(this.buttonSelectNone_Click);
          // 
+         // checkPublicFolders
+         // 
+         this.checkPublicFolders.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+         this.checkPublicFolders.AutoSize = true;
+         this.checkPublicFolders.Location = new System.Drawing.Point(310, 282);
+         this.checkPublicFolders.Name = "checkPublicFolders";
+         this.checkPublicFolders.Size = new System.Drawing.Size(140, 17);
+         this.checkPublicFolders.TabIndex = 10;
+         this.checkPublicFolders.Text = "Include public folders";
+         this.checkPublicFolders.UseVisualStyleBackColor = true;
+         // 
          // ucSelectDomain
          // 
          this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
          this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+         this.Controls.Add(this.checkPublicFolders);
          this.Controls.Add(this.buttonSelectNone);
          this.Controls.Add(this.buttonSelectAll);
          this.Controls.Add(this.listViewDomains);
@@ -109,5 +122,6 @@
       private System.Windows.Forms.ColumnHeader columnDomainName;
       private System.Windows.Forms.Button buttonSelectAll;
       private System.Windows.Forms.Button buttonSelectNone;
+      private System.Windows.Forms.CheckBox checkPublicFolders;
    }
 }

--- a/hmailserver/source/Tools/DataDirectorySynchronizer/Pages/ucSelectDomain.cs
+++ b/hmailserver/source/Tools/DataDirectorySynchronizer/Pages/ucSelectDomain.cs
@@ -40,6 +40,8 @@ namespace DataDirectorySynchronizer.Pages
             else
                item.Checked = false;
          }
+
+         checkPublicFolders.Checked = Globals.SynchronizePublicFolders;
       }
 
       public bool OnLeavePage(bool next)
@@ -52,24 +54,30 @@ namespace DataDirectorySynchronizer.Pages
                Globals.SelectedDomains.Add(item.Text);
          }
 
+         Globals.SynchronizePublicFolders = checkPublicFolders.Checked;
+
          return true;
       }
 
       public string Title
       {
-         get { return "Select domain"; }
+         get { return "Select what to synchronize"; }
       }
 
       private void buttonSelectAll_Click(object sender, EventArgs e)
       {
          foreach (ListViewItem item in listViewDomains.Items)
             item.Checked = true;
+
+         checkPublicFolders.Checked = true;
       }
 
       private void buttonSelectNone_Click(object sender, EventArgs e)
       {
          foreach (ListViewItem item in listViewDomains.Items)
             item.Checked = false;
+
+         checkPublicFolders.Checked = false;
       }
    }
 }

--- a/hmailserver/test/RegressionTests/API/Utilities.cs
+++ b/hmailserver/test/RegressionTests/API/Utilities.cs
@@ -92,6 +92,42 @@ namespace RegressionTests.API
       }
 
       [Test]
+      [Description(
+         "Import a message stored in a sub directory of the public folder. This must fail as well, since " +
+         "the public IMAP folder isn't part of the path on disk."
+      )]
+      public void TestImportOfMessageInPublicFolderSubdirectory()
+      {
+         var messageText =
+            "From: test@example.test\r\n" +
+            "\r\n" +
+            "Test\r\n";
+
+         var account = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "test@example.test", "test");
+
+         var guid = Guid.NewGuid().ToString();
+         var publicFolder = Path.Combine(_application.Settings.Directories.DataDirectory,
+            _application.Settings.PublicFolderDiskName);
+         var guidPath = Path.Combine(publicFolder, guid.Substring(1, 2));
+
+         Directory.CreateDirectory(guidPath);
+
+         var fileName = Path.Combine(guidPath, guid + ".eml");
+
+         File.WriteAllText(fileName, messageText);
+
+         Assert.IsFalse(_application.Utilities.ImportMessageFromFile(fileName, account.ID));
+         Assert.IsFalse(_application.Utilities.ImportMessageFromFile(fileName, 0));
+
+         // The file should have been left alone.
+         Assert.IsTrue(File.Exists(fileName));
+
+         Pop3ClientSimulator.AssertMessageCount(account.Address, "test", 0);
+
+         Directory.Delete(guidPath, true);
+      }
+
+      [Test]
       [Description("Import a mail located properly in a sub directory.")]
       public void TestImportOfMessageInSubdirectory()
       {
@@ -200,6 +236,53 @@ namespace RegressionTests.API
          sim.ConnectAndLogon("test@example.test", "test");
          Assert.AreEqual(1, sim.GetMessageCount("Woho"));
          sim.Disconnect();
+      }
+
+      [Test]
+      [Description(
+         "A message stored in a public folder must be found by its file name, so that the data directory " +
+         "synchronizer doesn't consider it an orphan and deletes it."
+      )]
+      public void TestRetrieveMessageIdForMessageInPublicFolder()
+      {
+         var publicFolders = _settings.PublicFolders;
+         var folder = publicFolders.Add("Share1");
+         folder.Save();
+
+         var message = folder.Messages.Add();
+         message.Subject = "Test";
+         message.Save();
+
+         var fileName = message.Filename;
+
+         Assert.IsTrue(fileName.Contains(_settings.PublicFolderDiskName));
+         Assert.AreEqual(message.ID, _application.Utilities.RetrieveMessageID(fileName));
+      }
+
+      [Test]
+      [Description(
+         "Importing a message which is already stored in a public folder should be a no-op. It should " +
+         "neither be duplicated nor moved to another file."
+      )]
+      public void TestImportOfExistingMessageInPublicFolder()
+      {
+         var publicFolders = _settings.PublicFolders;
+         var folder = publicFolders.Add("Share1");
+         folder.Save();
+
+         var message = folder.Messages.Add();
+         message.Subject = "Test";
+         message.Save();
+
+         var fileName = message.Filename;
+
+         Assert.IsTrue(_application.Utilities.ImportMessageFromFile(fileName, 0));
+
+         _application.Reinitialize();
+
+         Assert.AreEqual(1, _settings.PublicFolders[0].Messages.Count);
+         Assert.AreEqual(fileName, _settings.PublicFolders[0].Messages[0].Filename);
+         Assert.IsTrue(File.Exists(fileName));
       }
 
       [Test]


### PR DESCRIPTION
The data directory synchronizer only walked the domain folders, so messages stored in public folders (<data directory>\#Public) were never checked.