### PR TITLE
Run each connection's socket operations in a strand, #610

### DIFF
--- a/hmailserver/source/Server/Common/TCPIP/IOOperation.h
+++ b/hmailserver/source/Server/Common/TCPIP/IOOperation.h
@@ -29,10 +29,16 @@ namespace HM
       std::shared_ptr<ByteBuffer> GetBuffer() {return buffer_; }
       AnsiString GetString() {return string_; }
 
+      // Text to write to the protocol log once the operation has completed. Logging it when
+      // the operation is enqueued would claim data was sent while it's still queued.
+      void SetLogData(const AnsiString &log_data) {log_data_ = log_data; }
+      AnsiString GetLogData() {return log_data_; }
+
    private:
 
       OperationType type_;
       AnsiString string_;
+      AnsiString log_data_;
       std::shared_ptr<ByteBuffer> buffer_;
 
    };

--- a/hmailserver/source/Server/Common/TCPIP/IOOperationQueue.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/IOOperationQueue.cpp
@@ -13,18 +13,9 @@
 
 namespace HM
 {
-   IOOperationQueue::IOOperationQueue() :
-      is_ssl_(false)
+   IOOperationQueue::IOOperationQueue()
    {
-      
-   }
 
-   void
-   IOOperationQueue::SetIsSSL(bool is_ssl)
-   {
-      boost::lock_guard<boost::recursive_mutex> guard(mutex_);
-
-      is_ssl_ = is_ssl;
    }
 
    IOOperationQueue::~IOOperationQueue(void)
@@ -138,14 +129,9 @@ namespace HM
                   switch (pendingType)
                   {
                   case IOOperation::BCTWrite:
-                     // On a plain socket we may send data while we're processing data (normal responses).
-                     // On a ssl::stream, read and write drive the same SSL object; starting a write with a
-                     // read outstanding corrupts its state, so the write has to wait.
-                     if (is_ssl_)
-                     {
-                        std::shared_ptr<IOOperation> empty;
-                        return empty;
-                     }
+                     // We may send data while we're processing data (normal responses, and IMAP
+                     // notifications during IDLE). TCPConnection runs both in the same strand, so
+                     // a ssl::stream is never entered from two threads at once.
                      break;
                   case IOOperation::BCTDisconnect:   // We may disconnect while we're processing data
                   case IOOperation::BCTShutdownSend: // It's OK to close the sending even though we're receiving data.

--- a/hmailserver/source/Server/Common/TCPIP/IOOperationQueue.h
+++ b/hmailserver/source/Server/Common/TCPIP/IOOperationQueue.h
@@ -21,15 +21,9 @@ namespace HM
 
       bool ContainsQueuedSendOperation();
 
-      void SetIsSSL(bool is_ssl);
-
    private:
 
       boost::recursive_mutex mutex_;
-
-      // An ssl::stream cannot read and write concurrently, so a SSL connection needs a
-      // stricter rule than a plain socket.
-      bool is_ssl_;
 
       std::deque<std::shared_ptr<IOOperation> > queue_operations_;
       

--- a/hmailserver/source/Server/Common/TCPIP/TCPConnection.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/TCPConnection.cpp
@@ -223,7 +223,7 @@ namespace HM
       case IOOperation::BCTWrite:
          {
             std::shared_ptr<ByteBuffer> pBuf = operation->GetBuffer();
-            AsyncWrite(pBuf);
+            AsyncWrite(pBuf, operation->GetLogData());
             break;
          }
       case IOOperation::BCTRead:
@@ -604,8 +604,14 @@ namespace HM
       ProcessOperationQueue_(0);
    }
 
-   void 
+   void
    TCPConnection::EnqueueWrite(const AnsiString &sData)
+   {
+      EnqueueWrite(sData, "");
+   }
+
+   void
+   TCPConnection::EnqueueWrite(const AnsiString &sData, const AnsiString &log_data)
    {
       AnsiString sTemp = sData;
       char *pBuf = sTemp.GetBuffer();
@@ -619,30 +625,38 @@ namespace HM
       OutputDebugString(sDebugOutput);
 #endif
 
-      EnqueueWrite(pBuffer);
+      EnqueueWrite(pBuffer, log_data);
 
    }
 
-   void 
+   void
    TCPConnection::EnqueueWrite(std::shared_ptr<ByteBuffer> pBuffer)
+   {
+      EnqueueWrite(pBuffer, "");
+   }
+
+   void
+   TCPConnection::EnqueueWrite(std::shared_ptr<ByteBuffer> pBuffer, const AnsiString &log_data)
    {
       ThrowIfNotConnected_();
 
       std::shared_ptr<IOOperation> operation = std::shared_ptr<IOOperation>(new IOOperation(IOOperation::BCTWrite, pBuffer));
+      operation->SetLogData(log_data);
 
       operation_queue_.Push(operation);
       ProcessOperationQueue_(0);
    }
 
-   void 
-   TCPConnection::AsyncWrite(std::shared_ptr<ByteBuffer> buffer)
+   void
+   TCPConnection::AsyncWrite(std::shared_ptr<ByteBuffer> buffer, const AnsiString &log_data)
    {
       UpdateAutoLogoutTimer();
 
       std::function<void (const boost::system::error_code&, size_t)> AsyncWriteCompletedFunction =
          std::bind(&TCPConnection::AsyncWriteCompleted, shared_from_this(),
          std::placeholders::_1,
-         std::placeholders::_2);
+         std::placeholders::_2,
+         log_data);
 
       if (is_ssl_)
          boost::asio::async_write
@@ -654,10 +668,13 @@ namespace HM
       
    }
 
