### PR TITLE
Make every Administrator UI string localizable

### DIFF
--- a/hmailserver/source/Tools/Administrator/Dialogs/formAbout.cs
+++ b/hmailserver/source/Tools/Administrator/Dialogs/formAbout.cs
@@ -30,7 +30,7 @@ namespace hMailServer.Administrator
          }
          catch (Exception ex)
          {
-            MessageBox.Show("Web browser could not be started." + Environment.NewLine + ex.Message, EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            MessageBox.Show(Strings.Localize("Web browser could not be started.") + Environment.NewLine + ex.Message, EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK, MessageBoxIcon.Warning);
          }
       }
    }

--- a/hmailserver/source/Tools/Administrator/Dialogs/formActiveDirectoryAccounts.Designer.cs
+++ b/hmailserver/source/Tools/Administrator/Dialogs/formActiveDirectoryAccounts.Designer.cs
@@ -80,7 +80,7 @@ namespace hMailServer.Administrator.Dialogs
          this.labelDomain.Name = "labelDomain";
          this.labelDomain.Size = new System.Drawing.Size(46, 13);
          this.labelDomain.TabIndex = 34;
-         this.labelDomain.Text = "Domain:";
+         this.labelDomain.Text = "Domain";
          // 
          // labelAccounts
          // 
@@ -89,7 +89,7 @@ namespace hMailServer.Administrator.Dialogs
          this.labelAccounts.Name = "labelAccounts";
          this.labelAccounts.Size = new System.Drawing.Size(55, 13);
          this.labelAccounts.TabIndex = 36;
-         this.labelAccounts.Text = "Accounts:";
+         this.labelAccounts.Text = "Accounts";
          // 
          // listAccounts
          // 

--- a/hmailserver/source/Tools/Administrator/Dialogs/formActiveDirectoryAccounts.cs
+++ b/hmailserver/source/Tools/Administrator/Dialogs/formActiveDirectoryAccounts.cs
@@ -55,7 +55,7 @@ namespace hMailServer.Administrator.Dialogs
          }
          catch (Exception e)
          {
-            MessageBox.Show("Retrieving of domains failed:" + Environment.NewLine + e.Message, EnumStrings.hMailServerAdministrator);
+            MessageBox.Show(Strings.Localize("Retrieving of domains failed:") + Environment.NewLine + e.Message, EnumStrings.hMailServerAdministrator);
          }
       }
 

--- a/hmailserver/source/Tools/Administrator/Dialogs/formConnect.cs
+++ b/hmailserver/source/Tools/Administrator/Dialogs/formConnect.cs
@@ -107,7 +107,7 @@ namespace hMailServer.Administrator
 
          if (listServers.SelectedItems.Count > 1)
          {
-            MessageBox.Show("You can only connect to one server at a time.", EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK, MessageBoxIcon.Information);
+            MessageBox.Show(Strings.Localize("You can only connect to one server at a time."), EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK, MessageBoxIcon.Information);
             return;
          }
 
@@ -120,7 +120,7 @@ namespace hMailServer.Administrator
 
          if (item == null)
          {
-            MessageBox.Show("Please choose which server to connect to.", EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK, MessageBoxIcon.Information);
+            MessageBox.Show(Strings.Localize("Please choose which server to connect to."), EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK, MessageBoxIcon.Information);
             return;
          }
 

--- a/hmailserver/source/Tools/Administrator/Dialogs/formImportMembers.Designer.cs
+++ b/hmailserver/source/Tools/Administrator/Dialogs/formImportMembers.Designer.cs
@@ -71,7 +71,7 @@ namespace hMailServer.Administrator.Dialogs
          this.label1.Name = "label1";
          this.label1.Size = new System.Drawing.Size(26, 13);
          this.label1.TabIndex = 28;
-         this.label1.Text = "File:";
+         this.label1.Text = "File";
          // 
          // ucImportFile
          // 

