### PR TITLE
Let backup compression use half of the logical processors, #616

### DIFF
--- a/hmailserver/source/Server/Common/Util/Compression.cpp
+++ b/hmailserver/source/Server/Common/Util/Compression.cpp
@@ -6,6 +6,8 @@
 #include "Compression.h"
 #include "ProcessLauncher.h"
 
+#include <boost/thread/thread.hpp>
+
 #ifdef _DEBUG
 #define DEBUG_NEW new(_NORMAL_BLOCK, __FILE__, __LINE__)
 #define new DEBUG_NEW
@@ -27,10 +29,9 @@ namespace HM
    bool
    Compression::AddDirectory(const String &zipFile, const String &directoryToAdd)
    {
-      // -r = recurse -t = type 7z -mmt=off = single-threaded -mx1 = lowest compression
-      // Backups run while the server handles mail, so they use one core rather than all of them.
-      String commandLine = Formatter::Format("\"{0}\" a \"{1}\" \"{2}\" -r -t7z -mmt=off -mx1  -w\"{3}\"",
-         GetExecutableFullPath_(), zipFile, directoryToAdd, IniFileSettings::Instance()->GetTempDirectory());
+      // -r = recurse -t = type 7z -mmt = number of threads -mx1 = lowest compression
+      String commandLine = Formatter::Format("\"{0}\" a \"{1}\" \"{2}\" -r -t7z {3} -mx1  -w\"{4}\"",
+         GetExecutableFullPath_(), zipFile, directoryToAdd, GetMultithreadingParameter_(), IniFileSettings::Instance()->GetTempDirectory());
 
       return LaunchCommand_(commandLine);
    }
@@ -38,9 +39,9 @@ namespace HM
    bool
    Compression::AddFile(const String &zipFile, const String &fileToAdd)
    {
-      // -t = type 7z -mmt=off = single-threaded -mx1 = lowest compression
-      String commandLine = Formatter::Format("\"{0}\" a \"{1}\" \"{2}\" -t7z -mmt=off -mx1 -w\"{3}\"",
-         GetExecutableFullPath_(), zipFile, fileToAdd, IniFileSettings::Instance()->GetTempDirectory());
+      // -t = type 7z -mmt = number of threads -mx1 = lowest compression
+      String commandLine = Formatter::Format("\"{0}\" a \"{1}\" \"{2}\" -t7z {3} -mx1 -w\"{4}\"",
+         GetExecutableFullPath_(), zipFile, fileToAdd, GetMultithreadingParameter_(), IniFileSettings::Instance()->GetTempDirectory());
 
       return LaunchCommand_(commandLine);
    }
@@ -73,6 +74,20 @@ namespace HM
          return false;
 
       return true;
+   }
+
+   String
+   Compression::GetMultithreadingParameter_()
+   {
+      // Backups run while the server is processing email, so compression is given at most half of
+      // the logical processors rather than all of them.
+      unsigned int processorCount = boost::thread::hardware_concurrency();
+      unsigned int threadCount = processorCount / 2;
+
+      if (threadCount < 2)
+         return "-mmt=off";
+
+      return Formatter::Format("-mmt={0}", threadCount);
    }
 
    String 

--- a/hmailserver/source/Server/Common/Util/Compression.cpp
+++ b/hmailserver/source/Server/Common/Util/Compression.cpp
@@ -55,8 +55,9 @@ namespace HM
    bool
    Compression::Uncompress(const String &zipFile, const String &targetDirectory, const String &wildCard)
    {
-      String commandLine = Formatter::Format("\"{0}\" x \"{1}\" \"{2}\" -o\"{3}\" -y", 
-         GetExecutableFullPath_(), zipFile, wildCard, targetDirectory);
+      // -o = output directory -mmt = number of threads -y = assume yes on all queries
+      String commandLine = Formatter::Format("\"{0}\" x \"{1}\" \"{2}\" -o\"{3}\" {4} -y", 
+         GetExecutableFullPath_(), zipFile, wildCard, targetDirectory, GetMultithreadingParameter_());
 
       return LaunchCommand_(commandLine);
    }
@@ -79,8 +80,10 @@ namespace HM
    String
    Compression::GetMultithreadingParameter_()
    {
-      // Backups run while the server is processing email, so compression is given at most half of
-      // the logical processors rather than all of them.
+      // Backup and restore both run while the server is processing email, so 7za is given at most
+      // half of the logical processors rather than all of them. This matters on restore too:
+      // an archive written with several threads is split into blocks that 7za will otherwise
+      // decode on every core at once.
       unsigned int processorCount = boost::thread::hardware_concurrency();
       unsigned int threadCount = processorCount / 2;
 

--- a/hmailserver/source/Server/Common/Util/Compression.h
+++ b/hmailserver/source/Server/Common/Util/Compression.h
@@ -21,6 +21,7 @@ namespace HM
  
       bool LaunchCommand_(const String &commandLine);
       String GetExecutableFullPath_();
+      String GetMultithreadingParameter_();
 
    };
 }


### PR DESCRIPTION
Backup compression was switched to -mmt=off, which pins 7za to a single
thread. Running backups on one core makes large backups unnecessarily
slow, while letting 7za use every core starves mail processing.

Use half of the logical processors instead, falling back to -mmt=off when
that leaves fewer than two threads (or when the processor count cannot be
determined).