### PR TITLE
Never leave the greeting state without a HELO/EHLO

### DIFF
--- a/hmailserver/source/Server/SMTP/SMTPConnection.cpp
+++ b/hmailserver/source/Server/SMTP/SMTPConnection.cpp
@@ -150,11 +150,13 @@ namespace HM
                GetConnectionSecurity() == CSSTARTTLSRequired)
       {
          /*
-           Upon completion of the TLS handshake, the SMTP protocol is reset to
-           the initial state (the state in SMTP after a server issues a 220
-           service ready greeting). The server MUST discard any knowledge
-           obtained from the client, such as the argument to the EHLO command,
-           which was not obtained from the TLS negotiation itself.
+           RFC 3207, 4.2:
+
+             Upon completion of the TLS handshake, the SMTP protocol is reset to
+             the initial state (the state in SMTP after a server issues a 220
+             service ready greeting). The server MUST discard any knowledge
+             obtained from the client, such as the argument to the EHLO command,
+             which was not obtained from the TLS negotiation itself.
          */
 
          helo_host_.Empty();
@@ -162,8 +164,16 @@ namespace HM
          ResetLoginCredentials_();
          ResetCurrentMessage_();
 
-         // The session is back at the point right after the 220 greeting, so the
-         // client has to send a new EHLO before it can issue any other command.
+         /*
+           The initial state is the state before any greeting, so the client has to
+           greet us again before it can send mail. RFC 5321, 4.1.4:
+
+             A session that will contain mail transactions MUST first be
+             initialized by the use of the EHLO command.
+
+           The commands which need no initialization are unaffected, since they are
+           dispatched ahead of the state switch in InternalParseData.
+         */
          current_state_ = INITIAL;
 
          EnqueueRead();
@@ -455,6 +465,18 @@ namespace HM
       if (!CheckStartTlsRequired_())
          return;
 
+      /*
+        RSET is answered normally even before the client has greeted us.
+        RFC 5321, 4.1.4:
+
+          The NOOP, HELP, EXPN, VRFY, and RSET commands can be used at any time
+          during a session, or without previously initializing a session. SMTP
+          servers SHOULD process these normally (that is, not return a 503 code)
+          even if no EHLO command has yet been received [...]
+
+        ResetCurrentMessage_ leaves an ungreeted session in INITIAL, so the reply
+        below does not let the client past the greeting.
+      */
       ResetCurrentMessage_();
 
       EnqueueWrite_("250 OK");
@@ -1540,13 +1562,20 @@ namespace HM
       // message.
       cur_no_of_rcptto_ = 0;
 
-      // Switch back to normal ASCII mode and start of session, in
-      // case we are in binary transmission mode.
-      //
-      // If the client hasn't greeted us yet, we must remain in the initial
-      // state. Resetting the current message must never take the place of a
-      // HELO/EHLO, since that would let a client skip the greeting - and with
-      // it the OnHELO/OnEHLO script events and the HELO-based spam tests.
+      /*
+        Switch back to normal ASCII mode and start of session, in case we are in
+        binary transmission mode.
+
+        A session which hasn't been greeted stays in INITIAL: resetting the message
+        must never take the place of a HELO/EHLO. RFC 5321, 4.1.4:
+
+          A session that will contain mail transactions MUST first be initialized
+          by the use of the EHLO command.
+
+        A client which could reach HEADER by resetting would skip the greeting, and
+        with it the OnHELO/OnEHLO events and the HELO-based spam tests - the latter
+        would then run against an empty HELO host.
+      */
       if (current_state_ != INITIAL)
          current_state_ = HEADER;
    }

--- a/hmailserver/source/Server/SMTP/SMTPConnection.cpp
+++ b/hmailserver/source/Server/SMTP/SMTPConnection.cpp
@@ -451,13 +451,7 @@ namespace HM
       if (!CheckStartTlsRequired_())
          return;
 
-      const bool isInitialState = (current_state_ == INITIAL);
-
       ResetCurrentMessage_();
-
-      if (isInitialState) {
-         current_state_ = INITIAL;
-      }
 
       EnqueueWrite_("250 OK");
    }