-   void 
-   TCPConnection::AsyncWriteCompleted(const boost::system::error_code& error, size_t bytes_transferred)
+   void
+   TCPConnection::AsyncWriteCompleted(const boost::system::error_code& error, size_t bytes_transferred, const AnsiString &log_data)
    {
       UpdateAutoLogoutTimer();
+
+      if (!log_data.IsEmpty() && error.value() == 0)
+         LogSentData(log_data);
 
       if (error.value() != 0)
       {

--- a/hmailserver/source/Server/Common/TCPIP/TCPConnection.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/TCPConnection.cpp
@@ -34,6 +34,7 @@ namespace HM
                                 std::shared_ptr<Event> disconnected,
                                 AnsiString expected_remote_hostname) :
       connection_security_(connection_security),
+      strand_(boost::asio::make_strand(io_context)),
       socket_(io_context),
       ssl_socket_(socket_, context),
       resolver_(io_context),
@@ -155,7 +156,8 @@ namespace HM
       // Attempt a connection to the first endpoint in the list. Each endpoint
       // will be tried until we successfully establish a connection.
       socket_.async_connect(ep,
-               std::bind(&TCPConnection::AsyncConnectCompleted, shared_from_this(), std::placeholders::_1));
+               boost::asio::bind_executor(strand_,
+                  std::bind(&TCPConnection::AsyncConnectCompleted, shared_from_this(), std::placeholders::_1)));
 
    }
 
@@ -194,6 +196,19 @@ namespace HM
       {
          EnqueueHandshake();
       }
+   }
+
+   void
+   TCPConnection::DispatchProcessOperationQueue_()
+   {
+      // Runs inline if we're already in the strand, which is the case for the normal
+      // request-response flow. Notifications are sent from other threads and are posted.
+      auto self = shared_from_this();
+
+      boost::asio::dispatch(strand_, [self]()
+      {
+         self->ProcessOperationQueue_(0);
+      });
    }
 
    void
@@ -273,7 +288,7 @@ namespace HM
       std::shared_ptr<IOOperation> operation = std::shared_ptr<IOOperation>(new IOOperation(IOOperation::BCTDisconnect, pBuf));
       operation_queue_.Push(operation);
 
-      ProcessOperationQueue_(0);
+      DispatchProcessOperationQueue_();
    }
 
 
@@ -307,7 +322,7 @@ namespace HM
       std::shared_ptr<IOOperation> operation = std::shared_ptr<IOOperation>(new IOOperation(IOOperation::BCTHandshake, pBuf));
       operation_queue_.Push(operation);
 
-      ProcessOperationQueue_(0);
+      DispatchProcessOperationQueue_();
    }
 
 
@@ -383,8 +398,9 @@ namespace HM
       boost::asio::ssl::stream_base::server;
 
       ssl_socket_.async_handshake(handshakeType,
-         std::bind(&TCPConnection::AsyncHandshakeCompleted, shared_from_this(),
-         std::placeholders::_1));
+         boost::asio::bind_executor(strand_,
+            std::bind(&TCPConnection::AsyncHandshakeCompleted, shared_from_this(),
+            std::placeholders::_1)));
    }
 
 
