### PR TITLE
Fix: Interop.hMailServer.dll missing or mismatched in installer

### DIFF
--- a/hmailserver/installation/section_files_64.iss
+++ b/hmailserver/installation/section_files_64.iss
@@ -17,13 +17,13 @@ Source: "..\source\tools\Administrator\bin\x64\Release\hMailAdmin.exe"; DestDir:
 Source: "..\source\tools\DBUpdater\Bin\x64\Release\DBUpdater.exe"; DestDir: "{app}\Bin";  Flags: ignoreversion; Components: server;
 Source: "..\source\tools\DBSetup\Bin\x64\Release\DBSetup.exe"; DestDir: "{app}\Bin";Flags: ignoreversion;Components: server;
 Source: "..\Source\tools\DBSetupQuick\bin\x64\release\DBSetupQuick.exe"; DestDir: "{app}\Bin"; Flags: ignoreversion; Components: server;
-Source: "..\source\tools\Administrator\bin\x64\Release\Interop.hMailServer.dll"; DestDir: "{app}\Bin"; Flags: ignoreversion; Components: admintools;
+Source: "..\source\tools\Administrator\bin\x64\Release\Interop.hMailServer.dll"; DestDir: "{app}\Bin"; Flags: ignoreversion; Components: server admintools;
 Source: "..\source\tools\shared\bin\x64\Release\Shared.dll"; DestDir: "{app}\Bin"; Flags: ignoreversion; Components: server admintools;
 
 ; Data directory synchronizer
-Source: "..\source\Tools\DataDirectorySynchronizer\Bin\x64\Release\*.exe"; DestDir: "{app}\Addons\DataDirectorySynchronizer"; Flags: ignoreversion recursesubdirs;Components: server;
-Source: "..\source\tools\Administrator\bin\x64\Release\Interop.hMailServer.dll"; DestDir: "{app}\Addons\DataDirectorySynchronizer"; Flags: ignoreversion; Components: admintools;
-Source: "..\source\Tools\Shared\Bin\x64\Release\*.dll"; DestDir: "{app}\Addons\DataDirectorySynchronizer"; Flags: ignoreversion recursesubdirs;Components: server;
+Source: "..\source\Tools\DataDirectorySynchronizer\Bin\x64\Release\*.exe"; DestDir: "{app}\Addons\DataDirectorySynchronizer"; Flags: ignoreversion recursesubdirs; Components: server;
+Source: "..\source\tools\Administrator\bin\x64\Release\Interop.hMailServer.dll"; DestDir: "{app}\Addons\DataDirectorySynchronizer"; Flags: ignoreversion; Components: server;
+Source: "..\source\Tools\Shared\Bin\x64\Release\Shared.dll"; DestDir: "{app}\Addons\DataDirectorySynchronizer"; Flags: ignoreversion; Components: server;
 
 ; OpenSSL
 Source: "{#OPENSSL_LIBS_PATH}\libcrypto-3-x64.dll"; DestDir: "{app}\Bin"; Flags: ignoreversion; Components: server admintools;


### PR DESCRIPTION
Three packaging problems in section_files_64.iss:

The wildcard "Shared\Bin\x64\Release\*.dll" also matched the Interop.hMailServer.dll that Shared.csproj generates from its own COMReference, so the package carried two builds of the same assembly with different hashes. Name Shared.dll explicitly instead.

Interop.hMailServer.dll was tagged "admintools" in both destinations, but DBSetup, DBSetupQuick, DBUpdater, Shared.dll and DataDirectorySynchronizer are all "server" components and need it on disk. A server-only install therefore failed at database setup, since the installer execs DBSetup from [Code]. Tag it "server admintools" for {app}\Bin and "server" for the addon.

Reported by RvdHout in #623.