### PR TITLE
Make six WebAdmin strings translatable again

### DIFF
--- a/hmailserver/source/WebAdmin/hm_distributionlist.php
+++ b/hmailserver/source/WebAdmin/hm_distributionlist.php
@@ -106,7 +106,7 @@ $listrequiresmtpauthchecked = hmailCheckedIf1($listrequiresmtpauth);
                   </td>			
       		</tr>
       		<tr>
-      			<td><?php EchoTranslation("Require SMTP Authentication")?></td>
+      			<td><?php EchoTranslation("Require SMTP authentication")?></td>
       			<td><input type="checkbox" name="listrequiresmtpauth" value="1" <?php echo $listrequiresmtpauthchecked?>></td>
       		</tr>
 

--- a/hmailserver/source/WebAdmin/hm_domain.php
+++ b/hmailserver/source/WebAdmin/hm_domain.php
@@ -239,7 +239,7 @@ $MaxNumberOfDistributionListsEnabledChecked = hmailCheckedIf1($MaxNumberOfDistri
          		   <select name="SignatureMethod" style="font-family: Trebuchet MS, Verdana, Arial, Helvetica, sans-serif">
          		      <option value="1" <?php if ($SignatureMethod == "1") echo "selected";?> ><?php EchoTranslation("Use signature if none has been specified in the sender's account")?></option>
          		      <option value="2" <?php if ($SignatureMethod == "2") echo "selected";?> ><?php EchoTranslation("Overwrite account signature")?></option>
-         		      <option value="3" <?php if ($SignatureMethod == "3") echo "selected";?> ><?php EchoTranslation("Append signature to account signature")?></option>
+         		      <option value="3" <?php if ($SignatureMethod == "3") echo "selected";?> ><?php EchoTranslation("Append to account signature")?></option>
          		   </select>
       			</td>
       		</tr>   	
@@ -392,7 +392,7 @@ $MaxNumberOfDistributionListsEnabledChecked = hmailCheckedIf1($MaxNumberOfDistri
          <table border="0" width="100%" cellpadding="5">
       		<?php
                PrintCheckboxRow("DKIMSignEnabled", $obLanguage->String("Enabled"), $DKIMSignEnabled);
-               PrintCheckboxRow("DKIMSignAliasesEnabled", $obLanguage->String("Sign aliases"), $DKIMSignAliasesEnabled, $obDomain->DomainAliases->Count == 0);
+               PrintCheckboxRow("DKIMSignAliasesEnabled", $obLanguage->String("Sign Aliases"), $DKIMSignAliasesEnabled, $obDomain->DomainAliases->Count == 0);
                PrintPropertyEditRow("DKIMPrivateKeyFile", $obLanguage->String("Private key file"), $DKIMPrivateKeyFile, 50);
                PrintPropertyEditRow("DKIMSelector", $obLanguage->String("Selector"), $DKIMSelector, 20);
             ?>

--- a/hmailserver/source/WebAdmin/hm_smtp.php
+++ b/hmailserver/source/WebAdmin/hm_smtp.php
@@ -139,12 +139,12 @@ $SMTPConnectionSecurity = $obSettings->SMTPConnectionSecurity == CONNECTION_SECU
       	</tr>	
          <tr>
       		<td width="30%"><?php EchoTranslation("Local host name")?></td>
-      		<td width="70%"><input type="text" name="HostName" value="<?php echo PreprocessOutput($HostName)?>" size="20" checkmessage="<?php EchoTranslation("HostName")?>"></td>
+      		<td width="70%"><input type="text" name="HostName" value="<?php echo PreprocessOutput($HostName)?>" size="20" checkmessage="<?php EchoTranslation("Local host name")?>"></td>
       	</tr>	   				
                
          <tr>
             <td colspan="2">
-               <h3><?php EchoTranslation("SMTP relayer")?></h3>  
+               <h3><?php EchoTranslation("SMTP Relayer")?></h3>  
             </td> 
          </tr>
       	<tr>

--- a/hmailserver/source/WebAdmin/hm_sslcertificate.php
+++ b/hmailserver/source/WebAdmin/hm_sslcertificate.php
@@ -22,7 +22,7 @@ if ($action == "edit")
 }
 ?>
 
-<h1><?php EchoTranslation("SSL certificate")?></h1>
+<h1><?php EchoTranslation("SSL Certificate")?></h1>
 
 <form action="index.php" method="post" onSubmit="return formCheck(this);">
 


### PR DESCRIPTION
Six WebAdmin captions could not be translated in any language. This aligns them with the `english.ini` entries that already exist for the same captions.

## Why they were untranslatable

Translation is keyed on the English text itself: `$obLanguage->String()` passes the literal to `Language::GetString()`, which looks it up exactly in a map built by joining `english.ini` and the target language file. On a miss, `GetString` returns the input unchanged — which is why a missing string silently renders in English rather than failing.

Each of these six literals had drifted from the `english.ini` entry for the same caption, mostly in capitalisation, so the lookup never matched. `Language::CleanString_` would have forgiven a leading `&` or a trailing `...`, but it is never called, and it would not help with casing regardless.

This is the WebAdmin counterpart of what #628 fixed for the Administrator; WebAdmin was never given the same audit.

## The six

| File | Was | Now | Entry |
|---|---|---|---|
| `hm_distributionlist.php` | `Require SMTP Authentication` | `Require SMTP authentication` | `String_25` |
| `hm_smtp.php` | `SMTP relayer` | `SMTP Relayer` | `String_197` |
| `hm_sslcertificate.php` | `SSL certificate` | `SSL Certificate` | `String_517` |
| `hm_domain.php` | `Sign aliases` | `Sign Aliases` | `String_736` |
| `hm_domain.php` | `Append signature to account signature` | `Append to account signature` | `String_477` |
| `hm_smtp.php` | `HostName` | `Local host name` | `String_561` |

The wording moves toward the Administrator's, so the two UIs now agree on these captions.

**The last one was also a visible defect.** `HostName` is the `checkmessage` of the SMTP host name input, so the validation message showed users the raw form field name. The label directly above that field is `Local host name`, which is `String_561`. Only the argument to `EchoTranslation` changed — the input's `name="HostName"` attribute and the matching `hmailGetVar("HostName", "")` are untouched, so form handling is unaffected.

## Effect

Five of the six are already translated in 30 to 33 of the 38 language files and pick those translations up immediately, with no translator work:

```
String_25   33/38   de: SMTP-Authentifizierung erforderlich
String_197  31/38   de: SMTP-Relayer
String_477  33/38   de: Füge Signatur der Konten-Signatur an
String_517  32/38   de: SSL-Zertifikat
String_561  30/38   de: Lokaler Rechnername
String_736   0/38   (not yet translated anywhere)
```

`String_736` is a recent addition that no translator has reached yet, so it becomes *eligible* for translation rather than translated today.

No `english.ini` change and no translated file change; the diff is six PHP literals. Verified that every `english.ini` entry still matches a literal somewhere, and that the count of WebAdmin strings with no entry drops from 15 to 9.

## Still open

Nine WebAdmin strings have no `english.ini` counterpart at all and need new entries before they can be translated: `STARTTLS (Optional)`, `STARTTLS (Required)`, `You must save the account before you can edit rules.`, `You must save the rule before you can edit criteria and actions.`, `messages in queue`, `Incoming relay`, `Server message`, and the two route labels `When sender matches route, treat sender domain as` / `…recipient domain as`.

Three of those want a decision rather than a mechanical add: `Incoming relay` and `Server message` are singular page headings whose nearest entries (`String_639`, `String_449`) are the plural list captions, and the two route labels are WebAdmin's `domain` variant of `String_663`/`String_664`, which could be unified with the Administrator's wording instead of getting entries of their own.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECWgEBgUkSJjWHxAwvz2xk)_