### PR TITLE
Prevent EHLO/HELO bypass via SMTP RSET

### DIFF
--- a/hmailserver/source/Server/SMTP/SMTPConnection.cpp
+++ b/hmailserver/source/Server/SMTP/SMTPConnection.cpp
@@ -451,11 +451,15 @@ namespace HM
       if (!CheckStartTlsRequired_())
          return;
 
+      const bool isInitialState = (current_state_ == INITIAL);
+
       ResetCurrentMessage_();
 
-      EnqueueWrite_("250 OK");
+      if (isInitialState) {
+         current_state_ = INITIAL;
+      }
 
-      return;
+      EnqueueWrite_("250 OK");
    }
 
    void

--- a/hmailserver/test/RegressionTests/SMTP/Basics.cs
+++ b/hmailserver/test/RegressionTests/SMTP/Basics.cs
@@ -996,6 +996,22 @@ namespace RegressionTests.SMTP
       }
 
       [Test]
+      public void TestPreventRSETByPassHELO()
+      {
+         var settings = _settings;
+         settings.DisconnectInvalidClients = true;
+         settings.MaxNumberOfInvalidCommands = 3;
+
+         var sim = new TcpConnection();
+         sim.Connect(25);
+         sim.Receive(); // banner
+
+         sim.SendAndReceive("RSET\r\n");
+         var result = sim.SendAndReceive("MAIL FROM:<test@example.com>\r\n");
+         Assert.IsTrue(result.Contains("503 Bad sequence of command"), result);
+      }
+
+      [Test]
       public void TestTooManyInvalidCommandsHELOLastCommandOK()
       {
          var settings = _settings;


### PR DESCRIPTION
For details, see: https://github.com/cybercode3/hmailserver/commit/88ec404b05550bd4879e153439bf6a7f14eb6638

Included test