@@ -396,7 +412,6 @@ namespace HM
       if (!error)
       {
          is_ssl_ = true;
-         operation_queue_.SetIsSSL(true);
 
          // Send welcome message to client.
          auto cipher_info = GetCipherInfo();
@@ -442,7 +457,7 @@ namespace HM
       std::shared_ptr<IOOperation> operation = std::shared_ptr<IOOperation>(new IOOperation(IOOperation::BCTShutdownSend, pBuf));
       operation_queue_.Push(operation);
 
-      ProcessOperationQueue_(0);
+      DispatchProcessOperationQueue_();
    }
 
    void 
@@ -459,7 +474,7 @@ namespace HM
       std::shared_ptr<IOOperation> operation = std::shared_ptr<IOOperation>(new IOOperation(IOOperation::BCTRead, delimiter));
       operation_queue_.Push(operation);
 
-      ProcessOperationQueue_(0);
+      DispatchProcessOperationQueue_();
    }
 
    void 
@@ -467,10 +482,10 @@ namespace HM
    {
       UpdateAutoLogoutTimer();
 
-      std::function<void (const boost::system::error_code&, size_t)> AsyncReadCompletedFunction =
-         std::bind(&TCPConnection::AsyncReadCompleted, shared_from_this(), 
+      auto AsyncReadCompletedFunction = boost::asio::bind_executor(strand_,
+         std::bind(&TCPConnection::AsyncReadCompleted, shared_from_this(),
          std::placeholders::_1,
-         std::placeholders::_2);
+         std::placeholders::_2));
 
       if (is_ssl_)
       {
@@ -644,7 +659,7 @@ namespace HM
       operation->SetLogData(log_data);
 
       operation_queue_.Push(operation);
-      ProcessOperationQueue_(0);
+      DispatchProcessOperationQueue_();
    }
 
    void
@@ -652,11 +667,11 @@ namespace HM
    {
       UpdateAutoLogoutTimer();
 
-      std::function<void (const boost::system::error_code&, size_t)> AsyncWriteCompletedFunction =
+      auto AsyncWriteCompletedFunction = boost::asio::bind_executor(strand_,
          std::bind(&TCPConnection::AsyncWriteCompleted, shared_from_this(),
          std::placeholders::_1,
          std::placeholders::_2,
-         log_data);
+         log_data));
 
       if (is_ssl_)
          boost::asio::async_write
@@ -818,7 +833,8 @@ namespace HM
       // Put a timeout...
       timer_.expires_after(std::chrono::seconds(timeout_));
 
-      timer_.async_wait(std::bind(&TCPConnection::OnTimeout, std::weak_ptr<TCPConnection>(shared_from_this()), std::placeholders::_1));
+      timer_.async_wait(boost::asio::bind_executor(strand_,
+         std::bind(&TCPConnection::OnTimeout, std::weak_ptr<TCPConnection>(shared_from_this()), std::placeholders::_1)));
    }
 
    void

--- a/hmailserver/source/Server/Common/TCPIP/TCPConnection.h
+++ b/hmailserver/source/Server/Common/TCPIP/TCPConnection.h
@@ -117,6 +117,7 @@ namespace HM
       bool IsClient();
 
       void ProcessOperationQueue_(int recurse_level);
+      void DispatchProcessOperationQueue_();
 
       void Disconnect();
       void Shutdown(boost::asio::socket_base::shutdown_type);
@@ -134,6 +135,13 @@ namespace HM
       void ReportError(ErrorManager::eSeverity sev, int code, const String &context, const String &message, const boost::system::system_error &error);
       void ReportError(ErrorManager::eSeverity sev, int code, const String &context, const String &message, const boost::system::error_code &error);
       void ReportError(ErrorManager::eSeverity sev, int code, const String &context, const String &message);
+
+      /*
+         All operations on socket_/ssl_socket_ run in this strand. Read and write on a
+         ssl::stream drive the same SSL object, and notifications are sent from foreign
+         threads, so without it two threads could enter OpenSSL at the same time.
+      */
+      boost::asio::strand<boost::asio::io_context::executor_type> strand_;
 
       boost::asio::ip::tcp::socket socket_;
       ssl_socket ssl_socket_;

