### PR TITLE
Improve robustness of DNS queries

### DIFF
--- a/hmailserver/source/Server/Common/AntiSpam/SURBL.cpp
+++ b/hmailserver/source/Server/Common/AntiSpam/SURBL.cpp
@@ -170,11 +170,16 @@ namespace HM
          LOG_DEBUG(Formatter::Format(_T("SURBL: Lookup: {0}"), sHostToLookup));
 
          std::vector<String> saFoundNames;
+
          DNSResolver resolver;
-         if (!resolver.GetIpAddresses(sHostToLookup, saFoundNames, false))
+         if (!resolver.GetIpAddressesWithRetry(sHostToLookup, saFoundNames, false))
          {
+            // The lookup failed rather than came back empty. Skip this host rather
+            // than treating the entire message as clean.
             LOG_DEBUG("SURBL: DNS query failed.");
-            return true;
+
+            processedAddresses++;
+            continue;
          }
 
          if (saFoundNames.size() > 0)

--- a/hmailserver/source/Server/Common/TCPIP/DNSResolver.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/DNSResolver.cpp
@@ -58,9 +58,9 @@ namespace HM
    }
    
    bool 
-   DNSResolver::GetIpAddresses(const String &sDomain, std::vector<String> &vecFoundNames, bool followCnameRecords)
+   DNSResolver::GetIpAddresses(const String &sDomain, std::vector<String> &vecFoundNames, bool followCnameRecords, bool bypassCache)
    {
-      return GetIpAddressesRecursive_(sDomain, vecFoundNames, 0, followCnameRecords);
+      return GetIpAddressesRecursive_(sDomain, vecFoundNames, 0, followCnameRecords, bypassCache);
    }
 
    const int lookupAttempts = 2;