@@ -1544,7 +1538,13 @@ namespace HM
 
       // Switch back to normal ASCII mode and start of session, in
       // case we are in binary transmission mode.
-      current_state_ = HEADER;
+      //
+      // If the client hasn't greeted us yet, we must remain in the initial
+      // state. Resetting the current message must never take the place of a
+      // HELO/EHLO, since that would let a client skip the greeting - and with
+      // it the OnHELO/OnEHLO script events and the HELO-based spam tests.
+      if (current_state_ != INITIAL)
+         current_state_ = HEADER;
    }
 
 

--- a/hmailserver/source/Server/SMTP/SMTPConnection.cpp
+++ b/hmailserver/source/Server/SMTP/SMTPConnection.cpp
@@ -162,6 +162,10 @@ namespace HM
          ResetLoginCredentials_();
          ResetCurrentMessage_();
 
+         // The session is back at the point right after the 220 greeting, so the
+         // client has to send a new EHLO before it can issue any other command.
+         current_state_ = INITIAL;
+
          EnqueueRead();
       }
    }

--- a/hmailserver/test/RegressionTests/SMTP/Basics.cs
+++ b/hmailserver/test/RegressionTests/SMTP/Basics.cs
@@ -996,19 +996,47 @@ namespace RegressionTests.SMTP
       }
 
       [Test]
-      public void TestPreventRSETByPassHELO()
+      [Description("RSET must not take the place of a HELO/EHLO greeting.")]
+      public void RsetBeforeGreetingShouldNotAllowMailFrom()
       {
-         var settings = _settings;
-         settings.DisconnectInvalidClients = true;
-         settings.MaxNumberOfInvalidCommands = 3;
-
          var sim = new TcpConnection();
          sim.Connect(25);
          sim.Receive(); // banner
 
-         sim.SendAndReceive("RSET\r\n");
+         var rsetResult = sim.SendAndReceive("RSET\r\n");
+         StringAssert.Contains("250 OK", rsetResult);
+
          var result = sim.SendAndReceive("MAIL FROM:<test@example.com>\r\n");
-         Assert.IsTrue(result.Contains("503 Bad sequence of command"), result);
+         StringAssert.Contains("503 Bad sequence of commands", result);
+      }
+
+      [Test]
+      [Description("Closing the RSET greeting bypass must not break RSET itself.")]
+      public void RsetAfterGreetingShouldStillAllowMailFrom()
+      {
+         var sim = new TcpConnection();
+         sim.Connect(25);
+         sim.Receive(); // banner
+
+         StringAssert.Contains("250 Hello.", sim.SendAndReceive("HELO example.com\r\n"));
+         StringAssert.Contains("250 OK", sim.SendAndReceive("RSET\r\n"));
+         StringAssert.Contains("250 OK", sim.SendAndReceive("MAIL FROM:<test@example.com>\r\n"));
+      }
+
+      [Test]
+      [Description("Closing the RSET greeting bypass must not break RSET itself.")]
+      public void RsetShouldAbortTransactionInProgress()
+      {
+         var sim = new TcpConnection();
+         sim.Connect(25);
+         sim.Receive(); // banner
+
+         StringAssert.Contains("250 Hello.", sim.SendAndReceive("HELO example.com\r\n"));
+         StringAssert.Contains("250 OK", sim.SendAndReceive("MAIL FROM:<test@example.com>\r\n"));
+
+         // Without the RSET, a second MAIL FROM is rejected as a bad sequence.
+         StringAssert.Contains("250 OK", sim.SendAndReceive("RSET\r\n"));
+         StringAssert.Contains("250 OK", sim.SendAndReceive("MAIL FROM:<test@example.com>\r\n"));
       }
 
       [Test]

--- a/hmailserver/test/RegressionTests/SSL/StartTls/SmtpServerTests.cs
+++ b/hmailserver/test/RegressionTests/SSL/StartTls/SmtpServerTests.cs
@@ -122,6 +122,8 @@ namespace RegressionTests.SSL.StartTls
          smtpClientSimulator.SendAndReceive("STARTTLS\r\n");
          smtpClientSimulator.HandshakeAsClient();
 
