### PR TITLE
Fix grammar errors in english.ini

### DIFF
--- a/hmailserver/source/Translations/english.ini
+++ b/hmailserver/source/Translations/english.ini
@@ -18,7 +18,7 @@ String_15=SMTP
 String_16=Security
 String_17=POP3
 String_18=IP Ranges
-; An mirror email address
+; A mirror email address
 String_19=Mirror
 String_20=Logging
 ; Shown on the startup page in hMailAdmin.
@@ -60,9 +60,9 @@ String_57=E-mail address
 String_58=&Resolve
 String_59=Mail servers
 String_61=Cache update interval:
-; Every 25 hour
+; Every 25 hours
 String_62=Every
-; Every 25 hour
+; Every 25 hours
 String_63=hour
 String_64=TCP Port
 String_65=SMTP Port
@@ -95,7 +95,7 @@ String_98=A copy of all e-mails sent on this server, including both incoming and
 String_100=Log
 String_101=Application
 String_104=TCP/IP
-; A file on disk (dont mix up with File in menu)
+; A file on disk (don't mix up with File in menu)
 String_105=File
 String_106=Active Directory
 String_107=Account
@@ -136,7 +136,7 @@ String_153=NOTE
 String_154=This password will be stored unencrypted in hmailserver.ini. Configure your environment so that no other users can read from this file.
 String_155=The wizard has enough information to finish the operation.
 String_158=Please enter the name of the database server.
-String_159=Please enter the name of the database
+String_159=Please enter the name of the database.
 String_160=Connecting to
 String_161=Connected successfully.
 String_162=Could not connect to database server.
@@ -153,13 +153,13 @@ String_173=Failed to start hDBUpdater.exe
 String_174=Database creation failed.
 String_175=Please go back and review your settings.
 String_176=Add domain...
-; Short for Add active directory account
+; Short for Add Active Directory account
 String_180=Add AD account
 String_188=Root password
 String_189=Root password (repeat)
-String_190=This wizard will create and configure the hMailServer database for you.  The only thing you need to enter is the root password that you want to use.
+String_190=This wizard will create and configure the hMailServer database for you. The only thing you need to enter is the root password that you want to use.
 String_192=Press Finish to exit the wizard.
-; "Finish" an an operation.
+; "Finish" an operation.
 String_193=&Finish
 String_194=IMAP Settings
 String_195=IMAP port
@@ -201,10 +201,10 @@ String_232=Finish the operation
 String_233=Could not create the database.
 String_234=Could not connect to
 String_235=You must enter a root password.
-String_236=The passwords does not match.
+String_236=The passwords do not match.
 String_237=Connection error
 String_238=Autodetect
-String_239=hMailAdmin was able to autodetect the location of ClamScan and the database. Please verify that the path to the executable and the database is correct.
+String_239=hMailAdmin was able to autodetect the location of ClamScan and the database. Please verify that the paths to the executable and the database are correct.
 ; Live logging (as in live music)
 String_240=Live
 ; Clear all fields in a dialog
@@ -235,7 +235,7 @@ String_263=Deliver to addresses below:
 String_264=You must save the route before adding addresses.
 String_267=Statistics
 String_268=Send statistics to hMailServer.com
-String_269=If you enable statistics, statistics is sent to hMailServer.com every 1000 message. The only thing included in the statistics is your version number. No personal information or information on your configuration is sent.
+String_269=If you enable statistics, statistics are sent to hMailServer.com every 1000 messages. The only thing included in the statistics is your version number. No personal information or information about your configuration is sent.
 String_270=Host name
 String_271=Auto-reply
 String_272=Refresh
@@ -285,7 +285,7 @@ String_312=Server address
 String_313=Server information
 ; The type of the remote server
 String_314=Server type
-; The number of minutes between download
+; The number of minutes between downloads
 String_315=Minutes between download
 ; The number of days
 String_316=Days
@@ -306,7 +306,7 @@ String_327=Status
 String_328=Number of
 ; The number of processed messages
 String_329=Processed messages
-; The number of messages containing virus
+; The number of messages containing a virus
 String_330=Viruses detected
 ; The number of messages containing spam
 String_331=Spam messages
@@ -409,7 +409,7 @@ String_433=Script function
 String_434=Threading
 String_435=Max number of command threads
 String_436=Worker thread priority
-String_437=A route with this name already exist
+String_437=A route with this name already exists
 String_438=The SMTP relayer should never be set to a host name which is pointing at the local computer. Are you sure you want to do this?
 String_439=RFC compliance
 String_440=Allow incorrectly formatted line endings
@@ -417,8 +417,8 @@ String_441=Disconnect client after too many invalid commands
 String_442=Maximum number of invalid commands
 String_443=Bind to local IP address
 String_444=Maximum number of recipients in batch
-String_445=You must specify lower and upper IP address of this range.
-String_446=An IP range with this name already exist
+String_445=You must specify the lower and upper IP addresses of this range.
+String_446=An IP range with this name already exists
 String_447=Performance
 String_448=Default domain
 String_449=Server messages
@@ -429,7 +429,7 @@ String_453=Public - Anyone can send to the list
 String_454=Membership - Only members can send to the list
 String_455=Announcements - Only allow messages from the following address:
 String_456=Allocated size (MB)
-String_457=This domain has maximum size set. Because of this, you must specify a maximum account size.
+String_457=This domain has a maximum size set. Because of this, you must specify a maximum account size.
 String_459=Invalid user name or password.
 String_460=Ask when connecting
 String_461=Save password
@@ -465,7 +465,7 @@ String_490=Limits
 String_491=Max size of accounts (MB)
 String_496=Forwarding relay
 String_497=Are you sure you want to delete %s?
-String_498=NOTE: This functionality is designed to be used in small installations with less than 1GB of email data. If your  installation is larger than this, please consult the documentation for usage of external tools.
+String_498=NOTE: This functionality is designed to be used in small installations with less than 1GB of email data. If your installation is larger than this, please consult the documentation for the use of external tools.
 String_499=Retrieve date from Received header
 String_500=Move up
 String_501=Move down


### PR DESCRIPTION
Corrects grammar in the translator hint comments and in the string values
that no longer have a matching literal in the source code.

Strings that are still looked up by their English text (english.ini values
double as the translation lookup key) are left untouched, since changing
them without the corresponding source literal would drop the translation
for every language.