### PR TITLE
Log user interface strings that english.ini does not define

### DIFF
--- a/hmailserver/source/Server/Common/Util/Language.cpp
+++ b/hmailserver/source/Server/Common/Util/Language.cpp
@@ -15,6 +15,9 @@
 namespace HM
 {
    std::map<int, String> Language::mapEnglishContent;
+   std::set<String> Language::english_strings_;
+   std::set<String> Language::reported_missing_strings_;
+   boost::recursive_mutex Language::missing_string_mutex_;
 
    Language::Language(const String &sName, bool isDownloded) :
       is_loaded_(false),
@@ -35,7 +38,10 @@ namespace HM
 
       std::map<String, String>::const_iterator iterString = strings_.find(sEnglishString);
       if (iterString == strings_.end())
+      {
+         ReportMissingString_(sEnglishString);
          return sEnglishString;
+      }
       else
       {
          String translatedString = (*iterString).second;
@@ -70,6 +76,35 @@ namespace HM
          mapEnglishContent[pair.first] = pair.second;
       }
 
+      // Rebuilt from the map rather than filled in the loop above, so that the two
+      // cannot drift apart if LoadEnglish is called more than once.
+      boost::lock_guard<boost::recursive_mutex> guard(missing_string_mutex_);
+
+      english_strings_.clear();
+
+      for (const auto &englishString : mapEnglishContent)
+         english_strings_.insert(englishString.second);
+   }
+
+   void
+   Language::ReportMissingString_(const String &sEnglishString)
+   {
+      // A lookup misses for two different reasons. Either the string is not defined in
+      // english.ini at all, in which case it can never be translated, in any language,
+      // and whoever added it to the user interface has to add it here as well. Or it is
+      // defined but the language file being used has no translation for it yet, which is
+      // ordinary and would report most of the file for a partly translated language.
+      // Only the first is worth reporting.
+      boost::lock_guard<boost::recursive_mutex> guard(missing_string_mutex_);
+
+      if (english_strings_.find(sEnglishString) != english_strings_.end())
+         return;
+
+      if (!reported_missing_strings_.insert(sEnglishString).second)
+         return;
+
+      LOG_DEBUG("Language::GetString - The user interface asked for the string \"" + sEnglishString +
+                "\" which is not defined in english.ini. It is shown in English in every language.");
    }
 
    void 

--- a/hmailserver/source/Server/Common/Util/Language.h
+++ b/hmailserver/source/Server/Common/Util/Language.h
@@ -26,8 +26,18 @@ namespace HM
 
       static std::pair<int, String> GetString_(const String &sLine);
       static void CleanString_(String &sText);
+      static void ReportMissingString_(const String &sEnglishString);
       std::map<String, String> strings_;
       
       static std::map<int, String> mapEnglishContent;
+
+      // The values of mapEnglishContent, so that a lookup miss can be classified
+      // without searching that map by value on every miss.
+      static std::set<String> english_strings_;
+
+      // Strings already reported, so that each one is logged once per process
+      // instead of every time the user interface re-reads the pane it is on.
+      static std::set<String> reported_missing_strings_;
+      static boost::recursive_mutex missing_string_mutex_;
    };
 }


### PR DESCRIPTION
Adds a diagnostic to `Language::GetString`, so that clicking through the UI reveals strings that can never be translated.

When the interface asks for a string that is not a value in `english.ini`, the lookup cannot match, the English text is returned, and the string is shown untranslated in every language. That has always failed silently — which is why the gaps fixed in #636 and #637 had to be found by scanning the source instead of by using the program.

## Telling the two kinds of miss apart

A lookup misses for two reasons, and only one is a defect:

- **The string is not in `english.ini` at all.** It can never be translated, in any language, and whoever added it to the interface has to add it here too. This is what gets logged.
- **The string is in `english.ini`, but the language file in use has no translation for it yet.** Ordinary — and logging it would report most of the file for a partly translated language. Passed over silently.

`ReportMissingString_` separates them by checking the requested text against `english_strings_`, a set of the *values* of `mapEnglishContent`. `LoadEnglish` rebuilds that set from the map itself rather than filling it in the parse loop, so the two cannot drift apart if it is ever called more than once.

## Details worth reviewing

- **Reported once per process.** The Administrator re-localizes a pane every time it is opened, so without deduplication the same handful of strings would fill the log on every click.
- **`LOG_DEBUG`, not an error.** It appears only with Debug logging enabled under Settings → Logging, so an installation that is not being debugged is unaffected. That matters here because a few strings that would be reported are server error messages passed through the lookup by `Strings.Localize(ex.Message)` in `ucDomain.cs`; those have no entry by design, and reporting them as errors on a production server would be noise. Say the word if you would rather have it always on through `ErrorManager::ReportError` at `Low` severity — it is a one-line change.
- **Guarded by a recursive mutex**, since `GetString` is reached through `InterfaceLanguage::get_String` over COM and can be called from more than one thread. `LoadEnglish` takes the same lock while rebuilding the set.

## How to use it

Enable Debug logging, restart, then click through the panes. Each unreachable string produces one line:

```
Language::GetString - The user interface asked for the string "..." which is not
defined in english.ini. It is shown in English in every language.
```

Both UIs go through this path, so browsing WebAdmin exercises it too. Based on the static audit, the seven WebAdmin strings listed in #636 should appear, along with `formAbout`'s attribution label, which embeds `\r\n` and therefore cannot have an entry in a line-based file — it needs splitting into two calls the way `HandleConnectionLost()` already does.

## Verification

I cannot compile here, so the parts I could not build were checked against existing usage in the tree:

- `"literal" + String + "literal"` — `String` is `CStdStr<wchar_t>`; `StdString.h` defines both `operator+(PCSTR, const CStdStringW&)` (line 3791) and `operator+(const CStdStringW&, PCSTR)` (line 3826).
- `boost::lock_guard<boost::recursive_mutex>` and the range-based `for` both already appear in `Common` (`IMAPFolders.cpp`, `DKIM.cpp`).
- `<set>`, `<boost/thread.hpp>` and `Logger.h` are already in the precompiled header, so no new includes are needed.
- Neither file had a UTF-8 BOM; both still have none.

The diff is 45 added lines and no deletions — the existing `return sEnglishString;` is only wrapped in braces.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECWgEBgUkSJjWHxAwvz2xk)_