### PR TITLE
Localize the connection security and thread priority dropdowns

### DIFF
--- a/hmailserver/source/Tools/Administrator/Controls/ucComboBox.cs
+++ b/hmailserver/source/Tools/Administrator/Controls/ucComboBox.cs
@@ -31,7 +31,10 @@ namespace hMailServer.Administrator.Controls
       {
          foreach (var item in items)
          {
-            base.Items.Add(item.Key);
+            // The caption is translated here rather than by the caller, so that the
+            // dictionary stays keyed on the English text. AddItem is left alone: its
+            // callers pass either data or captions they have already localized.
+            base.Items.Add(Strings.Localize(item.Key));
             _keys.Add(item.Value);
          }
       }

--- a/hmailserver/source/Tools/Administrator/Main panes/ucPerformance.cs
+++ b/hmailserver/source/Tools/Administrator/Main panes/ucPerformance.cs
@@ -18,11 +18,14 @@ namespace hMailServer.Administrator
 
          DirtyChecker.SubscribeToChange(this, OnContentChanged);
 
-         comboWorkerThreadPriority.AddItem("Highest", 2);
-         comboWorkerThreadPriority.AddItem("Above normal", 1);
-         comboWorkerThreadPriority.AddItem("Normal", 0);
-         comboWorkerThreadPriority.AddItem("Below normal", -1);
-         comboWorkerThreadPriority.AddItem("Lowest", -2);
+         comboWorkerThreadPriority.AddItem(Strings.Localize("Highest"), 2);
+         comboWorkerThreadPriority.AddItem(Strings.Localize("Above normal"), 1);
+         comboWorkerThreadPriority.AddItem(Strings.Localize("Normal"), 0);
+         comboWorkerThreadPriority.AddItem(Strings.Localize("Below normal"), -1);
+         comboWorkerThreadPriority.AddItem(Strings.Localize("Lowest"), -2);
+         // Not localized: "Idle" is also String_744, the name of the IMAP IDLE
+         // extension. The lookup is keyed on the English text, so translating this
+         // would give the thread priority the IMAP capability's translation.
          comboWorkerThreadPriority.AddItem("Idle", -15);
 
          new TabOrderManager(this).SetTabOrder(TabOrderManager.TabScheme.AcrossFirst);

--- a/hmailserver/source/Translations/english.ini
+++ b/hmailserver/source/Translations/english.ini
@@ -647,3 +647,17 @@ String_789=hMailServer password
 String_790=Error message
 ; Caption above the technical details of an unhandled exception
 String_791=Details
+; Name of a connection security mode
+String_792=STARTTLS (Optional)
+; Name of a connection security mode
+String_793=STARTTLS (Required)
+; Worker thread priority
+String_794=Highest
+; Worker thread priority
+String_795=Above normal
+; Worker thread priority
+String_796=Normal
+; Worker thread priority
+String_797=Below normal
+; Worker thread priority
+String_798=Lowest


### PR DESCRIPTION
Combo box items never reached the translation lookup, so two dropdowns were shown in English in every language.

## The gap

`ucComboBox.AddItems()` added each caption with `base.Items.Add(item.Key)`, and `Strings.Localize(Control)` walks a control's `Text` but not its `Items`. A dropdown was therefore translated only if the *caller* localized each caption first — which the rule dialogs do, through `EnumStrings.GetMatchTypeString()` and friends, and which the connection security and worker thread priority dropdowns did not.

The effect was not limited to missing entries: `None` and `SSL/TLS` have had entries all along (`String_520`, `String_764`) and were still displayed untranslated, because nothing ever consulted them.

## Changes

**`ucComboBox.AddItems` translates the caption as it adds it.** Its only callers are the four connection security dropdowns — `formExternalAccount`, `ucTCPIPPort`, `ucProtocolSMTP`, `ucRoute`.

Translating here rather than inside `ConnectionSecurityTypes.Get()` is deliberate: that method builds a `Dictionary<string, object>` keyed by the caption, so localizing before insertion would mean two captions a translator renders identically throw a duplicate key exception. Translating on the way into the list keeps the dictionary keyed on the English text.

`AddItem`, the single-item overload, is left alone. Its callers pass either data (domain names, certificates, installed languages) or captions they have already localized, and leaving it untouched also keeps `Argon2id`, `PBKDF2-SHA256`, `VBScript` and `JScript` out of the lookup, where they belong.

**`ucPerformance` localizes its five priority captions at the call site.**

`Idle` is deliberately *not* localized, and a comment records why: it is also `String_744`, the name of the IMAP IDLE extension. The lookup is keyed on the English text, so one map key serves both meanings and translating this would give the thread priority the IMAP capability's translation. `String_744` currently has no translation in any of the 38 files, so nothing is visibly wrong today — but it would be the moment a translator reaches it. Giving these two distinct meanings separate entries is a change to how the file is keyed, so it is left out of this PR.

**Seven new entries, `String_792`–`String_798`:** `STARTTLS (Optional)`, `STARTTLS (Required)`, `Highest`, `Above normal`, `Normal`, `Below normal`, `Lowest`. Each was checked against the existing values first — none of them already existed, so no new entry collides with another the way `Idle` would have.

## Effect

- The connection security dropdown becomes translatable in four panes; `None` and `SSL/TLS` resolve for the first time using the translations that already exist.
- The worker thread priority dropdown becomes translatable except for `Idle`.
- **WebAdmin uses the same two STARTTLS captions**, so they become translatable there too — taking the WebAdmin strings with no entry from 9 down to 7.

The seven new strings are not yet translated anywhere, so they stay English until translators reach them; the pre-existing entries take effect immediately.

## Verification

- Selection is unaffected: `ucComboBox.SelectedValue` is index-based (`_keys[index]`) and its setter matches on the stored object, never on the displayed text. Translating captions cannot change which value is selected or saved.
- `Strings` resolves from `hMailServer.Administrator.Controls` through the parent namespace; it is the only type of that name in the Tools solution, and both files compile into the Administrator project.
- The reachability audit from #630 passes on all 568 entries, confirming the seven new ones match real literals.

## Related, not included

- `ucStatus.cs:434` builds `"%d messages in queue"` and assigns it to a label without localizing. WebAdmin has `messages in queue` as a separate fragment, so unifying the two needs a decision about the placeholder.
- `formAbout.Designer.cs:88` is passed to the lookup but embeds `\r\n`, which a line-based ini cannot hold; it needs splitting into two calls, as `HandleConnectionLost()` already does.
- `formRuleAction.cs:56` passes a bare `"None"` to `AddItem`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECWgEBgUkSJjWHxAwvz2xk)_