+         smtpClientSimulator.SendAndReceive("EHLO example.com\r\n");
+
          var loginResult = smtpClientSimulator.SendAndReceive("AUTH LOGIN\r\n");
          Assert.IsTrue(loginResult.StartsWith("334"));
       }
@@ -159,6 +161,61 @@ namespace RegressionTests.SSL.StartTls
                "530 A SSL/TLS-connection is required for authentication.")); // must run starttls first.
       }
 
+
+      [Test]
+      [Description("RFC 3207: after the handshake the session is back in the initial state, " +
+                   "so the client has to greet the server again.")]
+      public void AfterStartTlsMailFromShouldRequireNewEhlo()
+      {
+         var smtpClientSimulator = new TcpConnection();
+         smtpClientSimulator.Connect(25002);
+         smtpClientSimulator.Receive(); // banner
+         var capabilities = smtpClientSimulator.SendAndReceive("EHLO example.com\r\n");
+         Assert.IsTrue(capabilities.Contains("STARTTLS"));
+
+         smtpClientSimulator.SendAndReceive("STARTTLS\r\n");
+         smtpClientSimulator.HandshakeAsClient();
+
+         var result = smtpClientSimulator.SendAndReceive("MAIL FROM:<test@example.com>\r\n");
+         StringAssert.Contains("503 Bad sequence of commands", result);
+      }
+
+      [Test]
+      [Description("RSET must not take the place of the EHLO the client owes us after STARTTLS.")]
+      public void AfterStartTlsRsetShouldNotAllowMailFrom()
+      {
+         var smtpClientSimulator = new TcpConnection();
+         smtpClientSimulator.Connect(25002);
+         smtpClientSimulator.Receive(); // banner
+         var capabilities = smtpClientSimulator.SendAndReceive("EHLO example.com\r\n");
+         Assert.IsTrue(capabilities.Contains("STARTTLS"));
+
+         smtpClientSimulator.SendAndReceive("STARTTLS\r\n");
+         smtpClientSimulator.HandshakeAsClient();
+
+         StringAssert.Contains("250 OK", smtpClientSimulator.SendAndReceive("RSET\r\n"));
+
+         var result = smtpClientSimulator.SendAndReceive("MAIL FROM:<test@example.com>\r\n");
+         StringAssert.Contains("503 Bad sequence of commands", result);
+      }
+
+      [Test]
+      public void AfterStartTlsMailFromShouldBeAcceptedOnceEhloHasBeenReissued()
+      {
+         var smtpClientSimulator = new TcpConnection();
+         smtpClientSimulator.Connect(25002);
+         smtpClientSimulator.Receive(); // banner
+         var capabilities = smtpClientSimulator.SendAndReceive("EHLO example.com\r\n");
+         Assert.IsTrue(capabilities.Contains("STARTTLS"));
+
+         smtpClientSimulator.SendAndReceive("STARTTLS\r\n");
+         smtpClientSimulator.HandshakeAsClient();
+
+         smtpClientSimulator.SendAndReceive("EHLO example.com\r\n");
+
+         var result = smtpClientSimulator.SendAndReceive("MAIL FROM:<test@example.com>\r\n");
+         StringAssert.Contains("250 OK", result);
+      }
 
       [Test]
       public void TestPlaintextCommandInjection()

--- a/hmailserver/test/RegressionTests/Shared/SMTPClientSimulator.cs
+++ b/hmailserver/test/RegressionTests/Shared/SMTPClientSimulator.cs
@@ -206,6 +206,10 @@ namespace RegressionTests.Shared
             SendAndReceive("STARTTLS\r\n");
 
             _tcpConnection.HandshakeAsClient();
+
+            // RFC 3207: the handshake resets the session to the initial state, so the
+            // server expects a new greeting before it accepts any other command.
+            SendAndReceive("EHLO example.com\r\n");
          }
 
          if (!string.IsNullOrEmpty(username))


### PR DESCRIPTION
Follow-up to #604, which fixed the RSET half of this.

## The shape of the bug