@@ -76,7 +76,11 @@ namespace HM
    {
       for (int attempt = 1; attempt <= lookupAttempts; attempt++)
       {
-         if (GetIpAddresses(sDomain, saFoundNames, followCnameRecords))
+         // Windows caches the failure, so a plain retry is served the same bad result
+         // from the cache. Later attempts have to go to the wire.
+         bool bypassCache = attempt > 1;
+
+         if (GetIpAddresses(sDomain, saFoundNames, followCnameRecords, bypassCache))
             return true;
 
          if (attempt < lookupAttempts)
@@ -87,7 +91,7 @@ namespace HM
    }
 
    bool
-   DNSResolver::GetIpAddressesRecursive_(const String &hostName, std::vector<String> &addresses, int recursionLevel, bool followCnameRecords)
+   DNSResolver::GetIpAddressesRecursive_(const String &hostName, std::vector<String> &addresses, int recursionLevel, bool followCnameRecords, bool bypassCache)
    {
       if (hostName.IsEmpty())
       {
@@ -117,28 +121,28 @@ namespace HM
       // if IPv6 is preferred first do IPv6 DNS Lookup(s)
       if (ipv6Available && Configuration::Instance()->GetIPv6Preferred())
       {
-         querySucceeded &= resolver.Query(hostName, DNS_TYPE_AAAA, foundRecords);
-         querySucceeded &= resolver.Query(hostName, DNS_TYPE_A, foundRecords);
+         querySucceeded &= resolver.Query(hostName, DNS_TYPE_AAAA, foundRecords, bypassCache);
+         querySucceeded &= resolver.Query(hostName, DNS_TYPE_A, foundRecords, bypassCache);
       }
       else // Standard 
       {
-         querySucceeded &= resolver.Query(hostName, DNS_TYPE_A, foundRecords);
+         querySucceeded &= resolver.Query(hostName, DNS_TYPE_A, foundRecords, bypassCache);
 
          if (ipv6Available)
-            querySucceeded &= resolver.Query(hostName, DNS_TYPE_AAAA, foundRecords);
+            querySucceeded &= resolver.Query(hostName, DNS_TYPE_AAAA, foundRecords, bypassCache);
       }
 
       if (foundRecords.size() == 0 && followCnameRecords)
       {
          // The queries for A/AAAA didn't return any records. Attempt to look up via CNAME
          std::vector<DNSRecord> foundCNames;
-         bool cnameQueryResult = resolver.Query(hostName, DNS_TYPE_CNAME, foundCNames);
+         bool cnameQueryResult = resolver.Query(hostName, DNS_TYPE_CNAME, foundCNames, bypassCache);
 
          // A CNAME should only point at a single host name.
          if (cnameQueryResult && foundCNames.size() == 1)
          {
             auto cnameHostName = foundCNames[0].GetValue();
-            return GetIpAddressesRecursive_(cnameHostName, addresses, recursionLevel + 1, followCnameRecords);
+            return GetIpAddressesRecursive_(cnameHostName, addresses, recursionLevel + 1, followCnameRecords, bypassCache);
          }
       }
 

--- a/hmailserver/source/Server/Common/TCPIP/DNSResolver.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/DNSResolver.cpp
@@ -112,20 +112,20 @@ namespace HM
       // A query that fails tells us nothing; a query that succeeds without records
       // tells us the host has none. Keep the two apart, so that callers needing a
       // definitive answer can tell them apart.
-      bool queryFailed = false;
+      bool querySucceeded = true;
 
       // if IPv6 is preferred first do IPv6 DNS Lookup(s)
       if (ipv6Available && Configuration::Instance()->GetIPv6Preferred())
       {
-         queryFailed |= !resolver.Query(hostName, DNS_TYPE_AAAA, foundRecords);
-         queryFailed |= !resolver.Query(hostName, DNS_TYPE_A, foundRecords);
+         querySucceeded &= resolver.Query(hostName, DNS_TYPE_AAAA, foundRecords);
+         querySucceeded &= resolver.Query(hostName, DNS_TYPE_A, foundRecords);
       }
       else // Standard 
       {
-         queryFailed |= !resolver.Query(hostName, DNS_TYPE_A, foundRecords);
+         querySucceeded &= resolver.Query(hostName, DNS_TYPE_A, foundRecords);
 
          if (ipv6Available)
-            queryFailed |= !resolver.Query(hostName, DNS_TYPE_AAAA, foundRecords);
+            querySucceeded &= resolver.Query(hostName, DNS_TYPE_AAAA, foundRecords);
       }
 
       if (foundRecords.size() == 0 && followCnameRecords)
@@ -147,7 +147,7 @@ namespace HM
 
       // Records are usable even if the other query type failed. Without any records,
       // a failed query means the result is unknown rather than empty.
-      return !foundRecords.empty() || !queryFailed;
+      return !foundRecords.empty() || querySucceeded;
    }
 
 

--- a/hmailserver/source/Server/Common/TCPIP/DNSResolver.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/DNSResolver.cpp
@@ -63,6 +63,29 @@ namespace HM
       return GetIpAddressesRecursive_(sDomain, vecFoundNames, 0, followCnameRecords);
    }
 
+   const int lookupAttempts = 2;
+
+   //---------------------------------------------------------------------------()
+   // DESCRIPTION:
+   // Looks up a host, retrying if the lookup itself fails. Intended for callers
+   // which need a definitive answer, such as SURBL and the DNS blacklists, where a
+   // single bad response would otherwise turn a listed host into a clean one.
+   //---------------------------------------------------------------------------()
+   bool
+   DNSResolver::GetIpAddressesWithRetry(const String &sDomain, std::vector<String> &saFoundNames, bool followCnameRecords)
+   {
+      for (int attempt = 1; attempt <= lookupAttempts; attempt++)
+      {
+         if (GetIpAddresses(sDomain, saFoundNames, followCnameRecords))
+            return true;
+
+         if (attempt < lookupAttempts)
+            LOG_DEBUG(Formatter::Format(_T("DNS - Retrying lookup: {0}"), sDomain));
+      }
+
+      return false;
+   }
+
    bool
    DNSResolver::GetIpAddressesRecursive_(const String &hostName, std::vector<String> &addresses, int recursionLevel, bool followCnameRecords)
    {
@@ -84,18 +107,25 @@ namespace HM
 
       std::vector<DNSRecord> foundRecords;
 
-      bool ipv4QueryResult = false;
-      bool ipv6QueryResult = false;
+      bool ipv6Available = Configuration::Instance()->IsIPv6Available();
+
+      // A query that fails tells us nothing; a query that succeeds without records
+      // tells us the host has none. Keep the two apart, so that callers needing a
+      // definitive answer can tell them apart.
+      bool queryFailed = false;
+
       // if IPv6 is preferred first do IPv6 DNS Lookup(s)
-      if (Configuration::Instance()->IsIPv6Available() && Configuration::Instance()->GetIPv6Preferred())
+      if (ipv6Available && Configuration::Instance()->GetIPv6Preferred())
       {
-         ipv6QueryResult = resolver.Query(hostName, DNS_TYPE_AAAA, foundRecords);
-         ipv4QueryResult = resolver.Query(hostName, DNS_TYPE_A, foundRecords);
+         queryFailed |= !resolver.Query(hostName, DNS_TYPE_AAAA, foundRecords);
+         queryFailed |= !resolver.Query(hostName, DNS_TYPE_A, foundRecords);
       }
       else // Standard 
       {
-         ipv4QueryResult = resolver.Query(hostName, DNS_TYPE_A, foundRecords);
-         ipv6QueryResult = Configuration::Instance()->IsIPv6Available() ? resolver.Query(hostName, DNS_TYPE_AAAA, foundRecords) : false;
+         queryFailed |= !resolver.Query(hostName, DNS_TYPE_A, foundRecords);
+
+         if (ipv6Available)
+            queryFailed |= !resolver.Query(hostName, DNS_TYPE_AAAA, foundRecords);
       }
 
       if (foundRecords.size() == 0 && followCnameRecords)
@@ -115,7 +145,9 @@ namespace HM
       std::vector<String> foundValues = GetDnsRecordsValues_(foundRecords);
       addresses.insert(addresses.end(), foundValues.begin(), foundValues.end());
 
-      return ipv4QueryResult || ipv6QueryResult;
+      // Records are usable even if the other query type failed. Without any records,
+      // a failed query means the result is unknown rather than empty.
+      return !foundRecords.empty() || !queryFailed;
    }
 
 

--- a/hmailserver/source/Server/Common/TCPIP/DNSResolver.h
+++ b/hmailserver/source/Server/Common/TCPIP/DNSResolver.h
@@ -19,6 +19,7 @@ namespace HM
       bool GetEmailServers(const String &sDomainName, std::vector<HostNameAndIpAddress> &saFoundNames);
       bool GetMXRecords(const String &sDomain, std::vector<String> &vecFoundNames);
       bool GetIpAddresses(const String &sDomain, std::vector<String> &saFoundNames, bool followCnameRecords);
+      bool GetIpAddressesWithRetry(const String &sDomain, std::vector<String> &saFoundNames, bool followCnameRecords);
       bool GetTXTRecords(const String &sDomain, std::vector<String> &foundResult);
       bool GetPTRRecords(const String &sIP, std::vector<String> &vecFoundNames);
    private:

--- a/hmailserver/source/Server/Common/TCPIP/DNSResolver.h
+++ b/hmailserver/source/Server/Common/TCPIP/DNSResolver.h
@@ -18,14 +18,14 @@ namespace HM
 
       bool GetEmailServers(const String &sDomainName, std::vector<HostNameAndIpAddress> &saFoundNames);
       bool GetMXRecords(const String &sDomain, std::vector<String> &vecFoundNames);
-      bool GetIpAddresses(const String &sDomain, std::vector<String> &saFoundNames, bool followCnameRecords);
+      bool GetIpAddresses(const String &sDomain, std::vector<String> &saFoundNames, bool followCnameRecords, bool bypassCache = false);
       bool GetIpAddressesWithRetry(const String &sDomain, std::vector<String> &saFoundNames, bool followCnameRecords);
       bool GetTXTRecords(const String &sDomain, std::vector<String> &foundResult);
       bool GetPTRRecords(const String &sIP, std::vector<String> &vecFoundNames);
    private:
 
       bool GetEmailServersRecursive_(const String &sDomainName, std::vector<HostNameAndIpAddress> &saFoundNames, int recursionLevel);
-      bool GetIpAddressesRecursive_(const String &hostName, std::vector<String> &addresses, int recursionLevel, bool followCnameRecords);
+      bool GetIpAddressesRecursive_(const String &hostName, std::vector<String> &addresses, int recursionLevel, bool followCnameRecords, bool bypassCache);
       bool GetTXTRecordsRecursive_(const String &sDomain, std::vector<String> &foundResult, int recursionLevel);
       bool GetMXRecordsRecursive_(const String &sDomain, std::vector<String> &vecFoundNames, int recursionLevel);
 

--- a/hmailserver/source/Server/Common/TCPIP/DNSResolverWinApi.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/DNSResolverWinApi.cpp
@@ -62,7 +62,7 @@ namespace HM
    }
 
    bool