--- a/hmailserver/source/Tools/Administrator/Dialogs/formInputDialog.cs
+++ b/hmailserver/source/Tools/Administrator/Dialogs/formInputDialog.cs
@@ -22,7 +22,9 @@ namespace hMailServer.Administrator
       {
          set
          {
-            base.Text = value;
+            // Assigned after the constructor has localized the form, so the
+            // value has to be localized here instead.
+            base.Text = Strings.Localize(value);
          }
          get
          {
@@ -34,7 +36,9 @@ namespace hMailServer.Administrator
       {
          set
          {
-            labelText.Text = value;
+            // Assigned after the constructor has localized the form, so the
+            // value has to be localized here instead.
+            labelText.Text = Strings.Localize(value);
          }
          get
          {

--- a/hmailserver/source/Tools/Administrator/Dialogs/formMain.cs
+++ b/hmailserver/source/Tools/Administrator/Dialogs/formMain.cs
@@ -244,7 +244,7 @@ namespace hMailServer.Administrator
 
             if (settingsControl.Dirty)
             {
-                DialogResult dr = MessageBox.Show("Do you want to save the changes?", EnumStrings.hMailServerAdministrator, MessageBoxButtons.YesNoCancel);
+                DialogResult dr = MessageBox.Show(Strings.Localize("Do you want to save the changes?"), EnumStrings.hMailServerAdministrator, MessageBoxButtons.YesNoCancel);
 
                 switch (dr)
                 {
@@ -458,7 +458,7 @@ namespace hMailServer.Administrator
             }
             catch (Exception e)
             {
-                MessageBox.Show("Changes could not be saved" + Environment.NewLine + e.Message, EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK);
+                MessageBox.Show(Strings.Localize("Changes could not be saved") + Environment.NewLine + e.Message, EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK);
             }
 
             return false;
@@ -671,7 +671,7 @@ namespace hMailServer.Administrator
             }
             catch (Exception ex)
             {
-                MessageBox.Show("Web browser could not be started." + Environment.NewLine + ex.Message, EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                MessageBox.Show(Strings.Localize("Web browser could not be started.") + Environment.NewLine + ex.Message, EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
 
 
@@ -687,7 +687,7 @@ namespace hMailServer.Administrator
             }
             catch (Exception ex)
             {
-                MessageBox.Show("Web browser could not be started." + Environment.NewLine + ex.Message, EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                MessageBox.Show(Strings.Localize("Web browser could not be started.") + Environment.NewLine + ex.Message, EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
         }
 

--- a/hmailserver/source/Tools/Administrator/Main panes/ucAccount.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucAccount.cs
@@ -272,7 +272,7 @@ namespace hMailServer.Administrator
         {
             if (_representedAccount == null)
             {
-                MessageBox.Show("The account must be saved first.", EnumStrings.hMailServerAdministrator);
+                MessageBox.Show(Strings.Localize("The account must be saved first."), EnumStrings.hMailServerAdministrator);
                 return;
             }
 
@@ -425,7 +425,7 @@ namespace hMailServer.Administrator
         {
             if (_representedAccount == null)
             {
-                MessageBox.Show("The account must be saved first.", EnumStrings.hMailServerAdministrator);
+                MessageBox.Show(Strings.Localize("The account must be saved first."), EnumStrings.hMailServerAdministrator);
                 return;
             }
 

--- a/hmailserver/source/Tools/Administrator/Main panes/ucBackup.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucBackup.cs
@@ -123,7 +123,7 @@ namespace hMailServer.Administrator
 
         private void buttonSelectBackupFile_Click(object sender, EventArgs e)
         {
-            openFileDialog.Title = "Select backup file";
+            openFileDialog.Title = Strings.Localize("Select backup file");
 
             if (openFileDialog.ShowDialog() != DialogResult.OK)
                 return;

--- a/hmailserver/source/Tools/Administrator/Main panes/ucDistributionList.Designer.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucDistributionList.Designer.cs
@@ -93,7 +93,7 @@ namespace hMailServer.Administrator
            this.checkRequireSMTPAuthentication.Name = "checkRequireSMTPAuthentication";
            this.checkRequireSMTPAuthentication.Size = new System.Drawing.Size(167, 17);
            this.checkRequireSMTPAuthentication.TabIndex = 20;
-           this.checkRequireSMTPAuthentication.Text = "Require SMTP Authentication";
+           this.checkRequireSMTPAuthentication.Text = "Require SMTP authentication";
            this.checkRequireSMTPAuthentication.UseVisualStyleBackColor = true;
            // 
            // labelSecurity

--- a/hmailserver/source/Tools/Administrator/Main panes/ucIMAPFolders.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucIMAPFolders.cs
@@ -316,7 +316,7 @@ namespace hMailServer.Administrator
          }
          catch (Exception ex)
          {
-            MessageBox.Show("Creation of folder failed." + Environment.NewLine + ex.Message, EnumStrings.hMailServerAdministrator);
+            MessageBox.Show(Strings.Localize("Creation of folder failed.") + Environment.NewLine + ex.Message, EnumStrings.hMailServerAdministrator);
          }
 
       }

--- a/hmailserver/source/Tools/Administrator/Main panes/ucSSLTLS.Designer.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucSSLTLS.Designer.cs
@@ -81,7 +81,7 @@ namespace hMailServer.Administrator
             this.labelVersions.Name = "labelVersions";
             this.labelVersions.Size = new System.Drawing.Size(47, 13);
             this.labelVersions.TabIndex = 20;
-            this.labelVersions.Text = "Versions\r\n";
+            this.labelVersions.Text = "Versions";
             // 
             // checkTlsVersion10
             // 

--- a/hmailserver/source/Tools/Administrator/Main panes/ucStatus.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucStatus.cs
@@ -280,8 +280,8 @@ namespace hMailServer.Administrator
                   timerLiveLog.Enabled = false;
                   DisplayLiveLogButtonCaption();
 
-                  MessageBox.Show("The live log was automatically disabled due to too high throughput." + Environment.NewLine + 
-                                  "To retrieve logging information, please read the log files.", 
+                  MessageBox.Show(Strings.Localize("The live log was automatically disabled due to too high throughput.") + Environment.NewLine +
+                                  Strings.Localize("To retrieve logging information, please read the log files."), 
                                   EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                   return;
                }

--- a/hmailserver/source/Tools/Administrator/Program.cs
+++ b/hmailserver/source/Tools/Administrator/Program.cs
@@ -53,6 +53,7 @@ namespace hMailServer.Administrator
       static void currentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
       {
          formErrorMessage dialog = new formErrorMessage(e);
+         Strings.Localize(dialog);
          dialog.ShowDialog();
 
          Instances.MainForm.Repaint();
@@ -75,6 +76,7 @@ namespace hMailServer.Administrator
          }
 
          formErrorMessage dialog = new formErrorMessage(t);
+         Strings.Localize(dialog);
          dialog.ShowDialog();
 
          Instances.MainForm.Repaint();
@@ -82,12 +84,14 @@ namespace hMailServer.Administrator
 
       private static void HandleConnectionLost()
       {
-         MessageBox.Show("hMailServer Administrator lost the connection to the hMailServer service.\r\n"+
-                         "This may happen for example if the hMailServer service stops or restarts.\r\n" +
+         // Each sentence is localized separately. english.ini is line based, so a
+         // single string spanning several lines can not be stored in it.
+         MessageBox.Show(Strings.Localize("hMailServer Administrator lost the connection to the hMailServer service.") + "\r\n" +
+                         Strings.Localize("This may happen for example if the hMailServer service stops or restarts.") + "\r\n" +
                          "\r\n" +
-                         "If the stop or restart was unexpected, please review the hMailServer logs.\r\n" +
+                         Strings.Localize("If the stop or restart was unexpected, please review the hMailServer logs.") + "\r\n" +
                          "\r\n" +
-                         "Press OK to restart hMailServer Administrator.", EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                         Strings.Localize("Press OK to restart hMailServer Administrator."), EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK, MessageBoxIcon.Error);
          System.Windows.Forms.Application.Restart();
 
       }

--- a/hmailserver/source/Tools/Administrator/Utilities/APICreator.cs
+++ b/hmailserver/source/Tools/Administrator/Utilities/APICreator.cs
@@ -32,7 +32,7 @@ namespace hMailServer.Administrator.Utilities
          {
             if (comException.ErrorCode == -2147023174)
             {
-               MessageBox.Show("Unable to connect to the specified server.", EnumStrings.hMailServerAdministrator);
+               MessageBox.Show(Strings.Localize("Unable to connect to the specified server."), EnumStrings.hMailServerAdministrator);
             }
             else
             {
@@ -73,6 +73,7 @@ namespace hMailServer.Administrator.Utilities
             {
                // The user must input the password.
                formEnterPassword dlg = new formEnterPassword();
+               Strings.Localize(dlg);
                if (dlg.ShowDialog() == System.Windows.Forms.DialogResult.Cancel)
                   return false;
 
@@ -86,7 +87,7 @@ namespace hMailServer.Administrator.Utilities
                if (account == null)
                {
                   // Wrong password, try again.
-                  MessageBox.Show("The specified user name or password is incorrect.", EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK);
+                  MessageBox.Show(Strings.Localize("The specified user name or password is incorrect."), EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK);
 
                   wrongPassword = true;
                }
@@ -97,7 +98,7 @@ namespace hMailServer.Administrator.Utilities
                        if (account.AdminLevel != eAdminLevel.hAdminLevelServerAdmin)
                        {
                            // Wrong password, try again.
-                           MessageBox.Show("hMailServer server administration rights are required to run hMailServer Administrator.", EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                           MessageBox.Show(Strings.Localize("hMailServer server administration rights are required to run hMailServer Administrator."), EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK, MessageBoxIcon.Warning);
 
                            return false;
                        }
@@ -113,7 +114,7 @@ namespace hMailServer.Administrator.Utilities
             catch (Exception e)
             {
                // Wrong password, try again.
-               MessageBox.Show("The specified user name or password is incorrect." + Environment.NewLine + e.Message, EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK);
+               MessageBox.Show(Strings.Localize("The specified user name or password is incorrect.") + Environment.NewLine + e.Message, EnumStrings.hMailServerAdministrator, MessageBoxButtons.OK);
 
                wrongPassword = true;
             }

--- a/hmailserver/source/Translations/english.ini
+++ b/hmailserver/source/Translations/english.ini
@@ -659,98 +659,130 @@ String_702=Honor policy published by sender domain
 String_703=Add Authentication-Results header
 String_704=hMailServer
 String_705=List of contributors
-String_706=Domain:
-String_707=Accounts:
-String_708=Active Directory accounts
-String_709=Blocked attachment
-String_710=hMailServer Username
-String_711=MIME recipient headers
-String_712=File:
+String_706=Active Directory accounts
+String_707=Blocked attachment
+String_708=hMailServer Username
+String_709=MIME recipient headers
 ; Import the members of a distribution list from a file
-String_713=&Import
+String_710=&Import
 ; Caption of the import dialog
-String_714=Import
-String_715=hMailServer Administrator
-String_716=Message viewer
-String_717=Abort on messages marked as spam
+String_711=Import
+String_712=hMailServer Administrator
+String_713=Message viewer
+String_714=Abort on messages marked as spam
 ; Caption above a list of user accounts
-String_718=Users
-String_719=User accounts
-String_720=Prefer IPv6 over IPv4
+String_715=Users
+String_716=User accounts
+String_717=Prefer IPv6 over IPv4
 ; Verify the reverse DNS (PTR) record of the connecting host
-String_721=Check rDNS/PTR
-String_722=Verify DKIM-Signature header
+String_718=Check rDNS/PTR
+String_719=Verify DKIM-Signature header
 ; Name of the SpamAssassin anti-spam software
-String_723=SpamAssassin
-String_724=Prepend message subject
+String_720=SpamAssassin
+String_721=Prepend message subject
 ; Name of the ClamAV anti-virus software
-String_725=ClamAV
+String_722=ClamAV
 ; Name of the ClamWin anti-virus software
-String_726=ClamWin
+String_723=ClamWin
 ; Locate the anti-virus installation automatically
-String_727=Auto-detect
-String_728=Outbound port 25 test hostname
-String_729=Require SMTP Authentication
-String_730=Domain - Anyone in the domain can send to the list
-String_731=DKIM Signing
+String_724=Auto-detect
+String_725=Outbound port 25 test hostname
+String_726=Domain - Anyone in the domain can send to the list
+String_727=DKIM Signing
 ; Name of a hash algorithm
-String_732=SHA256
+String_728=SHA256
 ; Name of a hash algorithm
-String_733=SHA1
+String_729=SHA1
 ; Name of a DKIM canonicalization method
-String_734=Relaxed
+String_730=Relaxed
 ; Name of a DKIM canonicalization method
-String_735=Simple
-String_736=Signing algorithm
+String_731=Simple
+String_732=Signing algorithm
 ; DKIM canonicalization method used for the message body
-String_737=Body method
+String_733=Body method
 ; DKIM canonicalization method used for the message headers
-String_738=Header method
+String_734=Header method
 ; The DKIM selector, part of the DNS record name
-String_739=Selector
-String_740=Sign Aliases
-String_741=The IP range does not exist.
+String_735=Selector
+String_736=Sign Aliases
+String_737=The IP range does not exist.
 ; Restore the default values
-String_742=Default
+String_738=Default
 ; Name of the AWStats log file analyzer
-String_743=AWStats
-String_744=Create default special-use folders (Sent, Drafts, Trash, Junk) for new accounts
+String_739=AWStats
+String_740=Create default special-use folders (Sent, Drafts, Trash, Junk) for new accounts
 ; Name of an IMAP capability
-String_745=SASL Initial Client Response
+String_741=SASL Initial Client Response
 ; Name of an IMAP authentication mechanism
-String_746=SASL Plain
+String_742=SASL Plain
 ; Name of the IMAP access control list extension
-String_747=ACL
+String_743=ACL
 ; Name of the IMAP IDLE extension
-String_748=Idle
+String_744=Idle
 ; Name of the IMAP QUOTA extension
-String_749=Quota
+String_745=Quota
 ; Name of the IMAP SORT extension
-String_750=Sort
-String_751=Use STARTTLS if available
-String_752=If you change the settings below you must restart the server before your changes take affect.
-String_753=Treat this route as a
+String_746=Sort
+String_747=Use STARTTLS if available
+String_748=If you change the settings below you must restart the server before your changes take affect.
+String_749=Treat this route as a
 ; TCP/IP port number
-String_754=Port
-String_755=Target SMTP server
-String_756=Verify remote server SSL/TLS certificates
+String_750=Port
+String_751=Target SMTP server
+String_752=Verify remote server SSL/TLS certificates
+; Caption above the list of enabled TLS versions
+String_753=Versions
 ; Name of a TLS protocol version
-String_757=TLS v1.0
+String_754=TLS v1.0
 ; Name of a TLS protocol version
-String_758=TLS v1.1
+String_755=TLS v1.1
 ; Name of a TLS protocol version
-String_759=TLS v1.2
+String_756=TLS v1.2
 ; Name of a TLS protocol version
-String_760=TLS v1.3
-String_761=Prefer server cipher order
-String_762=Prioritize ChaCha20-Poly1305 when client prefers it (requires TLS v1.2 or TLS v1.3)
-String_763=(Use Windows to Start/Stop Service)
-String_764=Database information
+String_757=TLS v1.3
+String_758=Prefer server cipher order
+String_759=Prioritize ChaCha20-Poly1305 when client prefers it (requires TLS v1.2 or TLS v1.3)
+String_760=(Use Windows to Start/Stop Service)
+String_761=Database information
 ; Pause the delivery queue
-String_765=Pause
+String_762=Pause
 ; Resume the delivery queue
-String_766=Resume
+String_763=Resume
 ; Short name for Secure Sockets Layer / Transport Layer Security
-String_767=SSL/TLS
+String_764=SSL/TLS
 ; Shown when the value of a setting is not recognized
-String_768=Unknown
+String_765=Unknown
+String_766=hMailServer Administrator lost the connection to the hMailServer service.
+String_767=This may happen for example if the hMailServer service stops or restarts.
+String_768=If the stop or restart was unexpected, please review the hMailServer logs.
+String_769=Press OK to restart hMailServer Administrator.
+String_770=Web browser could not be started.
+String_771=Do you want to save the changes?
+; Followed by the error message on the next line
+String_772=Changes could not be saved
+String_773=You can only connect to one server at a time.
+String_774=Please choose which server to connect to.
+; Followed by the error message on the next line
+String_775=Retrieving of domains failed:
+String_776=Unable to connect to the specified server.
+String_777=The specified user name or password is incorrect.
+String_778=hMailServer server administration rights are required to run hMailServer Administrator.
+String_779=The account must be saved first.
+String_780=Creation of folder failed.
+String_781=The live log was automatically disabled due to too high throughput.
+String_782=To retrieve logging information, please read the log files.
+; Caption of the file selection dialog when restoring a backup
+String_783=Select backup file
+; Caption of the dialog used to enter a domain alias name
+String_784=Alias name
+String_785=Enter domain alias name
+String_786=Enter email address
+String_787=Please enter the hMailServer password.
+; Link to the documentation of the hMailServer password
+String_788=What is this?
+; Caption of the dialog asking for the hMailServer password
+String_789=hMailServer password
+; Caption above the error message of an unhandled exception
+String_790=Error message
+; Caption above the technical details of an unhandled exception
+String_791=Details

--- a/hmailserver/source/Translations/english.ini
+++ b/hmailserver/source/Translations/english.ini
@@ -481,7 +481,7 @@ String_510=hMailServer Administration password
 String_511=You need this password to be able to manage your hMailServer installation, so please remember it.
 String_513=Group
 String_514=Groups
-String_515=Permissions for %S
+String_515=Permissions for %s
 String_516=Anyone
 String_517=SSL Certificate
 String_518=SSL Certificates
@@ -657,3 +657,100 @@ String_700=Valid ranges: Argon2id memory 4096-1048576 KiB, iterations 1-20; PBKD
 String_701=Use DMARC
 String_702=Honor policy published by sender domain
 String_703=Add Authentication-Results header
+String_704=hMailServer
+String_705=List of contributors
+String_706=Domain:
+String_707=Accounts:
+String_708=Active Directory accounts
+String_709=Blocked attachment
+String_710=hMailServer Username
+String_711=MIME recipient headers
+String_712=File:
+; Import the members of a distribution list from a file
+String_713=&Import
+; Caption of the import dialog
+String_714=Import
+String_715=hMailServer Administrator
+String_716=Message viewer
+String_717=Abort on messages marked as spam
+; Caption above a list of user accounts
+String_718=Users
+String_719=User accounts
+String_720=Prefer IPv6 over IPv4
+; Verify the reverse DNS (PTR) record of the connecting host
+String_721=Check rDNS/PTR
+String_722=Verify DKIM-Signature header
+; Name of the SpamAssassin anti-spam software
+String_723=SpamAssassin
+String_724=Prepend message subject
+; Name of the ClamAV anti-virus software
+String_725=ClamAV
+; Name of the ClamWin anti-virus software
+String_726=ClamWin
+; Locate the anti-virus installation automatically
+String_727=Auto-detect
+String_728=Outbound port 25 test hostname
+String_729=Require SMTP Authentication
+String_730=Domain - Anyone in the domain can send to the list
+String_731=DKIM Signing
+; Name of a hash algorithm
+String_732=SHA256
+; Name of a hash algorithm
+String_733=SHA1
+; Name of a DKIM canonicalization method
+String_734=Relaxed
+; Name of a DKIM canonicalization method
+String_735=Simple
+String_736=Signing algorithm
+; DKIM canonicalization method used for the message body
+String_737=Body method
+; DKIM canonicalization method used for the message headers
+String_738=Header method
+; The DKIM selector, part of the DNS record name
+String_739=Selector
+String_740=Sign Aliases
+String_741=The IP range does not exist.
+; Restore the default values
+String_742=Default
+; Name of the AWStats log file analyzer
+String_743=AWStats
+String_744=Create default special-use folders (Sent, Drafts, Trash, Junk) for new accounts
+; Name of an IMAP capability
+String_745=SASL Initial Client Response
+; Name of an IMAP authentication mechanism
+String_746=SASL Plain
+; Name of the IMAP access control list extension
+String_747=ACL
+; Name of the IMAP IDLE extension
+String_748=Idle
+; Name of the IMAP QUOTA extension
+String_749=Quota
+; Name of the IMAP SORT extension
+String_750=Sort
+String_751=Use STARTTLS if available
+String_752=If you change the settings below you must restart the server before your changes take affect.
+String_753=Treat this route as a
+; TCP/IP port number
+String_754=Port
+String_755=Target SMTP server
+String_756=Verify remote server SSL/TLS certificates
+; Name of a TLS protocol version
+String_757=TLS v1.0
+; Name of a TLS protocol version
+String_758=TLS v1.1
+; Name of a TLS protocol version
+String_759=TLS v1.2
+; Name of a TLS protocol version
+String_760=TLS v1.3
+String_761=Prefer server cipher order
+String_762=Prioritize ChaCha20-Poly1305 when client prefers it (requires TLS v1.2 or TLS v1.3)
+String_763=(Use Windows to Start/Stop Service)
+String_764=Database information
+; Pause the delivery queue
+String_765=Pause
+; Resume the delivery queue
+String_766=Resume
+; Short name for Secure Sockets Layer / Transport Layer Security
+String_767=SSL/TLS
+; Shown when the value of a setting is not recognized
+String_768=Unknown


### PR DESCRIPTION
## Background

Translation in hMailServer Administrator is keyed on **the English text itself**. `Strings.Localize()` (`Administrator/Utilities/Localization/Strings.cs`) passes the literal to `Language::GetString()`, which looks it up in a `std::map<String, String>` built by `Language::Load()` (`Server/Common/Util/Language.cpp`) by joining `english.ini` and the target language file on the `String_<n>` key.

That lookup is exact and case-sensitive, so a user-visible string is only translatable if it is (a) actually passed through `Strings.Localize()` and (b) present verbatim as a value in `english.ini`. Otherwise it silently stays English in every language.

## Audit

I extracted every user-visible string under `source/Tools/Administrator` — designer `.Text` assignments (excluding the control types `Localize()` deliberately skips: `TextBox`, `ucText`, `ucPassword`, `ucDateTimePicker`), `Strings.Localize("…")` literals, `Node.Title`, `EnumStrings`, dialog captions, and hardcoded `MessageBox.Show` texts.

| | |
|---|---|
| Distinct user-visible strings found | 541 |
| Already translatable | 446 |
| **Not translatable** | **95** |

They fell into three groups, all fixed here:

- **A — 69** correctly routed through translation, but with no `english.ini` entry.
- **B — 24** never routed through localization at all, so an ini entry alone would not have helped.
- **C — 7** that differ from an entry `english.ini` already has only by case or a trailing colon.

## Changes

16 files, `+168 −30`.

### english.ini — 88 new entries (`String_704`..`String_791`)

Mostly labels for features added since the file was last brought up to date: the **SSL/TLS pane** (`TLS v1.0`–`v1.3`, `Prefer server cipher order`, the ChaCha20 option), **DKIM signing** (`SHA256`, `Relaxed`, `Simple`, `Selector`, `Body method`, …), the **IMAP extension toggles** (`ACL`, `Idle`, `Quota`, `Sort`, `SASL Plain`, …), **anti-spam / anti-virus** (`Check rDNS/PTR`, `Verify DKIM-Signature header`, `SpamAssassin`, `ClamAV`, `ClamWin`), plus the message-box texts newly routed through translation. Short or ambiguous entries carry a `;` comment for translators, following the file's existing convention.

**`String_515` is corrected** from `Permissions for %S` to `Permissions for %s`. `formFolderPermissions` is its only consumer and formats with a lowercase `%s`, so the entry never matched. Fixing the existing entry instead of adding a second one preserves the translations all 38 language files already provide for `String_515`.

Only `english.ini` is touched. Other language files map by number, so new strings fall back to English until translated — the existing behaviour for any untranslated key.

### Category B — strings that never reached the translation layer

**Hardcoded `MessageBox.Show()`** now goes through `Strings.Localize()` in `Program.cs`, `APICreator`, `formMain`, `formConnect`, `formAbout`, `formActiveDirectoryAccounts`, `ucAccount`, `ucIMAPFolders` and `ucStatus`.

The connection-lost message in `Program.cs` is localized **one sentence at a time**, because `Language::Load()` splits the file on `\r\n` and a value spanning lines cannot be stored in it. For the same reason `ucSSLTLS`'s `"Versions\r\n"` loses its stray trailing newline — the blank second line was an editing artifact, and the label is absolutely positioned, so nothing moves.

**`formInputDialog`** localizes itself in its constructor, but callers assign `Title` and `Text` *afterwards*, so those values were never translated. Both setters now localize on the way in, which covers `Address`, `Alias name`, `Enter email address` and `Enter domain alias name` in `ucDistributionList`, `ucDomain` and `ucRoute`. `ucBackup`'s file-dialog caption is wrapped the same way, matching what `ucSSLCertificate` already does.

**`Tools/Shared` has no localization calls at all** (`grep -r Localize Shared/` returns nothing). Administrator shows two of its dialogs directly, so it now localizes them at the call site: `formEnterPassword` in `APICreator`, `formErrorMessage` in `Program.cs`. Both are plain `Form`s and `Strings.Localize(Control)` skips the `ucText` controls they use, so only labels, buttons and captions are affected.

### Category C — align the code with the entry that already exists

| Was | Now | Existing entry |
|---|---|---|
| `Domain:` | `Domain` | `String_22` |
| `Accounts:` | `Accounts` | `String_100` |
| `File:` | `File` | `String_1` |
| `Require SMTP Authentication` | `Require SMTP authentication` | `String_25` |

This also makes those dialogs consistent with the rest of the Administrator, which doesn't put colons on field labels.

`&Import` and `Import` in `formImportMembers` are **kept as-is**. They look close to `&Import...` in `ucDistributionList`, but that button opens a dialog while these are the action button and window caption *of* the dialog, so the ellipsis would be wrong.

## Not addressed

- **`formAbout`'s attribution label** also spans two lines. Unlike `Versions`, the break is meaningful, and the label is `AutoSize` on a 310px-wide form — making it localizable needs a layout change I can't verify without building the GUI.
- **`ucItemsView`'s three "Not implemented" boxes** are developer diagnostics in `virtual` methods meant to be overridden, not user-facing text.
- **`ucWizard`'s `Next >`, `< Previous`, `Close`** belong to DBSetup and DataDirectorySynchronizer, not the Administrator. Neither tool localizes anything today.
- **Startup ordering:** `formConnect`, `APICreator` and `formEnterPassword` run before a server connection exists, and the language is only loaded once `formMain` has one. Localizing them is still correct — `Strings.Localize` is a no-op while no language is loaded, and these dialogs are shown again via *File → Connect* once it is.

## Verification

- Re-ran the audit against the final tree: **95 → 0** within the Administrator's scope; the only remaining hits are the four deliberate exclusions above.
- Re-parsed `english.ini` the way `Language::GetString_()` does (686 entries, max `String_791`): every line well-formed, no new duplicate English values (the 8 that exist are all pre-existing on `master`), and all 38 translation files still map onto it.
- Checked every edited file keeps its original encoding and line endings (`english.ini` UTF-8 + BOM, LF in-repo; the `.cs` files unchanged), and that paren/brace balance is identical to `HEAD` in all 15 C# files.

**Not built or run.** This session is a Linux container with no MSBuild, .NET or PowerShell available, so the C# changes are reviewed but uncompiled — worth a build before merge. The changes are mechanical (wrapping literals in an existing helper, two setter bodies, four designer string constants).

**No regression test.** `RegressionTests` drives the *server* over COM/SMTP/IMAP/POP3; there is no harness for the WinForms Administrator. The COM route can't substitute either: `Language::GetString()` returns its input when a string is missing, so for English a lookup can't distinguish "missing entry" from "untranslated". A CI check that diffs the Administrator sources against `english.ini` would be the right guard — happy to add one as a follow-up if wanted.