`ResetCurrentMessage_` ended with an unconditional `current_state_ = HEADER`. `HELO`/`EHLO` are the only intended `INITIAL -> HEADER` transitions, and both guard their own assignment - so any other caller of `ResetCurrentMessage_` silently promoted an ungreeted session past the greeting. #604 fixed that for `RSET` by restoring the state in `ProtocolRSET_` afterwards.

Two things were left:

1. **The guard belongs in `ResetCurrentMessage_`.** Fixing it there covers all nine callers rather than one, and leaves no trap for the next caller. None of the others can be in `INITIAL` - they run off DATA completion, QUIT, `OnExcessiveDataReceived` or the destructor - so this is a no-op for them.

2. **The STARTTLS path had the same bug.** `OnHandshakeCompleted` cleared `helo_host_` and then called `ResetCurrentMessage_`, landing the session in `HEADER`. A client could send `MAIL FROM` without greeting the encrypted session at all, and the message was accepted with no HELO host: the HELO-based spam tests ran against an empty string, the `Received:` header fell back to the bare IP, and `OnHELO`/`OnEHLO` never fired for the session that actually carried the mail.

## What the RFCs say

RFC 3207 section 4.2 says the handshake resets the protocol "to the initial state (the state in SMTP after a server issues a 220 service ready greeting)" and that the server MUST discard the EHLO argument. RFC 5321 section 4.1.4 then puts a MUST on the client: "a session that will contain mail transactions MUST first be initialized by the use of the EHLO command."

So a client that skips the second EHLO and sends `MAIL FROM` is out of order - it is not exercising RFC 3207's `SHOULD send an EHLO command as the first command`. That SHOULD covers the commands which need no initialization, and those still work: `NOOP`, `HELP`, `QUIT`, `RSET`, `HELO` and `EHLO` are all dispatched ahead of the state switch in `InternalParseData`. Section 4.1.4 is explicit that `RSET` in particular should be answered normally rather than with a 503, which is what #604 already does.

The three places that decide whether a session has been greeted now quote the text they implement, so the behaviour does not have to be taken on trust.

## Behaviour change worth a release note

Requiring a greeting after the handshake will 503 a client that previously got through.

`AUTH` is the case to watch. It is advertised before TLS on a STARTTLS-**optional** port (`GetAuthIsEnabled_() && (IsSSLConnection() || GetConnectionSecurity() != CSSTARTTLSRequired)`), so a client can learn the mechanism from the plaintext EHLO and previously went straight to `AUTH` after the handshake. Such a client now has to send `EHLO` first, as it already must on a STARTTLS-**required** port, where `AUTH` is not advertised until after TLS.

hMailServer's own outbound client is unaffected - `SMTPClientConnection::OnHandshakeCompleted` already calls `ProtocolStateHELOEHLO_`. Two places in the test suite did skip the re-greeting and are corrected here; that RFC 3207 asks clients to send it anyway is why those edits are no-ops against the old server.

The commit that makes this change is separate from the rest so it can be reverted on its own.

## Tests

`SSL/StartTls/SmtpServerTests.cs`

- `AfterStartTlsMailFromShouldRequireNewEhlo`
- `AfterStartTlsRsetShouldNotAllowMailFrom`
- `AfterStartTlsMailFromShouldBeAcceptedOnceEhloHasBeenReissued`

`SMTP/Basics.cs` - replacing `TestPreventRSETByPassHELO`, which asserted against `503 Bad sequence of command` (missing the trailing s) and carried two `DisconnectInvalidClients`/`MaxNumberOfInvalidCommands` settings that had nothing to do with what it tested:

- `RsetBeforeGreetingShouldNotAllowMailFrom` - now also asserts the `RSET` itself is answered `250 OK`
- `RsetAfterGreetingShouldStillAllowMailFrom`
- `RsetShouldAbortTransactionInProgress`

The last two exist so that this cannot be "fixed" by breaking `RSET`.

The tests were pushed on their own first and confirmed red on exactly the two expected tests and nothing else (981 passed / 2 failed / 12 skipped), then green once the fix landed (983 passed / 0 failed / 12 skipped) in run [#48](https://github.com/hmailserver/hmailserver/actions/runs/33649960536).

---
_Generated by [Claude Code](https://claude.ai/code/session_014iDHFrsVSMhsrXmv4tEnMq)_