-   DNSResolverWinApi::Query(const String &query, int resourceType, std::vector<DNSRecord> &foundRecords)
+   DNSResolverWinApi::Query(const String &query, int resourceType, std::vector<DNSRecord> &foundRecords, bool bypassCache)
    {
       PDNS_RECORD pDnsRecord = NULL;
       
@@ -71,7 +71,7 @@ namespace HM
       DWORD fOptions;
       fOptions = DNS_QUERY_STANDARD;
 
-      if (!IniFileSettings::Instance()->GetUseDNSCache())
+      if (bypassCache || !IniFileSettings::Instance()->GetUseDNSCache())
       {
          fOptions |= DNS_QUERY_BYPASS_CACHE;
       }

--- a/hmailserver/source/Server/Common/TCPIP/DNSResolverWinApi.h
+++ b/hmailserver/source/Server/Common/TCPIP/DNSResolverWinApi.h
@@ -15,7 +15,7 @@ namespace HM
       DNSResolverWinApi();
       virtual ~DNSResolverWinApi();
 
-      bool Query(const String &query, int resourceType, std::vector<DNSRecord> &foundRecords);
+      bool Query(const String &query, int resourceType, std::vector<DNSRecord> &foundRecords, bool bypassCache = false);
 
       static bool NameMatchesQuery(const String &query, const String &recordName);
 

--- a/hmailserver/source/Server/SMTP/BLCheck.cpp
+++ b/hmailserver/source/Server/SMTP/BLCheck.cpp
@@ -33,7 +33,7 @@ namespace HM
 
       std::vector<String> foundAddresses;
       DNSResolver resolver;
-      resolver.GetIpAddresses(sCheckHost, foundAddresses, false);
+      bool lookupSucceeded = resolver.GetIpAddressesWithRetry(sCheckHost, foundAddresses, false);
 
       bool isBlocked = false;
 
@@ -76,6 +76,13 @@ namespace HM
 
       String logMessage = Formatter::Format("DNS lookup: {0}, {1} addresses found: {2}, Match: {3}", sCheckHost, foundAddresses.size(), foundAddressesJoined, isBlocked);
       LOG_TCPIP(logMessage);
+
+      if (!lookupSucceeded)
+      {
+         // The lookup failed rather than came back empty, so the client hasn't been
+         // cleared by this blacklist. Let the message through, but say so in the log.
+         LOG_TCPIP(Formatter::Format("DNS lookup failed: {0}. The client could not be checked against this blacklist.", sCheckHost));
+      }
 
       return isBlocked;
    }

