### PR TITLE
DNSResolverWinApi

### DIFF
--- a/hmailserver/source/Server/Common/TCPIP/DNSResolverWinApi.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/DNSResolverWinApi.cpp
@@ -72,16 +72,19 @@ namespace HM
 
       if (!IniFileSettings::Instance()->GetUseDNSCache())
       {
-         fOptions += DNS_QUERY_BYPASS_CACHE;
+         fOptions |= DNS_QUERY_BYPASS_CACHE;
       }
 
+      // Use a Custom DNS server IPv4 address if specified in the settings. 
+      // If the address is invalid, we will fallback to the system DNS servers.
       AnsiString sCustomDNS;
       sCustomDNS = IniFileSettings::Instance()->GetDNSServer().Trim();
       if (!sCustomDNS.IsEmpty())
       {
+         // Allocate and zero-initialize for safety.
          pSrvList = (PIP4_ARRAY)malloc(sizeof(IP4_ARRAY));
-         if (!pSrvList) {
-
+         if (!pSrvList) 
+         {
             String sMessage;
             sMessage.Format(_T("Unable to allocate memory for DNS server list. Query: %s, Type: %d."), query, resourceType);
             ErrorManager::Instance()->ReportError(ErrorManager::Low, 4401, "DNSResolver::_Resolve", sMessage);
@@ -89,23 +92,23 @@ namespace HM
             return false;
          }
 
-         // Custom DNSServer IPv4 address
+         // Parse IPv4 address
          pSrvList->AddrCount = 1;
-         pSrvList->AddrArray[0] = inet_addr(sCustomDNS.c_str()); //Custom DNS server IP address
-         if (pSrvList->AddrArray[0] == INADDR_NONE) {
-
+         pSrvList->AddrArray[0] = inet_addr(sCustomDNS.c_str());
+         if (pSrvList->AddrArray[0] == INADDR_NONE) 
+         {
             String sMessage;
             sMessage.Format(_T("Invalid DNSServer IP address. DNSServer IP: %hs."), sCustomDNS.c_str());
             ErrorManager::Instance()->ReportError(ErrorManager::Low, 4401, "DNSResolver::_Resolve", sMessage);
 
-            // fallback to the system dns servers
+            // free and fallback to the system dns servers
+            free(pSrvList);
             pSrvList = NULL;
          }
          else
          {
-            // We need this if not using system dns servers
-            if (fOptions != DNS_QUERY_BYPASS_CACHE)
-               fOptions += DNS_QUERY_BYPASS_CACHE;
+            // If using a custom server, bypass local cache to ensure we query the specified server.
+            fOptions |= DNS_QUERY_BYPASS_CACHE;
          }
       }
 
@@ -125,8 +128,15 @@ namespace HM
             String sMessage;
             sMessage.Format(_T("DNS - Query failure. Query: %s, Type: %d, DnsQuery return value: %d."), query.c_str(), resourceType, nDnsStatus);
             LOG_TCPIP(sMessage);
+
+            if (pSrvList != NULL)
+               free(pSrvList);
+
             return false;
          }
+
+         if (pSrvList != NULL)
+            free(pSrvList);
 
          return true;
       }
@@ -227,8 +237,11 @@ namespace HM
          pDnsRecord = pDnsRecord->pNext;
       }
       
-      _FreeDNSRecord(pDnsRecordsToDelete);
-      pDnsRecordsToDelete = 0;
+      if (pDnsRecordsToDelete)
+      {
+         _FreeDNSRecord(pDnsRecordsToDelete);
+         pDnsRecordsToDelete = 0;
+      }
 
       if (pSrvList != NULL)
          free(pSrvList);

--- a/hmailserver/source/Server/Common/TCPIP/DNSResolverWinApi.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/DNSResolverWinApi.cpp
@@ -147,7 +147,8 @@ namespace HM
 
          // On some systems the in-addr.arpa or ip6.arpa addresses will have a trailing dot for local ip addresses in the PTR lookup. 
          // Remove it to ensure we can compare the query with the result.
-         if (pDnsRecord->wType == DNS_TYPE_PTR) {
+         if (pDnsRecord->wType == DNS_TYPE_PTR) 
+         {
             if (!name.empty() && name.back() == '.') {
                name.pop_back();
             }

--- a/hmailserver/source/Server/Common/TCPIP/DNSResolverWinApi.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/DNSResolverWinApi.cpp
@@ -145,6 +145,14 @@ namespace HM
       {
          String name = pDnsRecord->pName;
 
+         // On some systems the in-addr.arpa or ip6.arpa addresses will have a trailing dot for local ip addresses in the PTR lookup. 
+         // Remove it to ensure we can compare the query with the result.
+         if (pDnsRecord->wType == DNS_TYPE_PTR) {
+            if (!name.empty() && name.back() == '.') {
+               name.pop_back();
+            }
+         }
+
          if (pDnsRecord->wType == resourceType && 
              query.Equals(name))
          {


### PR DESCRIPTION
- Multiple calls to `free(pSrvList);` when `pSrvList != NULL`, on errors
- Use proper bitwise operators for fOptions