--- a/hmailserver/source/Server/Common/TCPIP/TCPConnection.h
+++ b/hmailserver/source/Server/Common/TCPIP/TCPConnection.h
@@ -43,7 +43,9 @@ namespace HM
       void SetReceiveBinary(bool binary);
 
       void EnqueueWrite(const AnsiString &sData);
+      void EnqueueWrite(const AnsiString &sData, const AnsiString &log_data);
       void EnqueueWrite(std::shared_ptr<ByteBuffer> pByteBuffer);
+      void EnqueueWrite(std::shared_ptr<ByteBuffer> pByteBuffer, const AnsiString &log_data);
       void EnqueueRead();
       void EnqueueRead(const AnsiString &delimiter);
       void EnqueueShutdownSend();
@@ -89,6 +91,11 @@ namespace HM
       virtual void OnExcessiveDataReceived() = 0;
       virtual void OnDataSent() {};
       virtual void OnReadError(int errorCode) {};
+
+      // Called when a write has actually completed, for connections which pass log data to
+      // EnqueueWrite.
+      virtual void LogSentData(const AnsiString &log_data) {};
+
       virtual AnsiString GetCommandSeparator() const = 0;
 
       /* PARSING METHODS */
@@ -114,14 +121,14 @@ namespace HM
       void Disconnect();
       void Shutdown(boost::asio::socket_base::shutdown_type);
       
-      void AsyncWrite(std::shared_ptr<ByteBuffer> buffer);
+      void AsyncWrite(std::shared_ptr<ByteBuffer> buffer, const AnsiString &log_data);
       void AsyncRead(const AnsiString &delimiter);
       void AsyncHandshake();
 
       void AsyncConnectCompleted(const boost::system::error_code& err);
       void AsyncHandshakeCompleted(const boost::system::error_code& error);
       void AsyncReadCompleted(const boost::system::error_code& /*error*/, size_t bytes_transferred);
-      void AsyncWriteCompleted(const boost::system::error_code& /*error*/, size_t bytes_transferred);
+      void AsyncWriteCompleted(const boost::system::error_code& /*error*/, size_t bytes_transferred, const AnsiString &log_data);
 
       void ReportDebugMessage(const String &message, const boost::system::error_code &error);
       void ReportError(ErrorManager::eSeverity sev, int code, const String &context, const String &message, const boost::system::system_error &error);

--- a/hmailserver/source/Server/IMAP/IMAPConnection.cpp
+++ b/hmailserver/source/Server/IMAP/IMAPConnection.cpp
@@ -467,6 +467,8 @@ namespace HM
    void
    IMAPConnection::SendAsciiData(const AnsiString & sData)
    {
+      AnsiString log_data;
+
       if (Logger::Instance()->GetLogIMAP())
       {
          // Let's tame these logs a bit. Disables IMAP SENT
@@ -481,12 +483,20 @@ namespace HM
             String sLogData = _T("SENT: ") + sData;
             sLogData.TrimRight(_T("\r\n"));
 
-            LOG_IMAP(GetSessionID(),GetIPAddressString(), sLogData);
+            log_data = sLogData;
          }
          // Logging gets skipped otherwise
       }
 
-      EnqueueWrite(sData);
+      // The data is logged when the write completes, not here. It may sit in the operation
+      // queue for a while, and logging it now would claim it had reached the client.
+      EnqueueWrite(sData, log_data);
+   }
+
+   void
+   IMAPConnection::LogSentData(const AnsiString &log_data)
+   {
+      LOG_IMAP(GetSessionID(), GetIPAddressString(), String(log_data));
    }
 
    IMAPConnection::eIMAPCommandType 

--- a/hmailserver/source/Server/IMAP/IMAPConnection.h
+++ b/hmailserver/source/Server/IMAP/IMAPConnection.h
@@ -152,6 +152,7 @@ namespace HM
       
       virtual void OnExcessiveDataReceived();
       virtual void OnConnectionTimeout();
+      virtual void LogSentData(const AnsiString &log_data);
             
       eIMAPCommandType GetCommandType(String & sCommand);
 

--- a/hmailserver/test/RegressionTests/RegressionTests.csproj
+++ b/hmailserver/test/RegressionTests/RegressionTests.csproj
@@ -237,6 +237,7 @@
     <Compile Include="SMTP\SMTPClientStartTLSTests.cs" />
     <Compile Include="SMTP\SMTPClientTests.cs" />
     <Compile Include="Shared\SmtpServerSimulator.cs" />