--- a/hmailserver/test/VMTestRunner.Console/TestEnvironments.json
+++ b/hmailserver/test/VMTestRunner.Console/TestEnvironments.json
@@ -1,214 +1,214 @@
 ﻿[
-  //{
-  //  "operatingSystem": "Windows 10",
-  //  "description": "Internal: Upgrade, 4.1.1",
-  //  "vmName": "Windows-10-hMailServer-4.4.4-InternalMySQL",
-  //  "snapshotName": "Ready",
-  //  "preInstallCommands": [
-  //    {
-  //      "executable": "C:\\Windows\\System32\\net.exe",
-  //      "parameters": "stop hMailServer"
-  //    }
-  //  ],
-  //  "preInstallFileCopy": [
-  //    {
-  //      "from": "{{MySQLLib}}",
-  //      "to": "C:\\Program Files (x86)\\hMailServer\\Bin\\libmySQL.dll"
-  //    }
-  //  ],
-  //  "postInstallCommands": [
-  //    {
-  //      "executable": "C:\\Windows\\System32\\net.exe",
-  //      "parameters": "stop hMailServer"
-  //    },
-  //    {
-  //      "executable": "C:\\Windows\\System32\\cmd.exe",
-  //      "parameters": "/c del /f /q \"C:\\Program Files (x86)\\hMailServer\\Bin\\libmariadb.dll\""
-  //    },
-  //    {
-  //      "executable": "C:\\Windows\\System32\\net.exe",
-  //      "parameters": "start hMailServer"
-  //    }
-  //  ],
-  //  "postInstallFileCopy": []
-  //},
-  //{
-  //  "operatingSystem": "Windows 10",
-  //  "description": "PostgreSQL 9.6.24: Upgrade, 5.0.0",
-  //  "vmName": "Windows-10-hMailServer-5.0.0-PostgreSQL9.6.24",
-  //  "snapshotName": "Ready",
-  //  "preInstallCommands": [
-  //    {
-  //      "executable": "C:\\Windows\\System32\\net.exe",
-  //      "parameters": "stop hMailServer"
-  //    }
-  //  ],
-  //  "preInstallFileCopy": [],
-  //  "postInstallCommands": [],
-  //  "postInstallFileCopy": []
-  //},
-  //{
-  //  "operatingSystem": "Windows 10",
-  //  "description": "Internal: Upgrade, 5.0.0",
-  //  "vmName": "Windows-10-hMailServer-5.0.0-InternalSQLCompact",
-  //  "snapshotName": "Ready",
-  //  "preInstallCommands": [
-  //    {
-  //      "executable": "C:\\Windows\\System32\\net.exe",
-  //      "parameters": "stop hMailServer"
-  //    }
-  //  ],
-  //  "preInstallFileCopy": [],
-  //  "postInstallCommands": [],
-  //  "postInstallFileCopy": []
-  //},
-  //{
-  //  "operatingSystem": "Windows 10",
-  //  "description": "SQL Server 2019: Upgrade, 4.4.4",
-  //  "vmName": "Windows-10-hMailServer-4.4.4-SQLServer2019",
-  //  "snapshotName": "Ready",
-  //  "preInstallCommands": [
-  //    {
-  //      "executable": "C:\\Windows\\System32\\net.exe",
-  //      "parameters": "stop hMailServer"
-  //    }
-  //  ],
-  //  "preInstallFileCopy": [],
-  //  "postInstallCommands": [],
-  //  "postInstallFileCopy": []
-  //},
-  //{
-  //  "operatingSystem": "Windows 10",
-  //  "description": "MySQL 8.0.29: Upgrade, 4.4.4",
-  //  "vmName": "Windows-10-hMailServer-4.4.4-MySQL 8.0.29",
-  //  "snapshotName": "Ready",
-  //  "preInstallCommands": [
-  //    {
-  //      "executable": "C:\\Windows\\System32\\net.exe",
-  //      "parameters": "stop hMailServer"
-  //    }
-  //  ],
-  //  "preInstallFileCopy": [
-  //    {
-  //      "from": "{{MySQLLib}}",
-  //      "to": "C:\\Program Files (x86)\\hMailServer\\Bin\\libmySQL.dll"
-  //    }
-  //  ],
-  //  "postInstallCommands": [
-  //    {
-  //      "executable": "C:\\Windows\\System32\\net.exe",
-  //      "parameters": "stop hMailServer"
-  //    },
-  //    {
-  //      "executable": "C:\\Windows\\System32\\cmd.exe",
-  //      "parameters": "/c del /f /q \"C:\\Program Files (x86)\\hMailServer\\Bin\\libmariadb.dll\""
-  //    },
-  //    {
-  //      "executable": "C:\\Windows\\System32\\net.exe",
-  //      "parameters": "start hMailServer"
-  //    }
-  //  ],
-  //  "postInstallFileCopy": []
-  //},
-  //{
-  //  "operatingSystem": "Windows 10",
-  //  "description": "PostgreSQL 9.6.24: New installation",
-  //  "vmName": "Windows10-PostgreSQL9.6.24",
-  //  "snapshotName": "Ready",
-  //  "preInstallCommands": [],
-  //  "preInstallFileCopy": [],
-  //  "postInstallCommands": [
-  //    {
-  //      "executable": "C:\\Program Files\\hMailServer\\Bin\\DBSetup.exe",
-  //      "parameters": "/silent ServerType:PGSQL ServerAddress:localhost DatabaseName:hMailServer Authentication:Server CreateNew:Yes Username:postgres Password:Secret123"
-  //    }
-  //  ],
-  //  "postInstallFileCopy": [],
-  //  "includeStressTests": true
-  //},
-  //{
-  //  "operatingSystem": "Windows 10",
-  //  "description": "SQL Server 2019: New installation",
-  //  "vmName": "Windows10-SQLServer2019",
-  //  "snapshotName": "Ready",
-  //  "preInstallCommands": [],
-  //  "preInstallFileCopy": [],
-  //  "postInstallCommands": [
-  //    {
-  //      "executable": "C:\\Program Files\\hMailServer\\Bin\\DBSetup.exe",
-  //      "parameters": "/silent ServerType:MSSQL ServerAddress:.\\SQLEXPRESS DatabaseName:hMailServer Authentication:SServer CreateNew:Yes Username:sa Password:Secret123"
-  //    }
-  //  ],
-  //  "postInstallFileCopy": []
-  //},
-  //{
-  //  "operatingSystem": "Windows 10",
-  //  "description": "MySQL 8.0.29: New installation - MySQL client",
-  //  "vmName": "Windows10-MySQL8.0.29",
-  //  "snapshotName": "Ready",
-  //  "preInstallCommands": [
-  //    {
-  //      "executable": "C:\\Windows\\System32\\net.exe",
-  //      "parameters": "stop hMailServer"
-  //    }
-  //  ],
-  //  "preInstallFileCopy": [],
-  //  "postInstallCommands": [
-  //    {
-  //      "executable": "C:\\Windows\\System32\\net.exe",
-  //      "parameters": "stop hMailServer"
-  //    },
-  //    {
-  //      "executable": "C:\\Windows\\System32\\cmd.exe",
-  //      "parameters": "/c del /f /q \"C:\\Program Files\\hMailServer\\Bin\\libmariadb.dll\""
-  //    },
-  //    {
-  //      "executable": "C:\\Program Files\\hMailServer\\Bin\\DBSetup.exe",
-  //      "parameters": "/silent ServerType:MySQL ServerAddress:localhost DatabaseName:hMailServer Authentication:Server CreateNew:Yes Username:root Password:Secret123"
-  //    },
-  //    {
-  //      "executable": "C:\\Windows\\System32\\net.exe",
-  //      "parameters": "start hMailServer"
-  //    }
-  //  ],
-  //  "postInstallFileCopy": [
-  //    {
-  //      "from": "{{MySQLLib}}",
-  //      "to": "C:\\Program Files\\hMailServer\\Bin\\libmySQL.dll"
-  //    }
-  //  ]
-  //},
-  //{
-  //  "operatingSystem": "Windows 10",
-  //  "description": "MySQL 26.7.0: New installation - MariaDB client",
-  //  "vmName": "Windows10-MySQL-26.7.0",
-  //  "snapshotName": "Ready",
-  //  "preInstallCommands": [
-  //    {
-  //      "executable": "C:\\Windows\\System32\\net.exe",
-  //      "parameters": "stop hMailServer"
-  //    }
-  //  ],
-  //  "preInstallFileCopy": [],
-  //  "postInstallCommands": [
-  //    {
-  //      "executable": "C:\\Program Files\\hMailServer\\Bin\\DBSetup.exe",
-  //      "parameters": "/silent ServerType:MySQL ServerAddress:localhost DatabaseName:hMailServer Authentication:Server CreateNew:Yes Username:root Password:Secret123"
-  //    }
-  //  ],
-  //  "postInstallFileCopy": []
-  //},
+  {
+    "operatingSystem": "Windows 10",
+    "description": "Internal: Upgrade, 4.1.1",
+    "vmName": "Windows-10-hMailServer-4.4.4-InternalMySQL",
+    "snapshotName": "Ready",
+    "preInstallCommands": [
+      {
+        "executable": "C:\\Windows\\System32\\net.exe",
+        "parameters": "stop hMailServer"
+      }
+    ],
+    "preInstallFileCopy": [
+      {
+        "from": "{{MySQLLib}}",
+        "to": "C:\\Program Files (x86)\\hMailServer\\Bin\\libmySQL.dll"
+      }
+    ],
+    "postInstallCommands": [
+      {
+        "executable": "C:\\Windows\\System32\\net.exe",
+        "parameters": "stop hMailServer"
+      },
+      {
+        "executable": "C:\\Windows\\System32\\cmd.exe",
+        "parameters": "/c del /f /q \"C:\\Program Files (x86)\\hMailServer\\Bin\\libmariadb.dll\""
+      },
+      {
+        "executable": "C:\\Windows\\System32\\net.exe",
+        "parameters": "start hMailServer"
+      }
+    ],
+    "postInstallFileCopy": []
+  },
+  {
+    "operatingSystem": "Windows 10",
+    "description": "PostgreSQL 9.6.24: Upgrade, 5.0.0",
+    "vmName": "Windows-10-hMailServer-5.0.0-PostgreSQL9.6.24",
+    "snapshotName": "Ready",
+    "preInstallCommands": [
+      {
+        "executable": "C:\\Windows\\System32\\net.exe",
+        "parameters": "stop hMailServer"
+      }
+    ],
+    "preInstallFileCopy": [],
+    "postInstallCommands": [],
+    "postInstallFileCopy": []
+  },
+  {
+    "operatingSystem": "Windows 10",
+    "description": "Internal: Upgrade, 5.0.0",
+    "vmName": "Windows-10-hMailServer-5.0.0-InternalSQLCompact",
+    "snapshotName": "Ready",
+    "preInstallCommands": [
+      {
+        "executable": "C:\\Windows\\System32\\net.exe",
+        "parameters": "stop hMailServer"
+      }
+    ],
+    "preInstallFileCopy": [],
+    "postInstallCommands": [],
+    "postInstallFileCopy": []
+  },
+  {
+    "operatingSystem": "Windows 10",
+    "description": "SQL Server 2019: Upgrade, 4.4.4",
+    "vmName": "Windows-10-hMailServer-4.4.4-SQLServer2019",
+    "snapshotName": "Ready",
+    "preInstallCommands": [
+      {
+        "executable": "C:\\Windows\\System32\\net.exe",
+        "parameters": "stop hMailServer"
+      }
+    ],
+    "preInstallFileCopy": [],
+    "postInstallCommands": [],
+    "postInstallFileCopy": []
+  },
+  {
+    "operatingSystem": "Windows 10",
+    "description": "MySQL 8.0.29: Upgrade, 4.4.4",
+    "vmName": "Windows-10-hMailServer-4.4.4-MySQL 8.0.29",
+    "snapshotName": "Ready",
+    "preInstallCommands": [
+      {
+        "executable": "C:\\Windows\\System32\\net.exe",
+        "parameters": "stop hMailServer"
+      }
+    ],
+    "preInstallFileCopy": [
+      {
+        "from": "{{MySQLLib}}",
+        "to": "C:\\Program Files (x86)\\hMailServer\\Bin\\libmySQL.dll"
+      }
+    ],
+    "postInstallCommands": [
+      {
+        "executable": "C:\\Windows\\System32\\net.exe",
+        "parameters": "stop hMailServer"
+      },
+      {
+        "executable": "C:\\Windows\\System32\\cmd.exe",
+        "parameters": "/c del /f /q \"C:\\Program Files (x86)\\hMailServer\\Bin\\libmariadb.dll\""
+      },
+      {
+        "executable": "C:\\Windows\\System32\\net.exe",
+        "parameters": "start hMailServer"
+      }
+    ],
+    "postInstallFileCopy": []
+  },
+  {
+    "operatingSystem": "Windows 10",
+    "description": "PostgreSQL 9.6.24: New installation",
+    "vmName": "Windows10-PostgreSQL9.6.24",
+    "snapshotName": "Ready",
+    "preInstallCommands": [],
+    "preInstallFileCopy": [],
+    "postInstallCommands": [
+      {
+        "executable": "C:\\Program Files\\hMailServer\\Bin\\DBSetup.exe",
+        "parameters": "/silent ServerType:PGSQL ServerAddress:localhost DatabaseName:hMailServer Authentication:Server CreateNew:Yes Username:postgres Password:Secret123"
+      }
+    ],
+    "postInstallFileCopy": [],
+    "includeStressTests": true
+  },
+  {
+    "operatingSystem": "Windows 10",
+    "description": "SQL Server 2019: New installation",
+    "vmName": "Windows10-SQLServer2019",
+    "snapshotName": "Ready",
+    "preInstallCommands": [],
+    "preInstallFileCopy": [],
+    "postInstallCommands": [
+      {
+        "executable": "C:\\Program Files\\hMailServer\\Bin\\DBSetup.exe",
+        "parameters": "/silent ServerType:MSSQL ServerAddress:.\\SQLEXPRESS DatabaseName:hMailServer Authentication:SServer CreateNew:Yes Username:sa Password:Secret123"
+      }
+    ],
+    "postInstallFileCopy": []
+  },
+  {
+    "operatingSystem": "Windows 10",
+    "description": "MySQL 8.0.29: New installation - MySQL client",
+    "vmName": "Windows10-MySQL8.0.29",
+    "snapshotName": "Ready",
+    "preInstallCommands": [
+      {
+        "executable": "C:\\Windows\\System32\\net.exe",
+        "parameters": "stop hMailServer"
+      }
+    ],
+    "preInstallFileCopy": [],
+    "postInstallCommands": [
+      {
+        "executable": "C:\\Windows\\System32\\net.exe",
+        "parameters": "stop hMailServer"
+      },
+      {
+        "executable": "C:\\Windows\\System32\\cmd.exe",
+        "parameters": "/c del /f /q \"C:\\Program Files\\hMailServer\\Bin\\libmariadb.dll\""
+      },
+      {
+        "executable": "C:\\Program Files\\hMailServer\\Bin\\DBSetup.exe",
+        "parameters": "/silent ServerType:MySQL ServerAddress:localhost DatabaseName:hMailServer Authentication:Server CreateNew:Yes Username:root Password:Secret123"
+      },
+      {
+        "executable": "C:\\Windows\\System32\\net.exe",
+        "parameters": "start hMailServer"
+      }
+    ],
+    "postInstallFileCopy": [
+      {
+        "from": "{{MySQLLib}}",
+        "to": "C:\\Program Files\\hMailServer\\Bin\\libmySQL.dll"
+      }
+    ]
+  },
+  {
+    "operatingSystem": "Windows 10",
+    "description": "MySQL 26.7.0: New installation - MariaDB client",
+    "vmName": "Windows10-MySQL-26.7.0",
+    "snapshotName": "Ready",
+    "preInstallCommands": [
+      {
+        "executable": "C:\\Windows\\System32\\net.exe",
+        "parameters": "stop hMailServer"
+      }
+    ],
+    "preInstallFileCopy": [],
+    "postInstallCommands": [
+      {
+        "executable": "C:\\Program Files\\hMailServer\\Bin\\DBSetup.exe",
+        "parameters": "/silent ServerType:MySQL ServerAddress:localhost DatabaseName:hMailServer Authentication:Server CreateNew:Yes Username:root Password:Secret123"
+      }
+    ],
+    "postInstallFileCopy": []
+  },
 
-  //{
-  //  "operatingSystem": "Windows 10",
-  //  "description": "Internal (SQL Compact): New installation",
-  //  "vmName": "Windows10",
-  //  "snapshotName": "Ready",
-  //  "preInstallCommands": [],
-  //  "preInstallFileCopy": [],
-  //  "postInstallCommands": [],
-  //  "postInstallFileCopy": []
-  //},
+  {
+    "operatingSystem": "Windows 10",
+    "description": "Internal (SQL Compact): New installation",
+    "vmName": "Windows10",
+    "snapshotName": "Ready",
+    "preInstallCommands": [],
+    "preInstallFileCopy": [],
+    "postInstallCommands": [],
+    "postInstallFileCopy": []
+  },
   {
     "operatingSystem": "Windows Server 2025",
     "description": "Internal (SQL Compact): New installation",
@@ -218,36 +218,36 @@
     "preInstallFileCopy": [],
     "postInstallCommands": [],
     "postInstallFileCopy": []
-  }
+  },
 