+    <Compile Include="SSL\ImapIdleSslTests.cs" />
     <Compile Include="SSL\SmtpDeliverySslTests.cs" />
     <Compile Include="SSL\SslSetup.cs" />
     <Compile Include="SSL\StartTls\ImapServerTests.cs" />

--- a/hmailserver/test/RegressionTests/SSL/ImapIdleSslTests.cs
+++ b/hmailserver/test/RegressionTests/SSL/ImapIdleSslTests.cs
@@ -1,0 +1,99 @@
+using System;
+using hMailServer;
+using NUnit.Framework;
+using RegressionTests.Shared;
+
+namespace RegressionTests.SSL
+{
+   /// <summary>
+   ///    IMAP IDLE notifications must reach the client while it is idling, also on TLS
+   ///    connections. Regression test for issue #610, where a queued write was withheld on SSL
+   ///    connections until the outstanding read completed - i.e. until the client sent DONE.
+   /// </summary>
+   [TestFixture]
+   public class ImapIdleSslTests : TestFixtureBase
+   {
+      private const int ImapPlainPort = 143;
+      private const int ImapTlsPort = 14301;
+      private const int ImapStartTlsPort = 14302;
+
+      private Account _account;
+
+      [OneTimeSetUp]
+      public new void TestFixtureSetUp()
+      {
+         SslSetup.SetupSSLPorts(_application);
+      }
+
+      [SetUp]
+      public new void SetUp()
+      {
+         _settings.IMAPIdleEnabled = true;
+
+         _account = SingletonProvider<TestSetup>.Instance.AddAccount(_domain, "idle-ssl@example.test", "test");
+      }
+
+      [Test]
+      [Description("A message delivered while idling on a plain connection is announced without DONE.")]
+      public void NotificationIsPushedDuringIdleOnPlainPort()
+      {
+         var simulator = new ImapClientSimulator(false, ImapPlainPort);
+
+         AssertNotificationPushedDuringIdle(simulator, false);
+      }
+
+      [Test]
+      [Category("SSL")]
+      [Description("A message delivered while idling on an implicit TLS connection is announced without DONE.")]
+      public void NotificationIsPushedDuringIdleOnTlsPort()
+      {
+         var simulator = new ImapClientSimulator(true, ImapTlsPort);
+
+         AssertNotificationPushedDuringIdle(simulator, false);
+      }
+
+      [Test]
+      [Category("SSL")]
+      [Description("A message delivered while idling after STARTTLS is announced without DONE.")]
+      public void NotificationIsPushedDuringIdleAfterStartTls()
+      {
+         var simulator = new ImapClientSimulator(false, ImapStartTlsPort);
+
+         AssertNotificationPushedDuringIdle(simulator, true);
+      }
+
+      private void AssertNotificationPushedDuringIdle(ImapClientSimulator simulator, bool useStartTls)
+      {
+         simulator.Connect();
+
+         if (useStartTls)
+         {
+            simulator.SendSingleCommand("A01 STARTTLS");
+            simulator.Handshake();
+         }
+
+         Assert.IsTrue(simulator.Logon(_account.Address, "test"), "Logon");
+         Assert.IsTrue(simulator.SelectFolder("INBOX"), "SelectFolder");
+         Assert.IsTrue(simulator.StartIdle(), "StartIdle");
+
+         Assert.IsFalse(simulator.GetPendingDataExists(), "Unexpected data before delivery.");
+
+         new SmtpClientSimulator().Send(_account.Address, _account.Address, "IDLE Test",
+            "This is a test of IDLE");
+
+         // No DONE is sent here - the notification has to arrive on its own.
+         if (!simulator.AssertPendingDataExists())
+            Assert.Fail("No notification was received while idling. Sent only after DONE?");
+
+         var data = simulator.Receive();
+
+         Assert.IsTrue(data.Contains("EXISTS"),
+            "Expected an EXISTS notification while idling, received: " + data);
+
+         string output;
+         Assert.IsTrue(simulator.EndIdle(true, out output), "EndIdle");
+
+         simulator.Disconnect();
+      }
+   }
+}


### PR DESCRIPTION
IMAP IDLE notifications were not sent immediately when using TLS.