-  //// PowerShell Direct needs a Windows 10 or later guest, so anything older is reached
-  //// over the network instead ("guestTransport": "Network"), at the fixed address its
-  //// adapter on the TestNet switch has. Scripts\Add-TestVMTestNetAdapter.ps1 sets those
-  //// adapters up; the guest must also allow File and Printer Sharing and WMI through its
-  //// firewall, and have HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
-  //// \LocalAccountTokenFilterPolicy set to 1.
-  //{
-  //  "operatingSystem": "Windows Vista SP2",
-  //  "description": "Internal (SQL Compact): New installation",
-  //  "vmName": "Windows-Vista-SP2",
-  //  "snapshotName": "Ready",
-  //  "guestTransport": "Network",
-  //  "guestAddress": "192.168.210.12",
-  //  "preInstallCommands": [],
-  //  "preInstallFileCopy": [],
-  //  "postInstallCommands": [],
-  //  "postInstallFileCopy": []
-  //},
-  //{
-  //  "operatingSystem": "Windows 8.1",
-  //  "description": "Internal (SQL Compact): New installation",
-  //  "vmName": "Windows-8.1",
-  //  "snapshotName": "Ready",
-  //  "guestTransport": "Network",
-  //  "guestAddress": "192.168.210.11",
-  //  "preInstallCommands": [],
-  //  "preInstallFileCopy": [],
-  //  "postInstallCommands": [],
-  //  "postInstallFileCopy": []
-  //}
+  // PowerShell Direct needs a Windows 10 or later guest, so anything older is reached
+  // over the network instead ("guestTransport": "Network"), at the fixed address its
+  // adapter on the TestNet switch has. Scripts\Add-TestVMTestNetAdapter.ps1 sets those
+  // adapters up; the guest must also allow File and Printer Sharing and WMI through its
+  // firewall, and have HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+  // \LocalAccountTokenFilterPolicy set to 1.
+  {
+    "operatingSystem": "Windows Vista SP2",
+    "description": "Internal (SQL Compact): New installation",
+    "vmName": "Windows-Vista-SP2",
+    "snapshotName": "Ready",
+    "guestTransport": "Network",
+    "guestAddress": "192.168.210.12",
+    "preInstallCommands": [],
+    "preInstallFileCopy": [],
+    "postInstallCommands": [],
+    "postInstallFileCopy": []
+  },
+  {
+    "operatingSystem": "Windows 8.1",
+    "description": "Internal (SQL Compact): New installation",
+    "vmName": "Windows-8.1",
+    "snapshotName": "Ready",
+    "guestTransport": "Network",
+    "guestAddress": "192.168.210.11",
+    "preInstallCommands": [],
+    "preInstallFileCopy": [],
+    "postInstallCommands": [],
+    "postInstallFileCopy": []
+  }
 ]


### PR DESCRIPTION
A few fixes have been made:

* If an A and an AAAA query was made, and the A query failed but AAAA succeeded with an empty result, that was treated as a success. This is invalid - a hard failure of the A query was masked by the AAAA query reporting that no AAAA record exists.
* If a DNS lookup fails, do a retry bypassing the local cache.